### PR TITLE
Akai Fire 2.3.0: shared sequencer clip row, chord/melodic step polish, and browser fix

### DIFF
--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -212,7 +212,6 @@ It uses the shared `Root Key` and `Scale` from live NOTE input and `SHIFT + PERF
 | `STEP SEQ` | Toggle `As Is` / `Cast` rendering |
 | `SHIFT + STEP SEQ` | Cycle note-step sub-mode |
 | `PATTERN UP/DOWN` | Page the visible chord-step window |
-| `SHIFT + ALT + PATTERN DOWN` | Clear current selected clip contents |
 | `ALT + BANK LEFT/RIGHT` | Halve / double clip length |
 | Hold step(s) + `BANK LEFT/RIGHT` | Fine-nudge held chord material |
 | `SHIFT + BANK LEFT/RIGHT` | Fine-nudge visible chord material |
@@ -276,7 +275,6 @@ Current generators:
 | `ALT + PATTERN UP` | Mutate pitch pool |
 | `PATTERN DOWN` | Generate new phrase |
 | `ALT + PATTERN DOWN` | Mutate phrase |
-| `SHIFT + ALT + PATTERN DOWN` | Clear current selected clip contents |
 | `SHIFT + PATTERN UP/DOWN` | Cycle view between `Notes`, `Expression`, and `Process` |
 
 If `Step Seq Pad Audition` is enabled, pressing a pitch-pool pad also auditions that note.

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -259,7 +259,6 @@ Current generators:
 - `Acid`
 - `Motif`
 - `Call/Resp`
-- `Euclid`
 - `Rolling`
 - `Octave`
 
@@ -301,6 +300,17 @@ Melodic transforms moved off the left-side buttons and now live on the `Mixer` e
 ### Melodic Step Encoders
 
 `Melodic Step` uses the shared step-encoder infrastructure with mode-specific pages for generation and phrase editing. The exact labels shown on OLED depend on the active view and the held-step state.
+
+Current `Channel` page:
+
+| Slot | Function |
+| --- | --- |
+| 1 | Engine |
+| `ALT + 1` | Engine subtype / family when available |
+| 2 | Density |
+| 3 | Engine-specific macro (`Motion`, `Contour`, `Answer`, `Movement`, `Jump`) |
+| 4 | Mutation type |
+| `ALT + 4` | Mutation strength |
 
 ## PERFORM Mode
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -215,8 +215,13 @@ It uses the shared `Root Key` and `Scale` from live NOTE input and `SHIFT + PERF
 | `SHIFT + STEP SEQ` | Cycle note-step sub-mode |
 | `PATTERN UP/DOWN` | Page the visible chord-step window |
 | `ALT + BANK LEFT/RIGHT` | Halve / double clip length |
-| Hold step(s) + `BANK LEFT/RIGHT` | Fine-nudge held chord material |
-| `SHIFT + BANK LEFT/RIGHT` | Fine-nudge visible chord material |
+| Hold step(s) + `BANK LEFT/RIGHT` | Experimental micro-timing nudge for held chord material |
+| `SHIFT + BANK LEFT/RIGHT` | Experimental micro-timing nudge for visible chord material |
+
+Chord-step timing note:
+
+- coarse nudge is intentionally disabled
+- chord-step micro-timing is currently temperamental and should be treated as experimental
 
 ### Chord Step Left-Side Buttons
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -70,6 +70,8 @@ When the popup browser is open, the main `SELECT` encoder is temporarily remappe
 | `SELECT` press | Commit selected result |
 | `BROWSER` | Close popup browser |
 
+Opening the browser keeps Bitwig's remembered search/filter state intact. Result navigation is immediately available from the `SELECT` encoder without needing keyboard or mouse focus first.
+
 Browser insert mode follows modifiers when opening:
 
 | Action | Browser open mode |
@@ -286,7 +288,9 @@ If `Step Seq Pad Audition` is enabled, pressing a pitch-pool pad also auditions 
 | `MUTE_1` | Select clip without launch |
 | `MUTE_2` | Last Step target mode |
 | `MUTE_3` | Paste to clip slot |
-| `MUTE_4` | Delete step or clip |
+| `MUTE_4` | Clear step or clip contents |
+
+On the top-row clip pads, `SHIFT + MUTE_4` removes the clip object.
 
 Melodic transforms moved off the left-side buttons and now live on the `Mixer` encoder page:
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -173,7 +173,7 @@ In live NOTE mode:
 | --- | --- | --- | --- | --- |
 | `Channel` | Mod | Pitch Gliss | Velocity sensitivity (`SHIFT`: Default velocity) | Shared scale |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
-| `User 1` | Mod | Pressure | Timbre | Pitch expression |
+| `User 1` | Aftertouch | Pressure | Timbre | Pitch expression |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
 
 ## Note-Step Sub-Modes
@@ -197,8 +197,9 @@ It uses the shared `Root Key` and `Scale` from live NOTE input and `SHIFT + PERF
 
 | Pad row | Role |
 | --- | --- |
-| Upper two rows | Curated chord slots |
-| Lower two rows | 32 visible steps |
+| Row 1 | Clip row |
+| Row 2 | Curated chord slots or builder notes |
+| Rows 3-4 | 32 visible steps |
 
 ### Main Chord Step Gestures
 
@@ -221,9 +222,9 @@ It uses the shared `Root Key` and `Scale` from live NOTE input and `SHIFT + PERF
 | Button | Role |
 | --- | --- |
 | `MUTE_1` | Select / load step |
-| `MUTE_2` | Paste to target step |
-| `MUTE_3` | Last Step target mode |
-| `MUTE_4` | Invert selected chord (`ALT` inverts the other direction) |
+| `MUTE_2` | Last Step target mode |
+| `MUTE_3` | Paste to target step or clip slot |
+| `MUTE_4` | Delete step or clip (`ALT`: invert chord, `SHIFT + ALT`: invert opposite direction) |
 
 The chord builder defaults to showing in-key notes only. If it auto-seeds a note into an empty builder, that note must be visible on the current builder rows.
 
@@ -246,8 +247,9 @@ The chord builder defaults to showing in-key notes only. If it auto-seeds a note
 
 | Pad row | Role |
 | --- | --- |
-| Upper two rows | Pitch pool |
-| Lower two rows | 32-step melodic phrase |
+| Row 1 | Clip row |
+| Row 2 | 16-note pitch pool |
+| Rows 3-4 | 32-step melodic phrase |
 
 ### Generator Modes
 
@@ -281,12 +283,19 @@ If `Step Seq Pad Audition` is enabled, pressing a pitch-pool pad also auditions 
 
 ### Melodic Step Left-Side Buttons
 
-| Button | Primary role | Alt / Shift variant |
-| --- | --- | --- |
-| `MUTE_1` | Repeat / double | `SHIFT`: halve, `ALT`: mirror-double |
-| `MUTE_2` | Reverse | `ALT`: swivel halves |
-| `MUTE_3` | Invert up | `ALT`: invert down |
-| `MUTE_4` | Last Step target mode | None |
+| Button | Role |
+| --- | --- |
+| `MUTE_1` | Select clip without launch |
+| `MUTE_2` | Last Step target mode |
+| `MUTE_3` | Paste to clip slot |
+| `MUTE_4` | Delete step or clip |
+
+Melodic transforms moved off the left-side buttons and now live on the `Mixer` encoder page:
+
+- Encoder 1: halve / double length
+- Encoder 2: swivel / mirror-double
+- Encoder 3: reverse
+- Encoder 4: invert down / up
 
 ### Melodic Step Encoders
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -232,7 +232,7 @@ The chord builder defaults to showing in-key notes only. If it auto-seeds a note
 
 | Encoder page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
 | --- | --- | --- | --- | --- |
-| `Channel` | Chord octave (`ALT`: Shared root key) | Velocity sensitivity (`SHIFT`: Default velocity) | Chord family | Chord render / interpretation |
+| `Channel` | Chord octave (`ALT`: Shared root key) | Velocity sensitivity (`SHIFT`: Default velocity) | Chord family (`ALT`: family page) | Chord render / interpretation |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
 | `User 1` | Note velocity edit | Note chance edit | Note recurrence length | Note recurrence count |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
@@ -242,6 +242,7 @@ The chord builder defaults to showing in-key notes only. If it auto-seeds a note
 ## Melodic Step
 
 `Melodic Step` is a generated and editable mono phrase sequencer for basslines and melodic hooks.
+It edits a 2-bar / 32-step window and does not expand beyond that range from within the mode.
 
 ### Pad Layout
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -218,7 +218,7 @@ Important gestures:
 - tap an empty step pad: place the selected chord
 - tap a lit step pad: remove the chord from that step
 - `BANK LEFT/RIGHT`: move written step content left or right
-- `SHIFT + BANK LEFT/RIGHT`: adjust held chord-step note duration
+- `SHIFT + BANK LEFT/RIGHT`: experimental micro-timing nudge for chord material; behavior is currently temperamental
 - `ALT + BANK LEFT/RIGHT`: halve / double clip length
 - `MUTE_1`: select / load step
 - `MUTE_2`: last-step target mode
@@ -228,6 +228,11 @@ Important gestures:
 - `SHIFT + ALT + MUTE_4`: invert chord in the opposite direction
 - `Encoder 3`: chord family
 - `ALT + Encoder 3`: chord family page
+
+Timing note:
+
+- coarse nudge is intentionally disabled in `Chord Step`
+- chord-step micro-timing is currently temperamental and should be treated as experimental
 
 ### Melodic STEP mode
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -210,7 +210,7 @@ To get to this mode from the Note live input mode, press the `NOTE` controller b
 
 Important gestures:
 
-- top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode
+- top row clip pads: launch, select, create, and paste clips; `Delete` clears clip contents and `Shift + Delete` removes the clip object
 - `PATTERN DOWN/UP`: previous/next visible step page
 - `STEP SEQ`: enter `Melodic Step`
 - `SHIFT + STEP SEQ`: accent toggle/edit
@@ -250,7 +250,7 @@ Main ideas:
 
 Important gestures:
 
-- top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode
+- top row clip pads: launch, select, create, and paste clips; `Delete` clears clip contents and `Shift + Delete` removes the clip object
 - tap a pitch pad: add or remove that note from the pool
 - tap a step pad: place, clear, or load that step depending on state
 - hold a step pad and turn encoders: edit that held step directly

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -205,14 +205,13 @@ To get to this mode from the Note live input mode, press the `NOTE` controller b
 - Rows 3-4: 32 visible steps
 - the builder defaults to in-key view and uses the same shared root/scale as live NOTE
 - In chord definition mode, first pick which notes should be in the chord on row 2, then place it on steps on the lower two rows.
-- If you select one of the pre-defined chord families (using the `PATTERN` buttons), the workflow mirrors Drum sequencing: pick a chord, then place or remove it on as many steps as you like
+- If you select one of the pre-defined chord families, the workflow mirrors Drum sequencing: pick a chord, then place or remove it on as many steps as you like
 - Holding one or more step pads while pressing a chord pad rewrites those held steps with the chosen chord
 
 Important gestures:
 
 - top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode
-- `PATTERN DOWN/UP`: next/previous chord family
-- `ALT + PATTERN DOWN/UP`: next/previous page within the current family
+- `PATTERN DOWN/UP`: previous/next visible step page
 - `STEP SEQ`: enter `Melodic Step`
 - `SHIFT + STEP SEQ`: accent toggle/edit
 - `ALT + STEP SEQ`: Fill
@@ -228,10 +227,13 @@ Important gestures:
 - `MUTE_4`: delete target step or clip
 - `ALT + MUTE_4`: invert chord
 - `SHIFT + ALT + MUTE_4`: invert chord in the opposite direction
+- `Encoder 3`: chord family
+- `ALT + Encoder 3`: chord family page
 
 ### Melodic STEP mode
 
 `STEP` is a generative and editable mono phrase sequencer for basslines, motifs, and melodic hooks.
+It edits a 2-bar / 32-step window and does not expand beyond that range from within the mode.
 
 - Row 1: clip row
 - Row 2: compact 16-note in-scale pitch pool

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -239,7 +239,7 @@ It edits a 2-bar / 32-step window and does not expand beyond that range from wit
 - Row 2: compact 16-note in-scale pitch pool
 - Rows 3-4: 32 visible steps
 - generated phrases are constrained to the current pitch pool
-- different generator modes provide different phrase grammars such as `Acid`, `Motif`, `Call/Resp`, `Euclid`, `Rolling`, and `Octave`
+- different generator modes provide different phrase grammars such as `Acid`, `Motif`, `Call/Resp`, `Rolling`, and `Octave`
 
 Main ideas:
 
@@ -266,10 +266,19 @@ Important gestures:
 
 Encoder pages:
 
-- `Channel`: generator, density, shape, mutation type
+- `Channel`: engine, density, engine macro, mutation type
 - `Mixer`: melodic process transforms
 - `User 1`: tension, Euclid pulses, Euclid rotation, mutation amount
 - `User 2`: selected or held step octave, gate, velocity, articulation
+
+Channel page details:
+
+- Encoder 1: `Engine`
+- `ALT + Encoder 1`: engine subtype / family when available
+- Encoder 2: `Density`
+- Encoder 3: engine-specific macro such as motion, contour, answer, movement, or jump
+- Encoder 4: `Mutation Type`
+- `ALT + Encoder 4`: mutation strength
 
 Melodic left-side buttons now align with the shared sequencer clip/edit workflow:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -136,7 +136,7 @@ Main gestures:
 
 In `DRUM`, hold `Paste` and press a clip slot, drum pad, or step. The currently selected item of the same type is used as the source to copy from:
 
-- clip-row paste uses the currently selected clip slot as the source to copy from
+- clip-row paste uses the currently selected clip slot as the source to copy from, or falls back to the playing clip on that track if no clip was explicitly selected
 - drum-pad paste uses the currently selected drum pad as the source to copy from
 - step paste uses the currently selected step as the source to copy from
 
@@ -266,7 +266,7 @@ Encoder pages:
 
 - `Channel`: engine, density, engine macro, mutation type
 - `Mixer`: melodic process transforms
-- `User 1`: tension, Euclid pulses, Euclid rotation, mutation amount
+- `User 1`: reserved for future melodic advanced controls
 - `User 2`: selected or held step octave, gate, velocity, articulation
 
 Channel page details:
@@ -283,7 +283,8 @@ Melodic left-side buttons now align with the shared sequencer clip/edit workflow
 - `MUTE_1`: select clip without launch
 - `MUTE_2`: last-step target mode
 - `MUTE_3`: paste to clip slot
-- `MUTE_4`: delete step or clip
+- `MUTE_4`: clear step or clear clip contents
+- `SHIFT + MUTE_4` on a clip pad: remove the clip object
 
 Melodic transform controls moved to the `Mixer` page:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -220,7 +220,6 @@ Important gestures:
 - `BANK LEFT/RIGHT`: move written step content left or right
 - `SHIFT + BANK LEFT/RIGHT`: adjust held chord-step note duration
 - `ALT + BANK LEFT/RIGHT`: halve / double clip length
-- `SHIFT + ALT + PATTERN DOWN`: clear the selected clip contents
 - `MUTE_1`: select / load step
 - `MUTE_2`: last-step target mode
 - `MUTE_3`: paste to target step or clip slot
@@ -262,7 +261,6 @@ Important gestures:
 - `SHIFT + PATTERN UP` and `SHIFT + PATTERN DOWN`: cycle the current view between `Notes`, `Expression`, and `Process`
 - `BANK LEFT/RIGHT`: rotate the phrase
 - `ALT + BANK LEFT/RIGHT`: halve or double the clip length
-- `SHIFT + ALT + PATTERN DOWN`: clear the selected clip contents
 
 Encoder pages:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -200,16 +200,17 @@ To get to this mode from the Note live input mode, press the `NOTE` controller b
 
 `Chord Step` is the chord-oriented note-step workflow.
 
-- Upper two rows: chord definition or curated chord slots
-- Lower two rows: 16 visible steps
+- Row 1: clip row
+- Row 2: chord definition or curated chord slots
+- Rows 3-4: 32 visible steps
 - the builder defaults to in-key view and uses the same shared root/scale as live NOTE
-- In chord definition mode, first pick which notes that should be in the chord on the top two rows, then place it on steps on the bottom two rows.
+- In chord definition mode, first pick which notes should be in the chord on row 2, then place it on steps on the lower two rows.
 - If you select one of the pre-defined chord families (using the `PATTERN` buttons), the workflow mirrors Drum sequencing: pick a chord, then place or remove it on as many steps as you like
 - Holding one or more step pads while pressing a chord pad rewrites those held steps with the chosen chord
 
 Important gestures:
 
-- `MUTE_1..4`: chord octave and root offsets
+- top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode
 - `PATTERN DOWN/UP`: next/previous chord family
 - `ALT + PATTERN DOWN/UP`: next/previous page within the current family
 - `STEP SEQ`: enter `Melodic Step`
@@ -221,15 +222,20 @@ Important gestures:
 - `SHIFT + BANK LEFT/RIGHT`: adjust held chord-step note duration
 - `ALT + BANK LEFT/RIGHT`: halve / double clip length
 - `SHIFT + ALT + PATTERN DOWN`: clear the selected clip contents
-
-In `Chord Step`, hold `Paste` (Mute_2) and press a step. The currently selected step is used as the source to copy from.
+- `MUTE_1`: select / load step
+- `MUTE_2`: last-step target mode
+- `MUTE_3`: paste to target step or clip slot
+- `MUTE_4`: delete target step or clip
+- `ALT + MUTE_4`: invert chord
+- `SHIFT + ALT + MUTE_4`: invert chord in the opposite direction
 
 ### Melodic STEP mode
 
 `STEP` is a generative and editable mono phrase sequencer for basslines, motifs, and melodic hooks.
 
-- Upper two rows: collapsed in-scale pitch pool
-- Lower two rows: 16 visible steps
+- Row 1: clip row
+- Row 2: compact 16-note in-scale pitch pool
+- Rows 3-4: 32 visible steps
 - generated phrases are constrained to the current pitch pool
 - different generator modes provide different phrase grammars such as `Acid`, `Motif`, `Call/Resp`, `Euclid`, `Rolling`, and `Octave`
 
@@ -242,6 +248,7 @@ Main ideas:
 
 Important gestures:
 
+- top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode
 - tap a pitch pad: add or remove that note from the pool
 - tap a step pad: place, clear, or load that step depending on state
 - hold a step pad and turn encoders: edit that held step directly
@@ -258,9 +265,23 @@ Important gestures:
 Encoder pages:
 
 - `Channel`: generator, density, shape, mutation type
-- `Mixer`: track volume, pan, send 1, send 2
+- `Mixer`: melodic process transforms
 - `User 1`: tension, Euclid pulses, Euclid rotation, mutation amount
 - `User 2`: selected or held step octave, gate, velocity, articulation
+
+Melodic left-side buttons now align with the shared sequencer clip/edit workflow:
+
+- `MUTE_1`: select clip without launch
+- `MUTE_2`: last-step target mode
+- `MUTE_3`: paste to clip slot
+- `MUTE_4`: delete step or clip
+
+Melodic transform controls moved to the `Mixer` page:
+
+- Encoder 1: halve / double length
+- Encoder 2: swivel / mirror-double
+- Encoder 3: reverse
+- Encoder 4: invert down / up
 
 Notes on generation:
 

--- a/modules/akai-fire/build.gradle
+++ b/modules/akai-fire/build.gradle
@@ -1,4 +1,4 @@
-version = '2.2.0'
+version = '2.3.0'
 
 jar {
     archiveBaseName.set('OikontrolFire')

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
@@ -25,7 +25,7 @@ public class AkaiFireOikontrolDefinition extends ControllerExtensionDefinition {
 
     @Override
     public String getVersion() {
-        return "2.2.0";
+        return "2.3.0";
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -869,9 +869,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (activeMode == TopLevelMode.DRUM) {
             applyDrumPinningIfEnabled();
             drumSequenceMode.activate();
+            refreshSurfaceLights();
             return;
         }
-        clearPads();
         if (activeMode == TopLevelMode.NOTE) {
             noteMode.activate();
         } else if (activeMode == TopLevelMode.MELODIC_STEP) {
@@ -879,12 +879,13 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         } else {
             performMode.activate();
         }
+        refreshSurfaceLights();
     }
 
-    private void clearPads() {
-        for (int index = 0; index < rgbButtons.length; index++) {
-            updateRgbPad(index, RgbLigthState.OFF);
-        }
+    private void refreshSurfaceLights() {
+        flush();
+        host.scheduleTask(this::flush, 0);
+        host.scheduleTask(this::flush, 8);
     }
 
     private void applyLaunchQuantizationPreference(final String preferenceValue) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -224,6 +224,8 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         ensureDrumPinningStillValid();
         oled.notifyBlink(blinkTicks);
         drumSequenceMode.notifyBlink(blinkTicks);
+        noteMode.notifyBlink(blinkTicks);
+        melodicStepMode.notifyBlink(blinkTicks);
         performMode.notifyBlink(blinkTicks);
         host.scheduleTask(this::handlePing, 100);
     }
@@ -575,13 +577,15 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         if (getButton(NoteAssign.SHIFT).isPressed()) {
+            final boolean nextState = !transport.isMetronomeEnabled().get();
             transport.isMetronomeEnabled().toggle();
-            notifyAction("Metronome", transport.isMetronomeEnabled().get() ? "On" : "Off");
+            notifyAction("Metronome", nextState ? "On" : "Off");
             return;
         }
         if (isGlobalAltHeld()) {
+            final boolean nextState = !transport.isClipLauncherOverdubEnabled().get();
             transport.isClipLauncherOverdubEnabled().toggle();
-            notifyAction("Launcher Overdub", transport.isClipLauncherOverdubEnabled().get() ? "On" : "Off");
+            notifyAction("Launcher Overdub", nextState ? "On" : "Off");
             return;
         }
         toggleClipLauncherAutomationWriteEnabled(true);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -30,6 +30,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private static final double MAIN_ENCODER_STEP = 0.01;
     private static final double MAIN_ENCODER_FINE_STEP = 0.0025;
     private static final int DEVICE_DISCOVERY_WIDTH = 128;
+    private static final int[] BROWSER_RESULTS_PRIME_DELAYS_MS = {0, 1, 10, 30};
     public static final String MAIN_ENCODER_LAST_TOUCHED_ROLE = FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED;
     public static final String MAIN_ENCODER_SHUFFLE_ROLE = FireControlPreferences.MAIN_ENCODER_SHUFFLE;
     public static final String MAIN_ENCODER_TEMPO_ROLE = FireControlPreferences.MAIN_ENCODER_TEMPO;
@@ -175,6 +176,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         popupBrowser.exists().markInterested();
         browserResultsCursor = popupBrowser.resultsColumn().createCursorItem();
         browserResultsCursor.exists().markInterested();
+        browserResultsCursor.isSelected().markInterested();
         browserResultsCursor.name().markInterested();
 
         layers = new Layers(this);
@@ -1298,6 +1300,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             } else {
                 viewControl.getCursorTrack().startOfDeviceChainInsertionPoint().browse();
             }
+            scheduleBrowserResultsSelectionPrime();
             notifyAction("Browser", "Before");
             return;
         }
@@ -1307,15 +1310,40 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             } else {
                 viewControl.getCursorTrack().endOfDeviceChainInsertionPoint().browse();
             }
+            scheduleBrowserResultsSelectionPrime();
             notifyAction("Browser", "After");
             return;
         }
         if (primaryDevice.exists().get()) {
             primaryDevice.replaceDeviceInsertionPoint().browse();
+            scheduleBrowserResultsSelectionPrime();
             notifyAction("Browser", "Replace");
         } else {
             viewControl.getCursorTrack().endOfDeviceChainInsertionPoint().browse();
+            scheduleBrowserResultsSelectionPrime();
             notifyAction("Browser", "Add");
+        }
+    }
+
+    private void scheduleBrowserResultsSelectionPrime() {
+        for (final int delayMs : BROWSER_RESULTS_PRIME_DELAYS_MS) {
+            host.scheduleTask(this::primeBrowserResultsSelection, delayMs);
+        }
+    }
+
+    private void primeBrowserResultsSelection() {
+        if (!isPopupBrowserActive()) {
+            return;
+        }
+        if (browserResultsCursor.exists().get()) {
+            if (!browserResultsCursor.isSelected().get()) {
+                browserResultsCursor.isSelected().set(true);
+            }
+            return;
+        }
+        popupBrowser.selectFirstFile();
+        if (browserResultsCursor.exists().get()) {
+            browserResultsCursor.isSelected().set(true);
         }
     }
 
@@ -1335,6 +1363,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         oled.valueInfo("Browser", browserResultsCursor.exists().get() ? browserResultsCursor.name().get() : "No Results");
     }
 
+    public void routeBrowserMainEncoder(final int inc) {
+        handleGlobalMainEncoder(inc);
+    }
+
     private void handleGlobalMainEncoderPress(final boolean press) {
         if (!isPopupBrowserActive()) {
             return;
@@ -1343,6 +1375,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             popupBrowser.commit();
             notifyAction("Browser", "Commit");
         }
+    }
+
+    public void routeBrowserMainEncoderPress(final boolean press) {
+        handleGlobalMainEncoderPress(press);
     }
 
     public static AkaiFireOikontrolExtension getInstance() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/AcidGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/AcidGenerator.java
@@ -23,13 +23,16 @@ public final class AcidGenerator implements MelodicGenerator {
     }
 
     private String lastFamilyLabel = "";
+    private int subtypeIndex = -1;
 
     @Override
     public MelodicPattern generate(final MelodicPhraseContext context, final GenerateParameters parameters) {
         final int loopSteps = Math.max(1, Math.min(MelodicPattern.MAX_STEPS, parameters.loopSteps()));
         final Random random = new Random(parameters.seed());
         final boolean[] active = buildActivity(loopSteps, parameters.density(), random);
-        final Family family = Family.values()[random.nextInt(Family.values().length)];
+        final Family family = subtypeIndex < 0
+                ? Family.values()[random.nextInt(Family.values().length)]
+                : Family.values()[subtypeIndex];
         lastFamilyLabel = familyLabel(family);
         final int[] degrees = new int[loopSteps];
         final int[] octaveOffsets = new int[loopSteps];
@@ -74,6 +77,23 @@ public final class AcidGenerator implements MelodicGenerator {
     @Override
     public String lastFamilyLabel() {
         return lastFamilyLabel;
+    }
+
+    @Override
+    public boolean supportsSubtypeSelection() {
+        return true;
+    }
+
+    @Override
+    public void cycleSubtype(final int direction) {
+        final int variantCount = Family.values().length + 1;
+        final int next = Math.floorMod(subtypeIndex + 1 + direction, variantCount);
+        subtypeIndex = next - 1;
+    }
+
+    @Override
+    public String currentSubtypeLabel() {
+        return subtypeIndex < 0 ? "Any" : familyLabel(Family.values()[subtypeIndex]);
     }
 
     private String familyLabel(final Family family) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/CallResponseGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/CallResponseGenerator.java
@@ -16,6 +16,7 @@ public final class CallResponseGenerator implements MelodicGenerator {
     }
 
     private String lastFamilyLabel = "";
+    private int subtypeIndex = -1;
 
     @Override
     public MelodicPattern generate(final MelodicPhraseContext context, final GenerateParameters parameters) {
@@ -24,7 +25,9 @@ public final class CallResponseGenerator implements MelodicGenerator {
         final int half = Math.max(1, loopSteps / 2);
         final boolean[] active = new boolean[loopSteps];
         final int[] degrees = new int[loopSteps];
-        final ResponseTransform transform = ResponseTransform.values()[random.nextInt(ResponseTransform.values().length)];
+        final ResponseTransform transform = subtypeIndex < 0
+                ? ResponseTransform.values()[random.nextInt(ResponseTransform.values().length)]
+                : ResponseTransform.values()[subtypeIndex];
         lastFamilyLabel = transformLabel(transform);
 
         buildCall(active, degrees, half, parameters.density(), parameters.tension(), random);
@@ -55,6 +58,23 @@ public final class CallResponseGenerator implements MelodicGenerator {
     @Override
     public String lastFamilyLabel() {
         return lastFamilyLabel;
+    }
+
+    @Override
+    public boolean supportsSubtypeSelection() {
+        return true;
+    }
+
+    @Override
+    public void cycleSubtype(final int direction) {
+        final int variantCount = ResponseTransform.values().length + 1;
+        final int next = Math.floorMod(subtypeIndex + 1 + direction, variantCount);
+        subtypeIndex = next - 1;
+    }
+
+    @Override
+    public String currentSubtypeLabel() {
+        return subtypeIndex < 0 ? "Any" : transformLabel(ResponseTransform.values()[subtypeIndex]);
     }
 
     private String transformLabel(final ResponseTransform transform) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicGenerator.java
@@ -7,6 +7,17 @@ public interface MelodicGenerator {
         return "";
     }
 
+    default boolean supportsSubtypeSelection() {
+        return false;
+    }
+
+    default void cycleSubtype(final int direction) {
+    }
+
+    default String currentSubtypeLabel() {
+        return "Any";
+    }
+
     record GenerateParameters(int loopSteps, double density, double tension, double octaveActivity,
                               int pulses, int rotation, long seed) {
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicRenderer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicRenderer.java
@@ -26,14 +26,17 @@ public final class MelodicRenderer {
         }
         final RgbLigthState baseColor = clipColor != null ? clipColor : ACTIVE_STEP;
         if (step.tieFromPrevious()) {
-            final RgbLigthState tied = baseColor.getSoftDimmed();
+            final RgbLigthState tied = baseColor.getDimmed();
             return playing ? StepPadLightHelper.renderPlayheadHighlight(tied) : tied;
         }
         if (!step.active()) {
             return StepPadLightHelper.renderEmptyStep(stepIndex, playing ? stepIndex : -1);
         }
-        final RgbLigthState base = step.accent() ? baseColor.getBrightend() : baseColor.getSoftDimmed();
-        return playing ? StepPadLightHelper.renderPlayheadHighlight(base) : base;
+        if (playing) {
+            return StepPadLightHelper.renderPlayheadHighlight(
+                    step.accent() ? baseColor.getBrightend() : baseColor);
+        }
+        return StepPadLightHelper.renderOccupiedStep(baseColor, step.accent(), false);
     }
 
     public static RgbLigthState pitchPoolLight(final boolean enabled, final boolean root, final boolean usedInPattern) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicRenderer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicRenderer.java
@@ -27,13 +27,13 @@ public final class MelodicRenderer {
         final RgbLigthState baseColor = clipColor != null ? clipColor : ACTIVE_STEP;
         if (step.tieFromPrevious()) {
             final RgbLigthState tied = baseColor.getSoftDimmed();
-            return playing ? tied.getBrightend() : tied;
+            return playing ? StepPadLightHelper.renderPlayheadHighlight(tied) : tied;
         }
         if (!step.active()) {
             return StepPadLightHelper.renderEmptyStep(stepIndex, playing ? stepIndex : -1);
         }
         final RgbLigthState base = step.accent() ? baseColor.getBrightend() : baseColor.getSoftDimmed();
-        return playing ? base.getBrightest() : base;
+        return playing ? StepPadLightHelper.renderPlayheadHighlight(base) : base;
     }
 
     public static RgbLigthState pitchPoolLight(final boolean enabled, final boolean root, final boolean usedInPattern) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -979,6 +979,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private void handleMainEncoder(final int inc) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoder(inc);
             return;
         }
         driver.markMainEncoderTurned();
@@ -1001,6 +1002,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private void handleMainEncoderPress(final boolean pressed) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoderPress(pressed);
             return;
         }
         driver.setMainEncoderPressed(pressed);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -58,6 +58,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private static final int STEP_COUNT = 32;
     private static final int DEFAULT_LOOP_STEPS = 16;
     private static final double STEP_LENGTH = 0.25;
+    private static final int MAX_CLIP_LENGTH_BEATS = (int) (STEP_COUNT * STEP_LENGTH);
     private static final int DEFAULT_VELOCITY = 96;
     private static final double DEFAULT_GATE = 0.8;
     private static final int ENGINE_ENCODER_THRESHOLD = 3;
@@ -1085,7 +1086,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (generator == Generator.ROLLING) {
             return "Density";
         }
-        return "Oct Span";
+        return "Shape";
     }
 
     private void adjustPostDensity(final int amount) {
@@ -1142,7 +1143,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private void adjustOctaveActivity(final int amount) {
         octaveActivity = clampUnit(octaveActivity + amount * 0.05);
-        oled.valueInfo("Octave", "%.2f".formatted(octaveActivity));
+        oled.valueInfo(channelShapeLabel(), "%.2f".formatted(octaveActivity));
     }
 
     private void adjustEuclideanPulses(final int amount) {
@@ -2109,6 +2110,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     @Override
     public AkaiFireOikontrolExtension getDriver() {
         return driver;
+    }
+
+    @Override
+    public int getClipCreateLengthBeats() {
+        return MAX_CLIP_LENGTH_BEATS;
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -240,7 +240,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         driver.getButton(NoteAssign.MUTE_3).bindPressed(this, pressed -> {
             if (pressed) {
                 copyHeld.set(true);
-                oled.valueInfo("Paste", "Clip / step target");
+                oled.valueInfo("Paste", "Clip target");
             } else {
                 copyHeld.set(false);
                 oled.clearScreenDelayed();
@@ -2057,7 +2057,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }, () -> BiColorLightState.GREEN_HALF);
         encoderLayer.activate();
         selectedStep = Math.min(selectedStep, Math.max(0, loopSteps - 1));
-        oled.lineInfo("Melodic Step", "Up Pool  Alt+Up MutPool\nDown Phrase  Sh+Alt+Dn Clear");
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -1692,7 +1692,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final int preferredSlotIndex = driver.getViewControl().getSelectedClipSlotIndex();
         if (preferredSlotIndex >= 0 && preferredSlotIndex < clipSlotBank.getSizeOfBank()) {
             final ClipLauncherSlot preferredSlot = clipSlotBank.getItemAt(preferredSlotIndex);
-            if (preferredSlot.exists().get()) {
+            if (preferredSlot.exists().get() && preferredSlot.isSelected().get()) {
                 preferredSlot.select();
                 clipSelected = true;
             }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -2048,9 +2048,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }, () -> BiColorLightState.GREEN_HALF);
         patternButtons.setDownCallback(pressed -> {
             if (pressed) {
-                if (driver.isGlobalShiftHeld() && driver.isGlobalAltHeld()) {
-                    clearCurrentClip();
-                } else if (driver.isGlobalShiftHeld()) {
+                if (driver.isGlobalShiftHeld()) {
                     setView(view == View.NOTES ? View.PROCESS : view == View.EXPRESSION ? View.NOTES : View.EXPRESSION);
                 } else if (driver.isGlobalAltHeld()) {
                     mutatePattern(false);
@@ -2073,21 +2071,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         stopPitchPoolAuditions();
         encoderLayer.deactivate();
         noteRepeatHandler.deactivate();
-    }
-
-    private void clearCurrentClip() {
-        if (!ensureClipAvailable()) {
-            return;
-        }
-        refreshClipCursor();
-        cursorClip.clearSteps();
-        noteStepsByPosition.clear();
-        cachedPattern = MelodicPattern.empty(loopSteps);
-        basePattern = MelodicPattern.empty(loopSteps);
-        playingStep = -1;
-        selectedStep = Math.min(selectedStep, Math.max(0, loopSteps - 1));
-        oled.valueInfo("Clip", "Cleared");
-        driver.notifyPopup("Clip", "Cleared");
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -86,7 +86,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private final Set<Integer> auditioningPoolPitches = new HashSet<>();
     private final MotifGenerator motifGenerator = new MotifGenerator();
     private final CallResponseGenerator callResponseGenerator = new CallResponseGenerator();
-    private final EuclideanPhraseGenerator euclideanGenerator = new EuclideanPhraseGenerator();
     private final AcidGenerator acidGenerator = new AcidGenerator();
     private final RollingBassGenerator rollingBassGenerator = new RollingBassGenerator();
     private final OctaveJumpGenerator octaveJumpGenerator = new OctaveJumpGenerator();
@@ -135,7 +134,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         ACID("Acid"),
         MOTIF("Motif"),
         CALL_RESPONSE("Call/Resp"),
-        EUCLIDEAN("Euclid"),
         ROLLING("Rolling"),
         OCTAVE("Octave");
 
@@ -413,6 +411,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         oled.valueInfo("Generate", newGenerator.label);
     }
 
+    private MelodicGenerator activeGenerator() {
+        return switch (generator) {
+            case MOTIF -> motifGenerator;
+            case CALL_RESPONSE -> callResponseGenerator;
+            case ACID -> acidGenerator;
+            case ROLLING -> rollingBassGenerator;
+            case OCTAVE -> octaveJumpGenerator;
+        };
+    }
+
     private void loadGeneratorDefaults(final Generator selectedGenerator) {
         switch (selectedGenerator) {
             case MOTIF -> {
@@ -424,12 +432,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 density = 0.46;
                 tension = 0.28;
                 octaveActivity = 1.0;
-            }
-            case EUCLIDEAN -> {
-                density = 0.55;
-                tension = 0.30;
-                octaveActivity = 1.0;
-                euclideanPulses = Math.max(3, Math.min(loopSteps, 5));
             }
             case ACID -> {
                 density = 0.52;
@@ -632,7 +634,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final int[] offsetPool = switch (generator) {
             case MOTIF -> new int[]{0, 1, 2, 3, 4, 5, 6};
             case CALL_RESPONSE -> new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
-            case EUCLIDEAN -> new int[]{0, 1, 2, 3, 4};
             case ACID -> new int[]{0, 1, 2, 3, 4, 5, 6, 7};
             case ROLLING -> new int[]{0, 1, 2, 3, 4, 5, 6};
             case OCTAVE -> new int[]{0, 2, 4, 7, 9, 11, 13};
@@ -640,7 +641,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final int targetCount = switch (generator) {
             case MOTIF -> 3 + random.nextInt(tension >= 0.5 ? 3 : 2);
             case CALL_RESPONSE -> 4 + random.nextInt(tension >= 0.5 ? 3 : 2);
-            case EUCLIDEAN -> 2 + random.nextInt(2 + (tension >= 0.6 ? 1 : 0));
             case ACID -> 5 + random.nextInt(2 + (tension >= 0.6 ? 1 : 0));
             case ROLLING -> 3 + random.nextInt(2 + (density >= 0.65 ? 1 : 0));
             case OCTAVE -> 3 + random.nextInt(2);
@@ -709,14 +709,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             buildGeneratedPitchPool(generationSeed, false);
         }
         final MelodicGenerator.GenerateParameters parameters = generatorParametersForCurrentEngine(generationSeed);
-        final MelodicGenerator activeGenerator = switch (generator) {
-            case MOTIF -> motifGenerator;
-            case CALL_RESPONSE -> callResponseGenerator;
-            case EUCLIDEAN -> euclideanGenerator;
-            case ACID -> acidGenerator;
-            case ROLLING -> rollingBassGenerator;
-            case OCTAVE -> octaveJumpGenerator;
-        };
+        final MelodicGenerator activeGenerator = activeGenerator();
         MelodicPattern generated = activeGenerator.generate(context, parameters);
         generated = enrichLatentSteps(generated);
         generated = constrainPatternToPool(generated);
@@ -733,7 +726,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         return switch (selectedGenerator) {
             case MOTIF -> "Mtf";
             case CALL_RESPONSE -> "C&R";
-            case EUCLIDEAN -> "Euc";
             case ACID -> "Acd";
             case ROLLING -> "Rol";
             case OCTAVE -> "Oct";
@@ -747,9 +739,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             case CALL_RESPONSE -> new MelodicGenerator.GenerateParameters(
                     loopSteps, Math.max(0.35, density), Math.max(0.2, tension),
                     octaveActivity, euclideanPulses, euclideanRotation, generationSeed);
-            case EUCLIDEAN -> new MelodicGenerator.GenerateParameters(
-                    loopSteps, density, tension, octaveActivity,
-                    Math.max(1, euclideanPulses), euclideanRotation, generationSeed);
             case ACID -> new MelodicGenerator.GenerateParameters(
                     loopSteps,
                     Math.max(0.35, density),
@@ -1068,25 +1057,17 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private void adjustChannelShape(final int amount) {
-        if (generator == Generator.EUCLIDEAN) {
-            adjustEuclideanPulses(amount);
-            return;
-        }
-        if (generator == Generator.ROLLING) {
-            adjustDensity(amount);
-            return;
-        }
         adjustOctaveActivity(amount);
     }
 
     private String channelShapeLabel() {
-        if (generator == Generator.EUCLIDEAN) {
-            return "Pulses";
-        }
-        if (generator == Generator.ROLLING) {
-            return "Density";
-        }
-        return "Shape";
+        return switch (generator) {
+            case ACID -> "Motion";
+            case MOTIF -> "Contour";
+            case CALL_RESPONSE -> "Answer";
+            case ROLLING -> "Movement";
+            case OCTAVE -> "Jump";
+        };
     }
 
     private void adjustPostDensity(final int amount) {
@@ -1166,6 +1147,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final int nextIndex = Math.max(0, Math.min(values.length - 1, mutationMode.ordinal() + direction));
         mutationMode = values[nextIndex];
         oled.valueInfo("Mut Type", mutationLabel(mutationMode));
+    }
+
+    private void cycleGeneratorSubtype(final int direction) {
+        final MelodicGenerator activeGenerator = activeGenerator();
+        if (!activeGenerator.supportsSubtypeSelection()) {
+            oled.valueInfo("Subtype", "Any");
+            return;
+        }
+        activeGenerator.cycleSubtype(direction);
+        oled.valueInfo("Subtype", activeGenerator.currentSubtypeLabel());
     }
 
     private void adjustSeed(final int amount) {
@@ -1396,11 +1387,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 default -> 5;
             };
             case OCTAVE -> Math.floorMod(stepIndex, 2) == 0 ? 0 : 12;
-            case EUCLIDEAN -> switch (Math.floorMod(stepIndex, 3)) {
-                case 0 -> 0;
-                case 1 -> 2;
-                default -> 5;
-            };
             case MOTIF -> switch (Math.floorMod(stepIndex, 4)) {
                 case 0 -> 0;
                 case 1 -> 2;
@@ -1810,7 +1796,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private EncoderBankLayout createEncoderBankLayout() {
         final Map<EncoderMode, EncoderBank> banks = new EnumMap<>(EncoderMode.class);
         banks.put(EncoderMode.CHANNEL, new EncoderBank(
-                "1: Engine\n2: Density\n3: Shape\n4: Mut Type",
+                "1: Engine\n2: Density\n3: Motion\n4: Mut Type",
                 new EncoderSlotBinding[]{
                         engineSlot(),
                         valueSlot(this::adjustDensity, () -> "Density"),
@@ -1863,15 +1849,24 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                              final int slotIndex) {
                 encoder.bindEncoder(layer, inc -> {
                     final int steps = accumulator.consume(inc);
-                    if (steps > 0) {
+                    if (steps == 0) {
+                        return;
+                    }
+                    if (driver.isGlobalAltHeld()) {
+                        cycleGeneratorSubtype(steps > 0 ? 1 : -1);
+                    } else if (steps > 0) {
                         cycleGenerator(1);
-                    } else if (steps < 0) {
+                    } else {
                         cycleGenerator(-1);
                     }
                 });
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
-                        oled.valueInfo("Engine", generator.label);
+                        if (driver.isGlobalAltHeld()) {
+                            oled.valueInfo("Subtype", activeGenerator().currentSubtypeLabel());
+                        } else {
+                            oled.valueInfo("Engine", generator.label);
+                        }
                     } else {
                         accumulator.reset();
                         oled.clearScreenDelayed();
@@ -1893,6 +1888,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
                              final int slotIndex) {
                 encoder.bindEncoder(layer, inc -> {
+                    if (driver.isGlobalAltHeld()) {
+                        handler.recordTouchAdjustment(slotIndex, Math.abs(inc));
+                        adjustMutateIntensity(inc);
+                        return;
+                    }
                     final int steps = accumulator.consume(inc);
                     if (steps > 0) {
                         cycleMutationMode(1);
@@ -1902,7 +1902,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 });
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
-                        oled.valueInfo("Mut Type", mutationLabel(mutationMode));
+                        if (driver.isGlobalAltHeld()) {
+                            oled.valueInfo("Mut %", "%.2f".formatted(mutateIntensity));
+                        } else {
+                            oled.valueInfo("Mut Type", mutationLabel(mutationMode));
+                        }
                     } else {
                         accumulator.reset();
                         oled.clearScreenDelayed();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -31,6 +31,8 @@ import com.oikoaudio.fire.sequence.EncoderMode;
 import com.oikoaudio.fire.sequence.EncoderSlotBinding;
 import com.oikoaudio.fire.control.MixerEncoderProfile;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
+import com.oikoaudio.fire.sequence.SeqClipHandler;
+import com.oikoaudio.fire.sequence.SeqClipRowHost;
 import com.oikoaudio.fire.sequence.StepSequencerEncoderHandler;
 import com.oikoaudio.fire.sequence.StepSequencerHost;
 import com.oikoaudio.fire.utils.PatternButtons;
@@ -48,7 +50,10 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class MelodicStepMode extends Layer implements StepSequencerHost {
+public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClipRowHost {
+    private static final int CLIP_ROW_PAD_COUNT = 16;
+    private static final int PITCH_POOL_PAD_OFFSET = 16;
+    private static final int PITCH_POOL_PAD_COUNT = 16;
     private static final int STEP_PAD_OFFSET = 32;
     private static final int STEP_COUNT = 32;
     private static final int DEFAULT_LOOP_STEPS = 16;
@@ -72,8 +77,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
     private final EncoderBankLayout encoderBankLayout;
     private final Map<Integer, Map<Integer, NoteStep>> noteStepsByPosition = new HashMap<>();
     private final BooleanValueObject lengthDisplay = new BooleanValueObject();
+    private final BooleanValueObject selectHeld = new BooleanValueObject();
+    private final BooleanValueObject copyHeld = new BooleanValueObject();
     private final BooleanValueObject deleteHeld = new BooleanValueObject();
     private final BooleanValueObject fixedLengthHeld = new BooleanValueObject();
+    private final SeqClipHandler clipHandler;
     private final Set<Integer> auditioningPoolPitches = new HashSet<>();
     private final MotifGenerator motifGenerator = new MotifGenerator();
     private final CallResponseGenerator callResponseGenerator = new CallResponseGenerator();
@@ -146,7 +154,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
         this.noteInput = driver.getNoteInput();
 
         final ControllerHost host = driver.getHost();
-        this.cursorTrack = host.createCursorTrack("MELODIC_STEP", "Melodic Step", 8, 8, true);
+        this.cursorTrack = host.createCursorTrack("MELODIC_STEP", "Melodic Step", 8, CLIP_ROW_PAD_COUNT, true);
         this.cursorTrack.name().markInterested();
         this.cursorTrack.canHoldNoteData().markInterested();
         this.clipSlotBank = cursorTrack.clipLauncherSlotBank();
@@ -170,6 +178,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
             parameter.value().markInterested();
         }
         observeSelectedClip();
+        this.clipHandler = new SeqClipHandler(this);
         bindPads();
         bindButtons();
         bindMainEncoder();
@@ -210,37 +219,15 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
 
         driver.getButton(NoteAssign.MUTE_1).bindPressed(this, pressed -> {
             if (pressed) {
-                if (driver.isGlobalShiftHeld()) {
-                    applyHalveLength();
-                } else if (driver.isGlobalAltHeld()) {
-                    applyMirrorDouble();
-                } else {
-                    applyRepeatDouble();
-                }
+                selectHeld.set(true);
+                oled.valueInfo("Select", "Load clip");
+            } else {
+                selectHeld.set(false);
+                oled.clearScreenDelayed();
             }
-        }, () -> driver.isGlobalShiftHeld() || driver.isGlobalAltHeld() ? BiColorLightState.RED_HALF : BiColorLightState.AMBER_HALF);
+        }, () -> selectHeld.get() ? BiColorLightState.GREEN_FULL : BiColorLightState.GREEN_HALF);
 
         driver.getButton(NoteAssign.MUTE_2).bindPressed(this, pressed -> {
-            if (pressed) {
-                if (driver.isGlobalAltHeld()) {
-                    applyTransform(swivelPattern(cachedPattern), "Swivel", "Halves", false);
-                } else {
-                    applyTransform(cachedPattern.reversed(), "Reverse", "Pattern", false);
-                }
-            }
-        }, () -> driver.isGlobalAltHeld() ? BiColorLightState.RED_HALF : BiColorLightState.AMBER_HALF);
-
-        driver.getButton(NoteAssign.MUTE_3).bindPressed(this, pressed -> {
-            if (pressed) {
-                if (driver.isGlobalAltHeld()) {
-                    applyTransform(contourInvertDown(cachedPattern), "Invert", "Down", true);
-                } else {
-                    applyTransform(contourInvertUp(cachedPattern), "Invert", "Up", true);
-                }
-            }
-        }, () -> driver.isGlobalAltHeld() ? BiColorLightState.RED_HALF : BiColorLightState.AMBER_HALF);
-
-        driver.getButton(NoteAssign.MUTE_4).bindPressed(this, pressed -> {
             fixedLengthHeld.set(pressed);
             if (pressed) {
                 oled.valueInfo("Last Step", "Target step");
@@ -248,12 +235,36 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
                 oled.clearScreenDelayed();
             }
         }, () -> fixedLengthHeld.get() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF);
+
+        driver.getButton(NoteAssign.MUTE_3).bindPressed(this, pressed -> {
+            if (pressed) {
+                copyHeld.set(true);
+                oled.valueInfo("Paste", "Clip / step target");
+            } else {
+                copyHeld.set(false);
+                oled.clearScreenDelayed();
+            }
+        }, () -> copyHeld.get() ? BiColorLightState.GREEN_FULL : BiColorLightState.OFF);
+
+        driver.getButton(NoteAssign.MUTE_4).bindPressed(this, pressed -> {
+            if (pressed) {
+                deleteHeld.set(true);
+                oled.valueInfo("Delete", "Clip / step target");
+            } else {
+                deleteHeld.set(false);
+                oled.clearScreenDelayed();
+            }
+        }, () -> deleteHeld.get() ? BiColorLightState.RED_FULL : BiColorLightState.OFF);
     }
 
     private void bindMainEncoder() {
         final TouchEncoder mainEncoder = driver.getMainEncoder();
         mainEncoder.bindEncoder(this, this::handleMainEncoder);
         mainEncoder.bindTouched(this, this::handleMainEncoderPress);
+    }
+
+    public void notifyBlink(final int blinkTicks) {
+        clipHandler.notifyBlink(blinkTicks);
     }
 
     public void handleStepButton(final boolean pressed) {
@@ -279,8 +290,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
     }
 
     private void handlePadPress(final int padIndex, final boolean pressed) {
+        if (padIndex < CLIP_ROW_PAD_COUNT) {
+            clipHandler.handlePadPress(padIndex, pressed);
+            return;
+        }
         if (padIndex < STEP_PAD_OFFSET && !pressed) {
-            stopPitchPoolAudition(padIndex);
+            stopPitchPoolAudition(padIndex - PITCH_POOL_PAD_OFFSET);
             return;
         }
         if (padIndex >= STEP_PAD_OFFSET && !pressed) {
@@ -298,7 +313,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
             return;
         }
         if (padIndex < STEP_PAD_OFFSET) {
-            togglePitchPoolPad(padIndex);
+            togglePitchPoolPad(padIndex - PITCH_POOL_PAD_OFFSET);
             return;
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
@@ -313,6 +328,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
         if (fixedLengthHeld.get()) {
             heldStepConsumed = true;
             setLoopSteps(stepIndex + 1);
+            return;
+        }
+        if (copyHeld.get()) {
+            heldStepConsumed = true;
+            oled.valueInfo("Paste", "Clip row only");
             return;
         }
         if (deleteHeld.get()) {
@@ -1433,7 +1453,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
     }
 
     private List<Integer> pitchPoolLayoutPitches() {
-        return phraseContext().collapsedScaleRange(STEP_PAD_OFFSET);
+        return phraseContext().collapsedScaleRange(PITCH_POOL_PAD_COUNT);
     }
 
     private String pitchName(final int midiPitch) {
@@ -1637,10 +1657,14 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
             slot.isSelected().markInterested();
             slot.hasContent().markInterested();
             slot.color().markInterested();
+            slot.isPlaying().markInterested();
+            slot.isRecording().markInterested();
             slot.exists().addValueObserver(ignored -> refreshSelectedClipState());
             slot.isSelected().addValueObserver(ignored -> refreshSelectedClipState());
             slot.hasContent().addValueObserver(ignored -> refreshSelectedClipState());
             slot.color().addValueObserver((r, g, b) -> refreshSelectedClipState());
+            slot.isPlaying().addValueObserver(ignored -> refreshSelectedClipState());
+            slot.isRecording().addValueObserver(ignored -> refreshSelectedClipState());
         }
         refreshSelectedClipState();
     }
@@ -1675,16 +1699,44 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
     }
 
     private void refreshClipCursor() {
+        boolean clipSelected = false;
         final int preferredSlotIndex = driver.getViewControl().getSelectedClipSlotIndex();
         if (preferredSlotIndex >= 0 && preferredSlotIndex < clipSlotBank.getSizeOfBank()) {
-            clipSlotBank.cursorIndex().set(preferredSlotIndex);
             final ClipLauncherSlot preferredSlot = clipSlotBank.getItemAt(preferredSlotIndex);
             if (preferredSlot.exists().get()) {
                 preferredSlot.select();
+                clipSelected = true;
             }
+        }
+        if (!clipSelected) {
+            clipSelected = selectPlayingClipSlot();
+        }
+        if (!clipSelected) {
+            selectSelectedClipSlot();
         }
         cursorClip.scrollToKey(0);
         cursorClip.scrollToStep(0);
+    }
+
+    private boolean selectPlayingClipSlot() {
+        for (int i = 0; i < clipSlotBank.getSizeOfBank(); i++) {
+            final ClipLauncherSlot slot = clipSlotBank.getItemAt(i);
+            if (slot.exists().get() && (slot.isPlaying().get() || slot.isRecording().get())) {
+                slot.select();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void selectSelectedClipSlot() {
+        for (int i = 0; i < clipSlotBank.getSizeOfBank(); i++) {
+            final ClipLauncherSlot slot = clipSlotBank.getItemAt(i);
+            if (slot.exists().get() && slot.isSelected().get()) {
+                slot.select();
+                return;
+            }
+        }
     }
 
     private MelodicPhraseContext phraseContext() {
@@ -1694,8 +1746,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
     }
 
     private RgbLigthState getPadLight(final int padIndex) {
+        if (padIndex < CLIP_ROW_PAD_COUNT) {
+            return clipHandler.getPadLight(padIndex);
+        }
         if (padIndex < STEP_PAD_OFFSET) {
-            return getPitchPoolPadLight(padIndex);
+            return getPitchPoolPadLight(padIndex - PITCH_POOL_PAD_OFFSET);
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
         return MelodicRenderer.stepLight(cachedPattern.step(stepIndex), heldStep != null && heldStep == stepIndex,
@@ -1762,12 +1817,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
                         mutationModeSlot()
                 }));
         banks.put(EncoderMode.MIXER, new EncoderBank(
-                "1: Volume\n2: Pan\n3: Send 1\n4: Send 2",
+                "1: Length\n2: Mirror\n3: Reverse\n4: Invert",
                 new EncoderSlotBinding[]{
-                        mixerSlot(0, "Volume"),
-                        mixerSlot(1, "Pan"),
-                        mixerSlot(2, "Send 1"),
-                        mixerSlot(3, "Send 2")
+                        actionSlot("Length", this::adjustLengthProcess),
+                        actionSlot("Mirror", this::adjustMirrorProcess),
+                        actionSlot("Reverse", this::adjustReverseProcess),
+                        actionSlot("Invert", this::adjustInvertProcess)
                 }));
         banks.put(EncoderMode.USER_1, new EncoderBank(
                 "1: Tension\n2: Pulses\n3: Rotation\n4: Mut %",
@@ -1917,6 +1972,59 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
         };
     }
 
+    private EncoderSlotBinding actionSlot(final String label, final java.util.function.IntConsumer adjuster) {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return MixerEncoderProfile.STEP_SIZE;
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                encoder.bindEncoder(layer, adjuster::accept);
+                encoder.bindTouched(layer, touched -> {
+                    if (touched) {
+                        oled.valueInfo(label, "Turn");
+                    } else {
+                        oled.clearScreenDelayed();
+                    }
+                });
+            }
+        };
+    }
+
+    private void adjustLengthProcess(final int inc) {
+        if (inc > 0) {
+            applyRepeatDouble();
+        } else if (inc < 0) {
+            applyHalveLength();
+        }
+    }
+
+    private void adjustMirrorProcess(final int inc) {
+        if (inc > 0) {
+            applyMirrorDouble();
+        } else if (inc < 0) {
+            applyTransform(swivelPattern(cachedPattern), "Swivel", "Halves", false);
+        }
+    }
+
+    private void adjustReverseProcess(final int inc) {
+        if (inc == 0) {
+            return;
+        }
+        applyTransform(cachedPattern.reversed(), "Reverse", "Pattern", false);
+    }
+
+    private void adjustInvertProcess(final int inc) {
+        if (inc > 0) {
+            applyTransform(contourInvertUp(cachedPattern), "Invert", "Up", true);
+        } else if (inc < 0) {
+            applyTransform(contourInvertDown(cachedPattern), "Invert", "Down", true);
+        }
+    }
+
     @Override
     protected void onActivate() {
         refreshClipCursor();
@@ -1980,7 +2088,47 @@ public class MelodicStepMode extends Layer implements StepSequencerHost {
 
     @Override
     public boolean isSelectHeld() {
-        return false;
+        return selectHeld.get();
+    }
+
+    @Override
+    public boolean isCopyHeld() {
+        return copyHeld.get();
+    }
+
+    @Override
+    public boolean isDeleteHeld() {
+        return deleteHeld.get();
+    }
+
+    @Override
+    public boolean isShiftHeld() {
+        return driver.isGlobalShiftHeld();
+    }
+
+    @Override
+    public AkaiFireOikontrolExtension getDriver() {
+        return driver;
+    }
+
+    @Override
+    public OledDisplay getOled() {
+        return oled;
+    }
+
+    @Override
+    public ClipLauncherSlotBank getClipSlotBank() {
+        return clipSlotBank;
+    }
+
+    @Override
+    public PinnableCursorClip getClipCursor() {
+        return cursorClip;
+    }
+
+    @Override
+    public void notifyPopup(final String title, final String value) {
+        driver.notifyPopup(title, value);
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -33,6 +33,7 @@ import com.oikoaudio.fire.control.MixerEncoderProfile;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
 import com.oikoaudio.fire.sequence.SeqClipHandler;
 import com.oikoaudio.fire.sequence.SeqClipRowHost;
+import com.oikoaudio.fire.sequence.AccentLatchState;
 import com.oikoaudio.fire.sequence.StepSequencerEncoderHandler;
 import com.oikoaudio.fire.sequence.StepSequencerHost;
 import com.oikoaudio.fire.utils.PatternButtons;
@@ -103,9 +104,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private final LinkedHashSet<Integer> allowedPitches = new LinkedHashSet<>();
     private boolean poolUserEdited = false;
     private Generator poolGeneratorSource = null;
-    private boolean accentActive = false;
-    private boolean accentButtonHeld = false;
-    private boolean accentModified = false;
+    private final AccentLatchState accentState = new AccentLatchState();
     private boolean mainEncoderPressConsumed = false;
     private double density = 0.45;
     private double tension = 0.25;
@@ -274,18 +273,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             }
             return;
         }
-        accentButtonHeld = pressed;
-        if (pressed) {
-            oled.valueInfo("Accent", accentActive ? "On" : "Off");
-        } else {
-            if (!accentModified) {
-                accentActive = !accentActive;
-                oled.valueInfo("Accent", accentActive ? "On" : "Off");
-            } else {
-                oled.clearScreenDelayed();
-            }
-            accentModified = false;
+        final AccentLatchState.Transition transition = accentState.handlePressed(pressed);
+        if (transition == AccentLatchState.Transition.PRESSED) {
+            oled.valueInfo("Accent", accentState.isActive() ? "On" : "Off");
+            return;
         }
+        if (transition == AccentLatchState.Transition.TOGGLED_ON_RELEASE) {
+            oled.valueInfo("Accent", accentState.isActive() ? "On" : "Off");
+            return;
+        }
+        oled.clearScreenDelayed();
     }
 
     private void handlePadPress(final int padIndex, final boolean pressed) {
@@ -299,8 +296,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }
         if (padIndex >= STEP_PAD_OFFSET && !pressed) {
             final int stepIndex = padIndex - STEP_PAD_OFFSET;
+            final boolean accentGesture = accentState.isHeld() || accentState.isActive();
             if (heldStep != null && heldStep == stepIndex) {
-                if (!heldStepConsumed && !accentButtonHeld && !fixedLengthHeld.get() && !deleteHeld.get()) {
+                if (!heldStepConsumed && !accentGesture && !fixedLengthHeld.get() && !deleteHeld.get()) {
                     toggleStep(stepIndex);
                 }
                 heldStep = null;
@@ -316,11 +314,14 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             return;
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
+        final boolean accentGesture = accentState.isHeld() || accentState.isActive();
         heldStep = stepIndex;
         heldStepConsumed = false;
-        if (accentButtonHeld) {
+        if (accentGesture) {
             heldStepConsumed = true;
-            accentModified = true;
+            if (accentState.isHeld()) {
+                accentState.markModified();
+            }
             toggleAccent(stepIndex);
             return;
         }
@@ -860,7 +861,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private MelodicPattern.Step applyCurrentAccentState(final MelodicPattern.Step step) {
-        return accentActive
+        return accentState.isActive()
                 ? step.withAccent(true).withVelocity(118)
                 : step.withAccent(false).withVelocity(DEFAULT_VELOCITY);
     }
@@ -1780,10 +1781,10 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (driver.isGlobalAltHeld()) {
             return driver.getStepFillLightState();
         }
-        if (accentButtonHeld) {
-            return accentActive ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+        if (accentState.isHeld()) {
+            return accentState.isActive() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
         }
-        return accentActive ? BiColorLightState.AMBER_HALF : BiColorLightState.GREEN_FULL;
+        return accentState.isActive() ? BiColorLightState.AMBER_HALF : BiColorLightState.GREEN_FULL;
     }
 
     private String mutationLabel(final MelodicMutator.Mode mode) {
@@ -2067,7 +2068,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     protected void onDeactivate() {
         patternButtons.setUpCallback(pressed -> { }, () -> BiColorLightState.OFF);
         patternButtons.setDownCallback(pressed -> { }, () -> BiColorLightState.OFF);
-        accentButtonHeld = false;
+        accentState.clearHeld();
         fixedLengthHeld.set(false);
         deleteHeld.set(false);
         stopPitchPoolAuditions();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MotifGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MotifGenerator.java
@@ -33,6 +33,7 @@ public final class MotifGenerator implements MelodicGenerator {
     }
 
     private String lastFamilyLabel = "";
+    private int subtypeIndex = -1;
 
     @Override
     public MelodicPattern generate(final MelodicPhraseContext context, final GenerateParameters parameters) {
@@ -41,7 +42,9 @@ public final class MotifGenerator implements MelodicGenerator {
         final int sectionLength = phraseSectionLength(loopSteps);
         final int[] baseRhythm = projectPositions(RHYTHM_CELLS[random.nextInt(RHYTHM_CELLS.length)], sectionLength);
         final int[] baseCell = buildBaseCell(baseRhythm.length, parameters.tension(), random);
-        final MotifFamily family = MotifFamily.values()[random.nextInt(MotifFamily.values().length)];
+        final MotifFamily family = subtypeIndex < 0
+                ? MotifFamily.values()[random.nextInt(MotifFamily.values().length)]
+                : MotifFamily.values()[subtypeIndex];
         lastFamilyLabel = familyLabel(family);
 
         final boolean[] active = new boolean[loopSteps];
@@ -87,6 +90,23 @@ public final class MotifGenerator implements MelodicGenerator {
     @Override
     public String lastFamilyLabel() {
         return lastFamilyLabel;
+    }
+
+    @Override
+    public boolean supportsSubtypeSelection() {
+        return true;
+    }
+
+    @Override
+    public void cycleSubtype(final int direction) {
+        final int variantCount = MotifFamily.values().length + 1;
+        final int next = Math.floorMod(subtypeIndex + 1 + direction, variantCount);
+        subtypeIndex = next - 1;
+    }
+
+    @Override
+    public String currentSubtypeLabel() {
+        return subtypeIndex < 0 ? "Any" : familyLabel(MotifFamily.values()[subtypeIndex]);
     }
 
     private String familyLabel(final MotifFamily family) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/RollingBassGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/RollingBassGenerator.java
@@ -25,6 +25,7 @@ public final class RollingBassGenerator implements MelodicGenerator {
     }
 
     private String lastFamilyLabel = "";
+    private int subtypeIndex = -1;
 
     @Override
     public MelodicPattern generate(final MelodicPhraseContext context, final GenerateParameters parameters) {
@@ -43,7 +44,7 @@ public final class RollingBassGenerator implements MelodicGenerator {
                 continue;
             }
             if (i > 0 && i % cellLength == 0) {
-                cellRoot = nextCellRoot(cellRoot, parameters.tension(), random);
+                cellRoot = nextCellRoot(cellRoot, parameters.tension(), parameters.octaveActivity(), random);
             }
 
             final int inCell = i % cellLength;
@@ -53,7 +54,8 @@ public final class RollingBassGenerator implements MelodicGenerator {
                 continue;
             }
 
-            final int degree = degreeAt(inCell, family, cellRoot, previousDegree, parameters.tension(), random);
+            final int degree = degreeAt(inCell, family, cellRoot, previousDegree,
+                    parameters.tension(), parameters.octaveActivity(), random);
             previousDegree = degree;
             final boolean anchor = inCell == 0 || i == loopSteps - 1;
             final int octaveOffset = chooseOctaveOffset(inCell, parameters.octaveActivity(), random);
@@ -72,6 +74,23 @@ public final class RollingBassGenerator implements MelodicGenerator {
         return lastFamilyLabel;
     }
 
+    @Override
+    public boolean supportsSubtypeSelection() {
+        return true;
+    }
+
+    @Override
+    public void cycleSubtype(final int direction) {
+        final int variantCount = Family.values().length + 1;
+        final int next = Math.floorMod(subtypeIndex + 1 + direction, variantCount);
+        subtypeIndex = next - 1;
+    }
+
+    @Override
+    public String currentSubtypeLabel() {
+        return subtypeIndex < 0 ? "Any" : familyLabel(Family.values()[subtypeIndex]);
+    }
+
     private String familyLabel(final Family family) {
         return switch (family) {
             case ROOT_DRIVE -> "RootDrive";
@@ -81,6 +100,9 @@ public final class RollingBassGenerator implements MelodicGenerator {
     }
 
     private Family chooseFamily(final double density, final Random random) {
+        if (subtypeIndex >= 0) {
+            return Family.values()[subtypeIndex];
+        }
         if (density >= 0.999) {
             final int pick = random.nextInt(10);
             if (pick < 5) {
@@ -94,11 +116,12 @@ public final class RollingBassGenerator implements MelodicGenerator {
         return Family.values()[random.nextInt(Family.values().length)];
     }
 
-    private int nextCellRoot(final int currentRoot, final double tension, final Random random) {
-        if (random.nextDouble() < 0.55 - tension * 0.12) {
+    private int nextCellRoot(final int currentRoot, final double tension, final double movement, final Random random) {
+        final double stayChance = Math.max(0.12, 0.62 - tension * 0.10 - movement * 0.45);
+        if (random.nextDouble() < stayChance) {
             return currentRoot;
         }
-        final int limit = tension >= 0.45 ? CELL_SHIFTS.length : CELL_SHIFTS.length - 1;
+        final int limit = tension + movement >= 0.55 ? CELL_SHIFTS.length : CELL_SHIFTS.length - 1;
         final int shift = CELL_SHIFTS[random.nextInt(limit)];
         return clampDegree(currentRoot + shift);
     }
@@ -114,20 +137,27 @@ public final class RollingBassGenerator implements MelodicGenerator {
     }
 
     private int degreeAt(final int inCell, final Family family, final int cellRoot, final int previousDegree,
-                         final double tension, final Random random) {
+                         final double tension, final double movement, final Random random) {
         final int pattern = FAMILY_PATTERNS[family.ordinal()][inCell];
         if (pattern == 0) {
             return cellRoot;
         }
         if (pattern == 1) {
-            final int[] offsets = tension >= 0.45 ? new int[]{1, -1, 2, 0} : new int[]{1, -1, 0};
+            final int[] offsets = movement >= 0.55
+                    ? new int[]{1, -1, 2, -2, 3, 0}
+                    : tension >= 0.45 ? new int[]{1, -1, 2, 0} : new int[]{1, -1, 0};
             return clampDegree(cellRoot + offsets[random.nextInt(offsets.length)]);
         }
         if (pattern == 2) {
+            if (movement >= 0.55 && random.nextDouble() < 0.45) {
+                return clampDegree(cellRoot + (family == Family.LATE_LIFT ? 4 : 3));
+            }
             return clampDegree(cellRoot + (family == Family.LATE_LIFT && random.nextDouble() < 0.55 ? 3
                     : random.nextDouble() < 0.72 ? 1 : 2));
         }
-        final int answer = random.nextDouble() < 0.68 ? previousDegree : cellRoot + (family == Family.LATE_LIFT ? 4 : 2);
+        final int answer = random.nextDouble() < Math.max(0.25, 0.78 - movement * 0.40)
+                ? previousDegree
+                : cellRoot + (family == Family.LATE_LIFT ? 4 : movement >= 0.6 ? 3 : 2);
         return clampDegree(answer);
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -42,6 +42,7 @@ import com.oikoaudio.fire.sequence.NoteRepeatHandler;
 import com.oikoaudio.fire.sequence.NoteStepAccess;
 import com.oikoaudio.fire.sequence.SeqClipHandler;
 import com.oikoaudio.fire.sequence.SeqClipRowHost;
+import com.oikoaudio.fire.sequence.AccentLatchState;
 import com.oikoaudio.fire.sequence.StepSequencerEncoderHandler;
 import com.oikoaudio.fire.sequence.StepPadLightHelper;
 import com.oikoaudio.fire.sequence.StepSequencerHost;
@@ -179,9 +180,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     private boolean pitchContextTouched = false;
     private boolean inKey = false;
     private boolean noteStepActive = false;
-    private boolean oikordAccentActive = false;
-    private boolean oikordAccentButtonHeld = false;
-    private boolean oikordAccentModified = false;
+    private final AccentLatchState oikordAccentState = new AccentLatchState();
     private boolean mainEncoderPressConsumed = false;
     private boolean builderInKey = true;
     private NoteStepSubMode currentStepSubMode = NoteStepSubMode.OIKORD_STEP;
@@ -823,7 +822,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private void handleStepSeqPressed(final boolean pressed) {
         if (noteStepActive && currentStepSubMode == NoteStepSubMode.OIKORD_STEP) {
-            if (driver.isGlobalShiftHeld()) {
+            if (driver.isGlobalShiftHeld() || oikordAccentState.isHeld()) {
                 handleOikordAccentPressed(pressed);
                 return;
             }
@@ -899,10 +898,11 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             return;
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
+        final boolean accentGesture = oikordAccentState.isHeld() || oikordAccentState.isActive();
         if (pressed && !ensureSelectedNoteClipSlot()) {
             return;
         }
-        if (oikordAccentButtonHeld) {
+        if (accentGesture) {
             if (pressed) {
                 toggleOikordAccentForStep(stepIndex);
             }
@@ -2143,31 +2143,29 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             return BiColorLightState.OFF;
         }
         if (driver.isGlobalShiftHeld()) {
-            return oikordAccentActive ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+            return oikordAccentState.isActive() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
         }
         if (driver.isGlobalAltHeld()) {
             return driver.getStepFillLightState();
         }
-        return oikordAccentActive ? BiColorLightState.AMBER_FULL : BiColorLightState.OFF;
+        return oikordAccentState.isActive() ? BiColorLightState.AMBER_FULL : BiColorLightState.OFF;
     }
 
     private void handleOikordAccentPressed(final boolean pressed) {
-        oikordAccentButtonHeld = pressed;
-        if (!pressed) {
-            if (!oikordAccentModified) {
-                oikordAccentActive = !oikordAccentActive;
-                oled.valueInfo("Accent", oikordAccentActive ? "On" : "Off");
-            } else {
-                oled.clearScreenDelayed();
-            }
-            oikordAccentModified = false;
+        final AccentLatchState.Transition transition = oikordAccentState.handlePressed(pressed);
+        if (transition == AccentLatchState.Transition.PRESSED) {
+            oled.valueInfo("Accent", oikordAccentState.isActive() ? "On" : "Off");
             return;
         }
-        oled.valueInfo("Accent", oikordAccentActive ? "On" : "Off");
+        if (transition == AccentLatchState.Transition.TOGGLED_ON_RELEASE) {
+            oled.valueInfo("Accent", oikordAccentState.isActive() ? "On" : "Off");
+            return;
+        }
+        oled.clearScreenDelayed();
     }
 
     private int currentOikordVelocity(final int rawVelocity) {
-        if (oikordAccentActive) {
+        if (oikordAccentState.isActive()) {
             return DEFAULT_OIKORD_ACCENTED_VELOCITY;
         }
         return LiveVelocityLogic.resolveVelocity(defaultOikordVelocity, oikordVelocitySensitivity, rawVelocity);
@@ -2181,7 +2179,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         final boolean accented = notesAtStep.values().stream().allMatch(this::isOikordAccented);
         final double targetVelocity = (accented ? defaultOikordVelocity : DEFAULT_OIKORD_ACCENTED_VELOCITY) / 127.0;
         notesAtStep.values().forEach(note -> note.setVelocity(targetVelocity));
-        oikordAccentModified = true;
+        oikordAccentState.markModified();
         oled.valueInfo("Accent", accented ? "Normal" : "Accented");
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -2321,6 +2321,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private void handleMainEncoder(final int inc) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoder(inc);
             return;
         }
         driver.markMainEncoderTurned();
@@ -2349,6 +2350,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private void handleMainEncoderPress(final boolean pressed) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoderPress(pressed);
             return;
         }
         driver.setMainEncoderPressed(pressed);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -3134,6 +3134,9 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private BiColorLightState getPatternDownLight() {
         if (noteStepActive && currentStepSubMode == NoteStepSubMode.OIKORD_STEP) {
+            if (driver.isGlobalShiftHeld() && driver.isGlobalAltHeld()) {
+                return BiColorLightState.RED_HALF;
+            }
             return chordStepPosition.canScrollRight().get() ? BiColorLightState.GREEN_HALF : BiColorLightState.OFF;
         }
         return BiColorLightState.GREEN_HALF;
@@ -3337,7 +3340,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
                         chordBuildVelocitySlot(),
                         oikordSlot(2, oikordFamilyEncoder,
                                 amount -> {
-                                    if (driver.isGlobalShiftHeld() || driver.isGlobalAltHeld()) {
+                                    if (driver.isGlobalAltHeld()) {
                                         adjustOikordPage(amount);
                                     } else {
                                         adjustOikordFamily(amount);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -40,6 +40,8 @@ import com.oikoaudio.fire.sequence.EncoderMode;
 import com.oikoaudio.fire.sequence.EncoderSlotBinding;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
 import com.oikoaudio.fire.sequence.NoteStepAccess;
+import com.oikoaudio.fire.sequence.SeqClipHandler;
+import com.oikoaudio.fire.sequence.SeqClipRowHost;
 import com.oikoaudio.fire.sequence.StepSequencerEncoderHandler;
 import com.oikoaudio.fire.sequence.StepPadLightHelper;
 import com.oikoaudio.fire.sequence.StepSequencerHost;
@@ -56,7 +58,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class NoteMode extends Layer implements StepSequencerHost {
+public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost {
+    private static final int CLIP_ROW_PAD_COUNT = 16;
+    private static final int OIKORD_SOURCE_PAD_OFFSET = 16;
+    private static final int OIKORD_SOURCE_PAD_COUNT = 16;
     private static final int BUILDER_FAMILY_INDEX = 0;
     private static final String BUILDER_FAMILY_LABEL = "Builder";
     private static final int PIANO_HIGHLIGHT_INDEX = -1;
@@ -146,6 +151,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
     private final Map<Integer, Map<Integer, Integer>> pendingBankFineStarts = new HashMap<>();
     private final Map<Integer, ChordEvent> pendingBankChordEvents = new HashMap<>();
     private final OikordBank oikordBank = new OikordBank();
+    private final SeqClipHandler clipHandler;
     private final CursorTrack cursorTrack;
     private final PinnableCursorClip noteStepClip;
     private final Clip observedNoteClip;
@@ -289,7 +295,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
         this.liveUser2Layer = new Layer(driver.getLayers(), "NOTE_MODE_LIVE_USER2");
 
         final ControllerHost host = driver.getHost();
-        this.cursorTrack = host.createCursorTrack("NOTE_VIEW", "Note View", 8, 8, true);
+        this.cursorTrack = host.createCursorTrack("NOTE_VIEW", "Note View", 8, CLIP_ROW_PAD_COUNT, true);
         this.cursorTrack.name().markInterested();
         this.cursorTrack.color().markInterested();
         this.cursorTrack.canHoldNoteData().markInterested();
@@ -311,6 +317,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
         this.observedNoteClip.addStepDataObserver(this::handleObservedStepData);
         this.noteStepClip.playingStep().addValueObserver(this::handlePlayingStep);
         observeSelectedNoteClip();
+        this.clipHandler = new SeqClipHandler(this);
         this.stepEncoderBankLayout = createStepEncoderBankLayout();
         this.stepEncoderLayer = new StepSequencerEncoderHandler(this, driver);
         this.currentLiveEncoderLayer = liveChannelLayer;
@@ -374,6 +381,10 @@ public class NoteMode extends Layer implements StepSequencerHost {
         liveVelocitySensitivity = driver.getDefaultVelocitySensitivityPreference();
     }
 
+    public void notifyBlink(final int blinkTicks) {
+        clipHandler.notifyBlink(blinkTicks);
+    }
+
     private void bindPads() {
         final RgbButton[] pads = driver.getRgbButtons();
         for (int index = 0; index < pads.length; index++) {
@@ -422,8 +433,8 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private void bindLiveChannelEncoders(final TouchEncoder[] encoders) {
-        bindLiveMidiEncoder(encoders[0], liveChannelLayer, "Mod",
-                this::adjustLiveModulation, () -> liveModulation);
+        bindResettableLiveMidiEncoder(encoders[0], liveChannelLayer, 0, "Mod",
+                this::adjustLiveModulation, () -> Integer.toString(liveModulation), this::resetLiveModulation);
 
         encoders[1].bindEncoder(liveChannelLayer, this::adjustLivePitchOffset);
         encoders[1].bindTouched(liveChannelLayer, this::handleLivePitchOffsetTouch);
@@ -436,14 +447,14 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private void bindLiveExpressionEncoders(final TouchEncoder[] encoders) {
-        bindLiveMidiEncoder(encoders[0], liveUser1Layer, "Mod",
-                this::adjustLiveModulation, () -> liveModulation);
-        bindLiveMidiEncoder(encoders[1], liveUser1Layer, "Pressure",
-                this::adjustLivePressure, () -> livePressure);
-        bindLiveMidiEncoder(encoders[2], liveUser1Layer, "Timbre",
-                this::adjustLiveTimbre, () -> liveTimbre);
-        bindLiveMidiEncoder(encoders[3], liveUser1Layer, "Pitch Expr",
-                this::adjustLivePitchExpression, () -> livePitchExpression);
+        bindResettableLiveMidiEncoder(encoders[0], liveUser1Layer, 0, "Aftertouch",
+                this::adjustLivePressure, () -> Integer.toString(livePressure), this::resetLivePressure);
+        bindResettableLiveMidiEncoder(encoders[1], liveUser1Layer, 1, "Pressure",
+                this::adjustLivePressure, () -> Integer.toString(livePressure), this::resetLivePressure);
+        bindResettableLiveMidiEncoder(encoders[2], liveUser1Layer, 2, "Timbre",
+                this::adjustLiveTimbre, () -> Integer.toString(liveTimbre), this::resetLiveTimbre);
+        bindResettableLiveMidiEncoder(encoders[3], liveUser1Layer, 3, "Pitch Expr",
+                this::adjustLivePitchExpression, this::formatLivePitchExpressionDisplay, this::resetLivePitchExpression);
     }
 
     private void bindLiveRemoteEncoders(final TouchEncoder[] encoders) {
@@ -500,6 +511,22 @@ public class NoteMode extends Layer implements StepSequencerHost {
                 Integer.toString(valueSupplier.getAsInt())));
     }
 
+    private void bindResettableLiveMidiEncoder(final TouchEncoder encoder, final Layer layer, final int encoderIndex,
+                                               final String label, final java.util.function.IntConsumer adjuster,
+                                               final java.util.function.Supplier<String> valueSupplier,
+                                               final Runnable resetAction) {
+        encoder.bindEncoder(layer, inc -> {
+            if (inc == 0) {
+                return;
+            }
+            markEncoderAdjusted(encoderIndex);
+            adjuster.accept(inc);
+        });
+        encoder.bindTouched(layer, touched -> handleResettableTouch(encoderIndex, touched,
+                () -> oled.valueInfo(label, valueSupplier.get()),
+                resetAction));
+    }
+
     private void handleLiveVelocityEncoder(final int inc) {
         final int steps = liveVelocityEncoder.consume(inc);
         if (steps == 0) {
@@ -549,7 +576,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private void adjustLivePressure(final int inc) {
-        adjustLiveMidiValue(inc, "Pressure", value -> {
+        adjustLiveMidiValue(inc, "Aftertouch", value -> {
             livePressure = value;
             noteInput.sendRawMidiEvent(Midi.CHANNEL_AT, livePressure, 0);
         }, livePressure);
@@ -570,10 +597,16 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private void adjustLivePitchExpression(final int inc) {
-        adjustLiveMidiValue(inc, "Pitch Expr", value -> {
-            livePitchExpression = value;
-            sendPitchExpressionValue(value);
-        }, livePitchExpression);
+        if (inc == 0) {
+            return;
+        }
+        final int nextValue = Math.max(MIN_MIDI_VALUE, Math.min(MAX_MIDI_VALUE, livePitchExpression + inc));
+        if (nextValue == livePitchExpression) {
+            return;
+        }
+        livePitchExpression = nextValue;
+        sendPitchExpressionValue(nextValue);
+        oled.valueInfo("Pitch Expr", formatLivePitchExpressionDisplay());
     }
 
     private void adjustLiveMidiValue(final int inc, final String label,
@@ -619,6 +652,30 @@ public class NoteMode extends Layer implements StepSequencerHost {
                     * (16383.0 - 8192.0));
         }
         noteInput.sendRawMidiEvent(Midi.PITCH_BEND, bend & 0x7F, (bend >> 7) & 0x7F);
+    }
+
+    private String formatLivePitchExpressionDisplay() {
+        return formatSignedValue(livePitchExpression - DEFAULT_LIVE_PITCH_EXPRESSION);
+    }
+
+    private void resetLivePressure() {
+        livePressure = MIN_MIDI_VALUE;
+        noteInput.sendRawMidiEvent(Midi.CHANNEL_AT, livePressure, 0);
+    }
+
+    private void resetLiveModulation() {
+        liveModulation = MIN_MIDI_VALUE;
+        noteInput.sendRawMidiEvent(Midi.CC, MIDI_CC_MOD, liveModulation);
+    }
+
+    private void resetLiveTimbre() {
+        liveTimbre = DEFAULT_TIMBRE;
+        noteInput.sendRawMidiEvent(Midi.CC, MIDI_CC_TIMBRE, liveTimbre);
+    }
+
+    private void resetLivePitchExpression() {
+        livePitchExpression = DEFAULT_LIVE_PITCH_EXPRESSION;
+        sendPitchExpressionValue(livePitchExpression);
     }
 
     private void resetLivePerformanceToggles() {
@@ -673,9 +730,9 @@ public class NoteMode extends Layer implements StepSequencerHost {
 
     private void handleMute2Button(final boolean pressed) {
         if (isChordStepModeActive()) {
-            copyHeld.set(pressed);
+            fixedLengthHeld.set(pressed);
             if (pressed) {
-                oled.valueInfo("Paste", "Target step");
+                oled.valueInfo("Last Step", "Target step");
             } else {
                 oled.clearScreenDelayed();
             }
@@ -691,9 +748,9 @@ public class NoteMode extends Layer implements StepSequencerHost {
 
     private void handleMute3Button(final boolean pressed) {
         if (isChordStepModeActive()) {
-            fixedLengthHeld.set(pressed);
+            copyHeld.set(pressed);
             if (pressed) {
-                oled.valueInfo("Last Step", "Target step");
+                oled.valueInfo("Paste", "Clip / step target");
             } else {
                 oled.clearScreenDelayed();
             }
@@ -706,9 +763,16 @@ public class NoteMode extends Layer implements StepSequencerHost {
 
     private void handleMute4Button(final boolean pressed) {
         if (isChordStepModeActive()) {
-            invertHeld.set(pressed);
             if (pressed) {
-                invertCurrentChord(driver.isGlobalAltHeld() ? -1 : 1);
+                if (driver.isGlobalAltHeld()) {
+                    invertCurrentChord(driver.isGlobalShiftHeld() ? -1 : 1);
+                    return;
+                }
+                deleteHeld.set(true);
+                oled.valueInfo("Delete", "Clip / step target");
+            } else {
+                deleteHeld.set(false);
+                oled.clearScreenDelayed();
             }
             return;
         }
@@ -723,24 +787,23 @@ public class NoteMode extends Layer implements StepSequencerHost {
 
     private BiColorLightState getMute2LightState() {
         if (isChordStepModeActive()) {
-            return copyHeld.get() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+            return fixedLengthHeld.get() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
         }
         return sostenutoActive ? BiColorLightState.AMBER_FULL : BiColorLightState.OFF;
     }
 
     private BiColorLightState getMute3LightState() {
         if (isChordStepModeActive()) {
-            return fixedLengthHeld.get() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+            return copyHeld.get() ? BiColorLightState.GREEN_FULL : BiColorLightState.OFF;
         }
         return noteRepeatHandler.getNoteRepeatActive().get() ? BiColorLightState.GREEN_FULL : BiColorLightState.GREEN_HALF;
     }
 
     private BiColorLightState getMute4LightState() {
         if (isChordStepModeActive()) {
-            if (invertHeld.get()) {
-                return driver.isGlobalAltHeld() ? BiColorLightState.RED_FULL : BiColorLightState.RED_FULL;
-            }
-            return driver.isGlobalAltHeld() ? BiColorLightState.RED_HALF : BiColorLightState.RED_FULL;
+            return driver.isGlobalAltHeld()
+                    ? BiColorLightState.RED_HALF
+                    : (deleteHeld.get() ? BiColorLightState.RED_FULL : BiColorLightState.OFF);
         }
         return BiColorLightState.OFF;
     }
@@ -804,16 +867,21 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private void handleOikordStepPadPress(final int padIndex, final boolean pressed, final int velocity) {
+        if (padIndex < CLIP_ROW_PAD_COUNT) {
+            clipHandler.handlePadPress(padIndex, pressed);
+            return;
+        }
         if (padIndex < STEP_PAD_OFFSET) {
+            final int sourcePadIndex = padIndex - OIKORD_SOURCE_PAD_OFFSET;
             if (isBuilderFamily()) {
-                handleBuilderSourcePadPress(padIndex, pressed);
+                handleBuilderSourcePadPress(sourcePadIndex, pressed);
                 return;
             }
-            if (!oikordBank.hasSlot(currentPresetFamilyIndex(), oikordPage, padIndex)) {
+            if (!oikordBank.hasSlot(currentPresetFamilyIndex(), oikordPage, sourcePadIndex)) {
                 return;
             }
             if (pressed) {
-                selectedOikordSlot = padIndex;
+                selectedOikordSlot = sourcePadIndex;
                 final boolean hasHeldSteps = !heldStepPads.isEmpty();
                 final boolean auditionEnabled = driver.isStepSeqPadAuditionEnabled();
                 final boolean transportStopped = !driver.isTransportPlaying();
@@ -864,6 +932,11 @@ public class NoteMode extends Layer implements StepSequencerHost {
             }
             if (copyHeld.get()) {
                 pasteCurrentChordToStep(stepIndex);
+                modifierHandledStepPads.add(stepIndex);
+                return;
+            }
+            if (deleteHeld.get()) {
+                clearChordStep(stepIndex);
                 modifierHandledStepPads.add(stepIndex);
                 return;
             }
@@ -2438,18 +2511,22 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private RgbLigthState getOikordStepPadLight(final int padIndex) {
+        if (padIndex < CLIP_ROW_PAD_COUNT) {
+            return clipHandler.getPadLight(padIndex);
+        }
         if (padIndex < STEP_PAD_OFFSET) {
+            final int sourcePadIndex = padIndex - OIKORD_SOURCE_PAD_OFFSET;
             if (isBuilderFamily()) {
-                return getBuilderSourcePadLight(padIndex);
+                return getBuilderSourcePadLight(sourcePadIndex);
             }
-            if (!oikordBank.hasSlot(currentPresetFamilyIndex(), oikordPage, padIndex)) {
+            if (!oikordBank.hasSlot(currentPresetFamilyIndex(), oikordPage, sourcePadIndex)) {
                 return RgbLigthState.OFF;
             }
-            final OikordBank.Slot slot = oikordBank.slot(currentPresetFamilyIndex(), oikordPage, padIndex);
-            final int groupIndex = padIndex / 8;
+            final OikordBank.Slot slot = oikordBank.slot(currentPresetFamilyIndex(), oikordPage, sourcePadIndex);
+            final int groupIndex = sourcePadIndex / 8;
             final RgbLigthState grouped = getFamilyGroupColor(slot.family(), groupIndex, oikordPage,
                     currentOikordPageCount());
-            return padIndex == selectedOikordSlot ? SELECTED_CHORD : grouped.getDimmed();
+            return sourcePadIndex == selectedOikordSlot ? SELECTED_CHORD : grouped.getDimmed();
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
         final boolean occupied = hasVisibleStepContent(stepIndex);
@@ -2461,10 +2538,16 @@ public class NoteMode extends Layer implements StepSequencerHost {
             return HELD_STEP.getBrightest();
         }
         if (occupied) {
-            return StepPadLightHelper.renderOccupiedStep(occupiedStepColor, accented, stepIndex == playingStep);
+            if (stepIndex == playingStep) {
+                return StepPadLightHelper.renderPlayheadHighlight(
+                        accented ? occupiedStepColor.getBrightend() : occupiedStepColor);
+            }
+            return StepPadLightHelper.renderOccupiedStep(occupiedStepColor, accented, false);
         }
         if (sustained) {
-            return stepIndex == playingStep ? sustainedStepColor.getBrightend() : sustainedStepColor;
+            return stepIndex == playingStep
+                    ? StepPadLightHelper.renderPlayheadHighlight(sustainedStepColor)
+                    : sustainedStepColor;
         }
         return StepPadLightHelper.renderEmptyStep(stepIndex, playingStep);
     }
@@ -2715,7 +2798,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
             return;
         }
         final int builderRoot = Math.floorMod(firstVisibleNote, 12);
-        for (int padIndex = 0; padIndex < STEP_PAD_OFFSET; padIndex++) {
+        for (int padIndex = 0; padIndex < OIKORD_SOURCE_PAD_COUNT; padIndex++) {
             final int midiNote = getBuilderRenderedNoteMidiForPad(padIndex);
             if (midiNote >= 0 && getScale().isRootMidiNote(builderRoot, midiNote)) {
                 builderSelectedNotes.add(midiNote);
@@ -2789,7 +2872,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     private int getBuilderNoteMidiForPad(final int padIndex) {
-        if (padIndex < 0 || padIndex >= STEP_PAD_OFFSET) {
+        if (padIndex < 0 || padIndex >= OIKORD_SOURCE_PAD_COUNT) {
             return -1;
         }
         final int firstVisibleNote = getBuilderFirstVisibleMidiNote();
@@ -3174,6 +3257,46 @@ public class NoteMode extends Layer implements StepSequencerHost {
     }
 
     @Override
+    public boolean isCopyHeld() {
+        return copyHeld.get();
+    }
+
+    @Override
+    public boolean isDeleteHeld() {
+        return deleteHeld.get();
+    }
+
+    @Override
+    public boolean isShiftHeld() {
+        return driver.isGlobalShiftHeld();
+    }
+
+    @Override
+    public AkaiFireOikontrolExtension getDriver() {
+        return driver;
+    }
+
+    @Override
+    public OledDisplay getOled() {
+        return oled;
+    }
+
+    @Override
+    public ClipLauncherSlotBank getClipSlotBank() {
+        return noteClipSlotBank;
+    }
+
+    @Override
+    public PinnableCursorClip getClipCursor() {
+        return noteStepClip;
+    }
+
+    @Override
+    public void notifyPopup(final String title, final String value) {
+        driver.notifyPopup(title, value);
+    }
+
+    @Override
     public String getPadInfo() {
         return currentStepSubMode.displayName();
     }
@@ -3442,10 +3565,14 @@ public class NoteMode extends Layer implements StepSequencerHost {
             slot.hasContent().markInterested();
             slot.isSelected().markInterested();
             slot.color().markInterested();
+            slot.isPlaying().markInterested();
+            slot.isRecording().markInterested();
             slot.exists().addValueObserver(ignored -> refreshSelectedNoteClipState());
             slot.hasContent().addValueObserver(ignored -> refreshSelectedNoteClipState());
             slot.isSelected().addValueObserver(ignored -> refreshSelectedNoteClipState());
             slot.color().addValueObserver((r, g, b) -> refreshSelectedNoteClipState());
+            slot.isPlaying().addValueObserver(ignored -> refreshSelectedNoteClipState());
+            slot.isRecording().addValueObserver(ignored -> refreshSelectedNoteClipState());
         }
         refreshSelectedNoteClipState();
     }
@@ -3491,26 +3618,46 @@ public class NoteMode extends Layer implements StepSequencerHost {
 
     private void refreshChordStepObservationPass() {
         clearObservedChordCaches();
+        boolean clipSelected = false;
         final int preferredSlotIndex = driver.getViewControl().getSelectedClipSlotIndex();
         if (preferredSlotIndex >= 0 && preferredSlotIndex < noteClipSlotBank.getSizeOfBank()) {
-            noteClipSlotBank.cursorIndex().set(preferredSlotIndex);
             final ClipLauncherSlot preferredSlot = noteClipSlotBank.getItemAt(preferredSlotIndex);
             if (preferredSlot.exists().get()) {
                 preferredSlot.select();
+                clipSelected = true;
             }
-        } else {
-            for (int i = 0; i < noteClipSlotBank.getSizeOfBank(); i++) {
-                final ClipLauncherSlot slot = noteClipSlotBank.getItemAt(i);
-                if (slot.exists().get() && slot.isSelected().get()) {
-                    slot.select();
-                    break;
-                }
-            }
+        }
+        if (!clipSelected) {
+            clipSelected = selectPlayingNoteClipSlot();
+        }
+        if (!clipSelected) {
+            selectSelectedNoteClipSlot();
         }
         noteStepClip.scrollToKey(0);
         observedNoteClip.scrollToKey(0);
         noteStepClip.scrollToStep(chordStepOffset());
         observedNoteClip.scrollToStep(0);
+    }
+
+    private boolean selectPlayingNoteClipSlot() {
+        for (int i = 0; i < noteClipSlotBank.getSizeOfBank(); i++) {
+            final ClipLauncherSlot slot = noteClipSlotBank.getItemAt(i);
+            if (slot.exists().get() && (slot.isPlaying().get() || slot.isRecording().get())) {
+                slot.select();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void selectSelectedNoteClipSlot() {
+        for (int i = 0; i < noteClipSlotBank.getSizeOfBank(); i++) {
+            final ClipLauncherSlot slot = noteClipSlotBank.getItemAt(i);
+            if (slot.exists().get() && slot.isSelected().get()) {
+                slot.select();
+                return;
+            }
+        }
     }
 
     private void clearObservedChordCaches() {
@@ -3715,7 +3862,7 @@ public class NoteMode extends Layer implements StepSequencerHost {
         return switch (mode) {
             case CHANNEL -> "1: Mod\n2: Pitch Gliss\n3: Velocity\n4: Scale";
             case MIXER -> "1: Volume\n2: Pan\n3: Send 1\n4: Send 2";
-            case USER_1 -> "1: Mod\n2: Pressure\n3: Timbre\n4: Pitch Expr";
+            case USER_1 -> "1: Aftertouch\n2: Pressure\n3: Timbre\n4: Pitch Expr";
             case USER_2 -> "1: Remote 1\n2: Remote 2\n3: Remote 3\n4: Remote 4";
         };
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -3115,9 +3115,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             return;
         }
         if (noteStepActive && currentStepSubMode == NoteStepSubMode.OIKORD_STEP) {
-            if (driver.isGlobalShiftHeld() && driver.isGlobalAltHeld()) {
-                clearCurrentChordClip();
-            } else if (!driver.isGlobalAltHeld()) {
+            if (!driver.isGlobalAltHeld()) {
                 pageChordSteps(1);
             }
             return;
@@ -3134,9 +3132,6 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private BiColorLightState getPatternDownLight() {
         if (noteStepActive && currentStepSubMode == NoteStepSubMode.OIKORD_STEP) {
-            if (driver.isGlobalShiftHeld() && driver.isGlobalAltHeld()) {
-                return BiColorLightState.RED_HALF;
-            }
             return chordStepPosition.canScrollRight().get() ? BiColorLightState.GREEN_HALF : BiColorLightState.OFF;
         }
         return BiColorLightState.GREEN_HALF;
@@ -3668,23 +3663,6 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         observedFineOccupancyByStep.clear();
         observedFineNoteStartsByStep.clear();
         pendingMovedNotes.clear();
-    }
-
-    private void clearCurrentChordClip() {
-        if (!ensureSelectedNoteClip()) {
-            return;
-        }
-        refreshChordStepObservationPass();
-        noteStepClip.clearSteps();
-        clipNotesByStep.clear();
-        noteStepsByPosition.clear();
-        clearObservedChordCaches();
-        heldStepPads.clear();
-        heldStepAnchor = null;
-        selectedPresetStepIndex = null;
-        queueChordObservationResync();
-        oled.valueInfo("Clip", "Cleared");
-        driver.notifyPopup("Clip", "Cleared");
     }
 
     private record ObservedChordNote(int localStep, int globalStep, int fineStart, int midiNote, int velocity,

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/OikordBank.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/OikordBank.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class OikordBank {
-    public static final int PAGE_SIZE = 32;
+    public static final int PAGE_SIZE = 16;
     public static final int MID_REGISTER_OCTAVE = 3;
     private static final int MID_REGISTER_CENTER = 64;
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentButtonModel.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentButtonModel.java
@@ -1,0 +1,43 @@
+package com.oikoaudio.fire.sequence;
+
+import com.oikoaudio.fire.lights.BiColorLightState;
+
+final class AccentButtonModel {
+    private static final int ACCENTED_VELOCITY = 127;
+
+    private final AccentLatchState latchState = new AccentLatchState();
+
+    AccentLatchState.Transition handlePressed(final boolean pressed) {
+        return latchState.handlePressed(pressed);
+    }
+
+    void markModified() {
+        if (latchState.isHeld()) {
+            latchState.markModified();
+        }
+    }
+
+    int currentVelocity(final int defaultVelocity) {
+        return latchState.isActive() ? ACCENTED_VELOCITY : defaultVelocity;
+    }
+
+    int accentedVelocity() {
+        return ACCENTED_VELOCITY;
+    }
+
+    BiColorLightState lightState() {
+        return latchState.isActive() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+    }
+
+    boolean isHolding() {
+        return latchState.isHeld();
+    }
+
+    boolean isActive() {
+        return latchState.isActive();
+    }
+
+    String label() {
+        return latchState.isActive() ? "On" : "Off";
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentHandler.java
@@ -2,13 +2,9 @@ package com.oikoaudio.fire.sequence;
 
 import com.oikoaudio.fire.lights.BiColorLightState;
 import com.bitwig.extension.controller.api.NoteStep;
-import com.bitwig.extensions.framework.values.BooleanValueObject;
 
 public class AccentHandler {
-	private static final int ACCENTED_VELOCITY = 127;
-	private final BooleanValueObject accentActive = new BooleanValueObject();
-	private boolean accenButtonHeld = false;
-	private boolean modified = false;
+	private final AccentButtonModel model = new AccentButtonModel();
 	private final DrumSequenceMode parent;
 
 	public AccentHandler(final DrumSequenceMode drumSequenceMode) {
@@ -16,7 +12,7 @@ public class AccentHandler {
 	}
 
 	public int getCurrenVel() {
-		return accentActive.get() ? ACCENTED_VELOCITY : parent.getDefaultVelocity();
+		return model.currentVelocity(parent.getDefaultVelocity());
 	}
 
 	public int getStandardVelocity() {
@@ -24,7 +20,7 @@ public class AccentHandler {
 	}
 
 	public int getAccentedVelocity() {
-		return ACCENTED_VELOCITY;
+		return model.accentedVelocity();
 	}
 
 	public boolean isAccented(final NoteStep noteStep) {
@@ -35,33 +31,37 @@ public class AccentHandler {
 	}
 
 	public void markModified() {
-		modified = true;
+		model.markModified();
 	}
 
 	BiColorLightState getLightState() {
-		return accentActive.get() ? BiColorLightState.AMBER_FULL : BiColorLightState.AMBER_HALF;
+		return model.lightState();
 	}
 
 	public boolean isHolding() {
-		return accenButtonHeld;
+		return model.isHolding();
+	}
+
+	public boolean isActive() {
+		return model.isActive();
 	}
 
 	void handlePressed(final boolean pressed) {
-		if (!pressed) {
-			if (!modified) {
-				accentActive.toggle();
-				this.parent.getPadHandler().getNoteRepeaterHandler().setNoteInputVelocity(this.getCurrenVel());
-			}
-			parent.getOled().clearScreenDelayed();
-			modified = false;
-		} else {
+		final AccentLatchState.Transition transition = model.handlePressed(pressed);
+		if (transition == AccentLatchState.Transition.PRESSED) {
 			displayAccentInfo();
+			return;
 		}
-		accenButtonHeld = pressed;
+		if (transition == AccentLatchState.Transition.TOGGLED_ON_RELEASE) {
+			this.parent.getPadHandler().getNoteRepeaterHandler().setNoteInputVelocity(this.getCurrenVel());
+			displayAccentInfo();
+			return;
+		}
+		parent.getOled().clearScreenDelayed();
 	}
 
 	private void displayAccentInfo() {
-		parent.getOled().valueInfo("Accent", accentActive.get() ? "On" : "Off");
+		parent.getOled().valueInfo("Accent", model.label());
 	}
 
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentLatchState.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/AccentLatchState.java
@@ -1,0 +1,43 @@
+package com.oikoaudio.fire.sequence;
+
+public final class AccentLatchState {
+    public enum Transition {
+        PRESSED,
+        TOGGLED_ON_RELEASE,
+        MODIFIED_RELEASE
+    }
+
+    private boolean active;
+    private boolean held;
+    private boolean modified;
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public boolean isHeld() {
+        return held;
+    }
+
+    public void markModified() {
+        modified = true;
+    }
+
+    public void clearHeld() {
+        held = false;
+    }
+
+    public Transition handlePressed(final boolean pressed) {
+        if (pressed) {
+            held = true;
+            return Transition.PRESSED;
+        }
+        held = false;
+        final boolean toggled = !modified;
+        if (toggled) {
+            active = !active;
+        }
+        modified = false;
+        return toggled ? Transition.TOGGLED_ON_RELEASE : Transition.MODIFIED_RELEASE;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -569,6 +569,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
 
     private void handleMainEncoder(final int inc) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoder(inc);
             return;
         }
         driver.markMainEncoderTurned();
@@ -743,6 +744,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
 
     private void handeMainEncoderPress(final boolean press) {
         if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoderPress(press);
             return;
         }
         driver.setMainEncoderPressed(press);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -29,6 +29,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
     private final IntSetValue heldSteps = new IntSetValue();
     private final Set<Integer> addedSteps = new HashSet<>();
     private final Set<Integer> modifiedSteps = new HashSet<>();
+    private final Set<Integer> gestureConsumedSteps = new HashSet<>();
     private final HashMap<Integer, NoteStep> expectedNoteChanges = new HashMap<>();
     // Maintain fractional offsets for held notes.
     private final Map<NoteStep, Double> fractionalOffsets = new HashMap<>();
@@ -248,14 +249,20 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
 
     private void handleSeqSelection(final int index, final boolean pressed) {
         final NoteStep note = assignments[index];
+        final boolean accentGesture = accentHandler.isHolding() || accentHandler.isActive();
         if (!pressed) {
             heldSteps.remove(index);
             heldStepFineStarts.remove(index);
             if (copyHeld.get() || fixedLengthHeld.get()) {
                 // do nothing
+            } else if (accentGesture) {
+                // Accent mode applies on press and should not fall through to normal step toggling on release.
+                gestureConsumedSteps.remove(index);
+            } else if (gestureConsumedSteps.remove(index)) {
+                // A non-toggle gesture already handled this step on press.
             } else if (note != null && note.state() == State.NoteOn && !addedSteps.contains(index)) {
                 if (!modifiedSteps.contains(index)) {
-                    cursorClip.toggleStep(index, 0, accentHandler.getCurrenVel());
+                    cursorClip.clearStep(index, 0);
                 } else {
                     modifiedSteps.remove(index);
                 }
@@ -268,7 +275,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
                 stepActionFixedLength(index);
             } else if (copyHeld.get()) {
                 handleNoteCopyAction(index, note);
-            } else if (accentHandler.isHolding()) {
+            } else if (accentGesture) {
                 handleAccentStepAction(index, note);
             } else {
                 if (note == null || note.state() == State.Empty || note.state() == State.NoteSustain) {
@@ -739,7 +746,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
                 ? accentHandler.getStandardVelocity()
                 : accentHandler.getAccentedVelocity();
         note.setVelocity(targetVelocity / 127.0);
-        modifiedSteps.add(index);
+        gestureConsumedSteps.add(index);
     }
 
     private void handeMainEncoderPress(final boolean press) {
@@ -1557,7 +1564,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
     }
 
     private void handleStepSeqPressed(final boolean pressed) {
-        if (shiftActive.get()) {
+        if (shiftActive.get() || accentHandler.isHolding()) {
             accentHandler.handlePressed(pressed);
             return;
         }
@@ -1580,9 +1587,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
         if (altActive.get()) {
             return driver.getStepFillLightState();
         }
-        return accentHandler.getLightState() == BiColorLightState.AMBER_FULL
-                ? BiColorLightState.AMBER_FULL
-                : BiColorLightState.OFF;
+        return accentHandler.isActive() ? BiColorLightState.AMBER_FULL : BiColorLightState.OFF;
     }
 
     private void handleBankButton(final boolean pressed, final int dir) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -21,7 +21,7 @@ import com.bitwig.extensions.framework.values.StepViewPosition;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class DrumSequenceMode extends Layer implements StepSequencerHost {
+public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqClipRowHost {
     private final ControllerHost host;
     private final AkaiFireOikontrolExtension driver;
     private Application app;
@@ -142,7 +142,8 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost {
         positionHandler = new StepViewPosition(cursorClip, 32, "AKAI");
 
         padHandler = new PadHandler(driver, this, mainLayer, muteLayer, soloLayer, noteRepeatHandler);
-        clipHandler = new SeqClipHandler(driver, this, mainLayer);
+        clipHandler = new SeqClipHandler(this);
+        clipHandler.bindClipRow(mainLayer, driver.getRgbButtons());
         recurrenceEditor = new RecurrenceEditor(driver, this);
 
         initSequenceSection(driver);
@@ -1233,11 +1234,22 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost {
         return positionHandler;
     }
 
+    @Override
+    public PinnableCursorClip getClipCursor() {
+        return cursorClip;
+    }
+
     PinnableCursorClip getCursorClip() {
         return cursorClip;
     }
 
-    boolean isShiftHeld() {
+    @Override
+    public ClipLauncherSlotBank getClipSlotBank() {
+        return clipSlotBank;
+    }
+
+    @Override
+    public boolean isShiftHeld() {
         return shiftActive.get();
     }
 
@@ -1246,11 +1258,13 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost {
     }
 
 
-    boolean isCopyHeld() {
+    @Override
+    public boolean isCopyHeld() {
         return copyHeld.get();
     }
 
-    boolean isDeleteHeld() {
+    @Override
+    public boolean isDeleteHeld() {
         return deleteHeld.get();
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipCopySourceResolver.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipCopySourceResolver.java
@@ -1,0 +1,23 @@
+package com.oikoaudio.fire.sequence;
+
+final class SeqClipCopySourceResolver {
+    private SeqClipCopySourceResolver() {
+    }
+
+    static int resolve(final int selectedSlotIndex, final boolean[] playingSlots, final boolean[] recordingSlots) {
+        if (selectedSlotIndex >= 0) {
+            return selectedSlotIndex;
+        }
+        for (int i = 0; i < playingSlots.length; i++) {
+            if (playingSlots[i]) {
+                return i;
+            }
+        }
+        for (int i = 0; i < recordingSlots.length; i++) {
+            if (recordingSlots[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
@@ -143,7 +143,7 @@ public class SeqClipHandler {
                 slot.select();
                 slot.launch();
             }
-            case CREATE_EMPTY -> slot.createEmptyClip(host.getDriver().getDefaultClipLengthBeats());
+            case CREATE_EMPTY -> slot.createEmptyClip(host.getClipCreateLengthBeats());
         }
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
@@ -1,40 +1,42 @@
 package com.oikoaudio.fire.sequence;
 
-import com.oikoaudio.fire.AkaiFireOikontrolExtension;
 import com.oikoaudio.fire.ColorLookup;
 import com.oikoaudio.fire.control.RgbButton;
 import com.oikoaudio.fire.lights.RgbLigthState;
 import com.bitwig.extension.api.Color;
 import com.bitwig.extension.controller.api.ClipLauncherSlot;
 import com.bitwig.extension.controller.api.ClipLauncherSlotBank;
-import com.bitwig.extension.controller.api.CursorTrack;
 import com.bitwig.extension.controller.api.PinnableCursorClip;
 import com.bitwig.extensions.framework.Layer;
 
 public class SeqClipHandler {
 
-    private final DrumSequenceMode parent;
+    private final SeqClipRowHost host;
     private final PinnableCursorClip cursorClip;
     private int selectedSlotIndex = -1;
     private final ClipLauncherSlotBank slotBank;
     private final RgbLigthState[] slotColors = new RgbLigthState[16];
-    private final CursorTrack cursorTrack;
     private int blinkState = 0;
 
-    public SeqClipHandler(final AkaiFireOikontrolExtension driver, final DrumSequenceMode parent, final Layer clipLayer) {
-        this.parent = parent;
-        this.cursorClip = parent.getCursorClip();
-        cursorTrack = driver.getViewControl().getCursorTrack();
-        slotBank = cursorTrack.clipLauncherSlotBank();
-        initClipControlButtons(clipLayer, driver);
+    public SeqClipHandler(final SeqClipRowHost host) {
+        this.host = host;
+        this.cursorClip = host.getClipCursor();
+        this.slotBank = host.getClipSlotBank();
+        initSlotObservers();
     }
 
-    private void initClipControlButtons(final Layer clipLayer, final AkaiFireOikontrolExtension driver) {
-        final RgbButton[] rgbButtons = driver.getRgbButtons();
+    public void bindClipRow(final Layer clipLayer, final RgbButton[] rgbButtons) {
         for (int i = 0; i < 16; i++) {
             final RgbButton button = rgbButtons[i];
             final int index = i;
+            final ClipLauncherSlot cs = slotBank.getItemAt(index);
+            button.bindPressed(clipLayer, p -> handleClip(index, cs, p), () -> getClipSate(index, cs));
+        }
+    }
 
+    private void initSlotObservers() {
+        for (int i = 0; i < 16; i++) {
+            final int index = i;
             final ClipLauncherSlot cs = slotBank.getItemAt(index);
 
             cs.color().addValueObserver((r, g, b) -> {
@@ -55,8 +57,21 @@ public class SeqClipHandler {
             cs.isSelected().markInterested();
             cs.isStopQueued().markInterested();
 
-            button.bindPressed(clipLayer, p -> handleClip(index, cs, p), () -> getClipSate(index, cs));
         }
+    }
+
+    public void handlePadPress(final int index, final boolean pressed) {
+        if (index < 0 || index >= 16) {
+            return;
+        }
+        handleClip(index, slotBank.getItemAt(index), pressed);
+    }
+
+    public RgbLigthState getPadLight(final int index) {
+        if (index < 0 || index >= 16) {
+            return RgbLigthState.OFF;
+        }
+        return getClipSate(index, slotBank.getItemAt(index));
     }
 
     private RgbLigthState getClipSate(final int index, final ClipLauncherSlot slot) {
@@ -102,46 +117,33 @@ public class SeqClipHandler {
     }
 
     private void handleClip(final int index, final ClipLauncherSlot slot, final boolean pressed) {
-        if (!pressed) {
-            return;
-        }
         final boolean hasContent = slot.hasContent().get();
-        if (hasContent) {
-            if (parent.isDeleteHeld()) {
-                if (parent.isShiftHeld()) { // SHIFT + DELETE => remove clip
-                    slot.deleteObject();
-                } else { // SHIFT + DELETE => clear all steps
-                    final int previous = selectedSlotIndex;
-                    slot.select();
-                    cursorClip.clearSteps();
-                    if (previous != -1) {
-                        slotBank.getItemAt(previous).select();
-                    }
-                }
-            } else if (parent.isCopyHeld()) { // copies note
-                if (selectedSlotIndex != -1 && selectedSlotIndex != index) {
-                    slot.replaceInsertionPoint().copySlotsOrScenes(slotBank.getItemAt(selectedSlotIndex));
-                    parent.getOled().valueInfo("Copy Clip", "Select target");
-                    parent.notifyPopup("Copy Clip", slotLabel(selectedSlotIndex) + " -> " + slotLabel(index));
-                }
-            } else if (parent.isSelectHeld()) {
+        switch (SeqClipRowActionResolver.resolve(pressed, hasContent,
+                host.isDeleteHeld(), host.isCopyHeld(), host.isSelectHeld(), host.isShiftHeld(),
+                selectedSlotIndex, index)) {
+            case IGNORE -> {
+            }
+            case DELETE_OBJECT -> slot.deleteObject();
+            case CLEAR_STEPS -> {
+                final int previous = selectedSlotIndex;
                 slot.select();
-            } else if (parent.isShiftHeld()) {
-                slot.color().set(getSlotColor(slot));
-            } else {
+                cursorClip.clearSteps();
+                if (previous != -1) {
+                    slotBank.getItemAt(previous).select();
+                }
+            }
+            case COPY_TO_TARGET -> {
+                slot.replaceInsertionPoint().copySlotsOrScenes(slotBank.getItemAt(selectedSlotIndex));
+                host.getOled().valueInfo("Copy Clip", "Select target");
+                host.notifyPopup("Copy Clip", slotLabel(selectedSlotIndex) + " -> " + slotLabel(index));
+            }
+            case SELECT_ONLY -> slot.select();
+            case CYCLE_COLOR -> slot.color().set(getSlotColor(slot));
+            case SELECT_AND_LAUNCH -> {
                 slot.select();
                 slot.launch();
             }
-        } else {
-            if (parent.isCopyHeld()) {
-                if (selectedSlotIndex != -1 && selectedSlotIndex != index) {
-                    slot.replaceInsertionPoint().copySlotsOrScenes(slotBank.getItemAt(selectedSlotIndex));
-                    parent.getOled().valueInfo("Copy Clip", "Select target");
-                    parent.notifyPopup("Copy Clip", slotLabel(selectedSlotIndex) + " -> " + slotLabel(index));
-                }
-            } else {
-                slot.createEmptyClip(parent.getDriver().getDefaultClipLengthBeats());
-            }
+            case CREATE_EMPTY -> slot.createEmptyClip(host.getDriver().getDefaultClipLengthBeats());
         }
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipHandler.java
@@ -16,6 +16,8 @@ public class SeqClipHandler {
     private int selectedSlotIndex = -1;
     private final ClipLauncherSlotBank slotBank;
     private final RgbLigthState[] slotColors = new RgbLigthState[16];
+    private final boolean[] playingSlots = new boolean[16];
+    private final boolean[] recordingSlots = new boolean[16];
     private int blinkState = 0;
 
     public SeqClipHandler(final SeqClipRowHost host) {
@@ -47,6 +49,8 @@ public class SeqClipHandler {
                     selectedSlotIndex = index;
                 }
             });
+            cs.isPlaying().addValueObserver(playing -> playingSlots[index] = playing);
+            cs.isRecording().addValueObserver(recording -> recordingSlots[index] = recording);
             slotColors[index] = ColorLookup.getColor(cs.color().get());
             cs.exists().markInterested();
             cs.hasContent().markInterested();
@@ -117,10 +121,11 @@ public class SeqClipHandler {
     }
 
     private void handleClip(final int index, final ClipLauncherSlot slot, final boolean pressed) {
+        final int copySourceIndex = SeqClipCopySourceResolver.resolve(selectedSlotIndex, playingSlots, recordingSlots);
         final boolean hasContent = slot.hasContent().get();
         switch (SeqClipRowActionResolver.resolve(pressed, hasContent,
                 host.isDeleteHeld(), host.isCopyHeld(), host.isSelectHeld(), host.isShiftHeld(),
-                selectedSlotIndex, index)) {
+                copySourceIndex, index)) {
             case IGNORE -> {
             }
             case DELETE_OBJECT -> slot.deleteObject();
@@ -133,9 +138,9 @@ public class SeqClipHandler {
                 }
             }
             case COPY_TO_TARGET -> {
-                slot.replaceInsertionPoint().copySlotsOrScenes(slotBank.getItemAt(selectedSlotIndex));
+                slot.replaceInsertionPoint().copySlotsOrScenes(slotBank.getItemAt(copySourceIndex));
                 host.getOled().valueInfo("Copy Clip", "Select target");
-                host.notifyPopup("Copy Clip", slotLabel(selectedSlotIndex) + " -> " + slotLabel(index));
+                host.notifyPopup("Copy Clip", slotLabel(copySourceIndex) + " -> " + slotLabel(index));
             }
             case SELECT_ONLY -> slot.select();
             case CYCLE_COLOR -> slot.color().set(getSlotColor(slot));

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowActionResolver.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowActionResolver.java
@@ -1,0 +1,47 @@
+package com.oikoaudio.fire.sequence;
+
+final class SeqClipRowActionResolver {
+    enum Action {
+        IGNORE,
+        DELETE_OBJECT,
+        CLEAR_STEPS,
+        COPY_TO_TARGET,
+        SELECT_ONLY,
+        CYCLE_COLOR,
+        SELECT_AND_LAUNCH,
+        CREATE_EMPTY
+    }
+
+    private SeqClipRowActionResolver() {
+    }
+
+    static Action resolve(final boolean pressed, final boolean hasContent,
+                          final boolean deleteHeld, final boolean copyHeld,
+                          final boolean selectHeld, final boolean shiftHeld,
+                          final int selectedSlotIndex, final int index) {
+        if (!pressed) {
+            return Action.IGNORE;
+        }
+        if (hasContent) {
+            if (deleteHeld) {
+                return shiftHeld ? Action.DELETE_OBJECT : Action.CLEAR_STEPS;
+            }
+            if (copyHeld) {
+                return selectedSlotIndex != -1 && selectedSlotIndex != index
+                        ? Action.COPY_TO_TARGET
+                        : Action.IGNORE;
+            }
+            if (selectHeld) {
+                return Action.SELECT_ONLY;
+            }
+            if (shiftHeld) {
+                return Action.CYCLE_COLOR;
+            }
+            return Action.SELECT_AND_LAUNCH;
+        }
+        if (copyHeld && selectedSlotIndex != -1 && selectedSlotIndex != index) {
+            return Action.COPY_TO_TARGET;
+        }
+        return Action.CREATE_EMPTY;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowHost.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowHost.java
@@ -8,6 +8,10 @@ import com.oikoaudio.fire.display.OledDisplay;
 public interface SeqClipRowHost {
     AkaiFireOikontrolExtension getDriver();
 
+    default int getClipCreateLengthBeats() {
+        return getDriver().getDefaultClipLengthBeats();
+    }
+
     OledDisplay getOled();
 
     ClipLauncherSlotBank getClipSlotBank();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowHost.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/SeqClipRowHost.java
@@ -1,0 +1,26 @@
+package com.oikoaudio.fire.sequence;
+
+import com.bitwig.extension.controller.api.ClipLauncherSlotBank;
+import com.bitwig.extension.controller.api.PinnableCursorClip;
+import com.oikoaudio.fire.AkaiFireOikontrolExtension;
+import com.oikoaudio.fire.display.OledDisplay;
+
+public interface SeqClipRowHost {
+    AkaiFireOikontrolExtension getDriver();
+
+    OledDisplay getOled();
+
+    ClipLauncherSlotBank getClipSlotBank();
+
+    PinnableCursorClip getClipCursor();
+
+    boolean isSelectHeld();
+
+    boolean isCopyHeld();
+
+    boolean isDeleteHeld();
+
+    boolean isShiftHeld();
+
+    void notifyPopup(String title, String value);
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/StepPadLightHelper.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/StepPadLightHelper.java
@@ -3,6 +3,8 @@ package com.oikoaudio.fire.sequence;
 import com.oikoaudio.fire.lights.RgbLigthState;
 
 public final class StepPadLightHelper {
+    private static final int PLAYHEAD_WHITE_FLOOR = 96;
+
     private StepPadLightHelper() {
     }
 
@@ -22,5 +24,14 @@ public final class StepPadLightHelper {
             return base.getBrightend();
         }
         return base;
+    }
+
+    public static RgbLigthState renderPlayheadHighlight(final RgbLigthState base) {
+        final RgbLigthState brightest = base.getBrightest();
+        return new RgbLigthState(
+                Math.max(brightest.getRed() & 0xFF, PLAYHEAD_WHITE_FLOOR),
+                Math.max(brightest.getGreen() & 0xFF, PLAYHEAD_WHITE_FLOOR),
+                Math.max(brightest.getBlue() & 0xFF, PLAYHEAD_WHITE_FLOOR),
+                true);
     }
 }

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -260,6 +260,7 @@
 
       <h3>Melodic Step workflow</h3>
       <p><code>Melodic Step</code> is a generated and editable mono phrase sequencer for basslines, motifs, and melodic hooks.</p>
+      <p>It edits a 2-bar / 32-step window and does not expand beyond that range from within the mode.</p>
       <ul>
         <li>Row 1: clip row</li>
         <li>Row 2: compact 16-note in-scale pitch pool</li>
@@ -333,8 +334,7 @@
       <p>Important gestures:</p>
       <ul>
         <li>top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode</li>
-        <li><code>PATTERN DOWN/UP</code>: next/previous chord family</li>
-        <li><code>ALT + PATTERN DOWN/UP</code>: next/previous page within the current family</li>
+        <li><code>PATTERN DOWN/UP</code>: previous/next visible step page</li>
         <li><code>STEP SEQ</code>: enter <code>Melodic Step</code></li>
         <li><code>SHIFT + STEP SEQ</code>: accent toggle/edit</li>
         <li><code>ALT + STEP SEQ</code>: Fill</li>
@@ -350,6 +350,8 @@
         <li><code>MUTE_4</code>: delete target step or clip</li>
         <li><code>ALT + MUTE_4</code>: invert chord</li>
         <li><code>SHIFT + ALT + MUTE_4</code>: invert chord in the opposite direction</li>
+        <li>Encoder 3: chord family</li>
+        <li><code>ALT + Encoder 3</code>: chord family page</li>
       </ul>
 
       <h3>PERFORM mode</h3>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -289,7 +289,6 @@
         <li><code>SHIFT + PATTERN UP</code> and <code>SHIFT + PATTERN DOWN</code>: cycle the current view between <code>Notes</code>, <code>Expression</code>, and <code>Process</code></li>
         <li><code>BANK LEFT/RIGHT</code>: rotate the phrase</li>
         <li><code>ALT + BANK LEFT/RIGHT</code>: halve or double the clip length</li>
-        <li><code>SHIFT + ALT + PATTERN DOWN</code>: clear the selected clip contents</li>
       </ul>
       <p>Encoder pages:</p>
       <ul>
@@ -352,7 +351,6 @@
         <li><code>BANK LEFT/RIGHT</code>: move written step content left or right</li>
         <li><code>SHIFT + BANK LEFT/RIGHT</code>: adjust held chord-step note duration</li>
         <li><code>ALT + BANK LEFT/RIGHT</code>: halve / double clip length</li>
-        <li><code>SHIFT + ALT + PATTERN DOWN</code>: clear the selected clip contents</li>
         <li><code>MUTE_1</code>: select / load step</li>
         <li><code>MUTE_2</code>: last-step target mode</li>
         <li><code>MUTE_3</code>: paste to target step or clip slot</li>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -350,7 +350,7 @@
         <li>tap an empty step pad: place the selected chord</li>
         <li>tap a lit step pad: remove the chord from that step</li>
         <li><code>BANK LEFT/RIGHT</code>: move written step content left or right</li>
-        <li><code>SHIFT + BANK LEFT/RIGHT</code>: adjust held chord-step note duration</li>
+        <li><code>SHIFT + BANK LEFT/RIGHT</code>: experimental micro-timing nudge for chord material; behavior is currently temperamental</li>
         <li><code>ALT + BANK LEFT/RIGHT</code>: halve / double clip length</li>
         <li><code>MUTE_1</code>: select / load step</li>
         <li><code>MUTE_2</code>: last-step target mode</li>
@@ -360,6 +360,11 @@
         <li><code>SHIFT + ALT + MUTE_4</code>: invert chord in the opposite direction</li>
         <li>Encoder 3: chord family</li>
         <li><code>ALT + Encoder 3</code>: chord family page</li>
+      </ul>
+      <p>Timing note:</p>
+      <ul>
+        <li>coarse nudge is intentionally disabled in <code>Chord Step</code></li>
+        <li>chord-step micro-timing is currently temperamental and should be treated as experimental</li>
       </ul>
 
       <h3>PERFORM mode</h3>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -277,7 +277,7 @@
       </ul>
       <p>Important gestures:</p>
       <ul>
-        <li>top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode</li>
+        <li>top row clip pads: launch, select, create, and paste clips; <code>Delete</code> clears clip contents and <code>Shift + Delete</code> removes the clip object</li>
         <li>tap a pitch pad: add or remove that note from the pool</li>
         <li>tap a step pad: place, clear, or load that step depending on state</li>
         <li>hold a step pad and turn encoders: edit that held step directly</li>
@@ -333,7 +333,7 @@
       </ul>
       <p>Important gestures:</p>
       <ul>
-        <li>top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode</li>
+        <li>top row clip pads: launch, select, create, and paste clips; <code>Delete</code> clears clip contents and <code>Shift + Delete</code> removes the clip object</li>
         <li><code>PATTERN DOWN/UP</code>: previous/next visible step page</li>
         <li><code>STEP SEQ</code>: enter <code>Melodic Step</code></li>
         <li><code>SHIFT + STEP SEQ</code>: accent toggle/edit</li>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -198,7 +198,7 @@
       </ul>
       <p>In <code>DRUM</code>, hold <code>Paste</code> and press a clip slot, drum pad, or step. The currently selected item of the same type is used as the source to copy from:</p>
       <ul>
-        <li>clip-row paste uses the currently selected clip slot as the source to copy from</li>
+        <li>clip-row paste uses the currently selected clip slot as the source to copy from, or falls back to the playing clip on that track if no clip was explicitly selected</li>
         <li>drum-pad paste uses the currently selected drum pad as the source to copy from</li>
         <li>step paste uses the currently selected step as the source to copy from</li>
       </ul>
@@ -294,7 +294,7 @@
       <ul>
         <li><code>Channel</code>: engine, density, engine macro, mutation type</li>
         <li><code>Mixer</code>: melodic process transforms</li>
-        <li><code>User 1</code>: tension, Euclid pulses, Euclid rotation, mutation amount</li>
+        <li><code>User 1</code>: reserved for future melodic advanced controls</li>
         <li><code>User 2</code>: selected or held step octave, gate, velocity, articulation</li>
       </ul>
       <p>Channel page details:</p>
@@ -311,7 +311,8 @@
         <li><code>MUTE_1</code>: select clip without launch</li>
         <li><code>MUTE_2</code>: last-step target mode</li>
         <li><code>MUTE_3</code>: paste to clip slot</li>
-        <li><code>MUTE_4</code>: delete step or clip</li>
+        <li><code>MUTE_4</code>: clear step or clear clip contents</li>
+        <li><code>SHIFT + MUTE_4</code> on a clip pad: remove the clip object</li>
       </ul>
       <p>Melodic transforms moved to the <code>Mixer</code> page:</p>
       <ul>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -266,7 +266,7 @@
         <li>Row 2: compact 16-note in-scale pitch pool</li>
         <li>Rows 3-4: 32 visible steps</li>
         <li>generated phrases are constrained to the current pitch pool</li>
-        <li>different generator modes provide different phrase grammars such as <code>Acid</code>, <code>Motif</code>, <code>Call/Resp</code>, <code>Euclid</code>, <code>Rolling</code>, and <code>Octave</code></li>
+        <li>different generator modes provide different phrase grammars such as <code>Acid</code>, <code>Motif</code>, <code>Call/Resp</code>, <code>Rolling</code>, and <code>Octave</code></li>
       </ul>
       <p>Main ideas:</p>
       <ul>
@@ -293,10 +293,19 @@
       </ul>
       <p>Encoder pages:</p>
       <ul>
-        <li><code>Channel</code>: generator, density, shape, mutation type</li>
+        <li><code>Channel</code>: engine, density, engine macro, mutation type</li>
         <li><code>Mixer</code>: melodic process transforms</li>
         <li><code>User 1</code>: tension, Euclid pulses, Euclid rotation, mutation amount</li>
         <li><code>User 2</code>: selected or held step octave, gate, velocity, articulation</li>
+      </ul>
+      <p>Channel page details:</p>
+      <ul>
+        <li>Encoder 1: <code>Engine</code></li>
+        <li><code>ALT + Encoder 1</code>: engine subtype / family when available</li>
+        <li>Encoder 2: <code>Density</code></li>
+        <li>Encoder 3: engine-specific macro such as motion, contour, answer, movement, or jump</li>
+        <li>Encoder 4: <code>Mutation Type</code></li>
+        <li><code>ALT + Encoder 4</code>: mutation strength</li>
       </ul>
       <p>Melodic left-side buttons now align with the shared sequencer clip/edit workflow:</p>
       <ul>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -261,8 +261,9 @@
       <h3>Melodic Step workflow</h3>
       <p><code>Melodic Step</code> is a generated and editable mono phrase sequencer for basslines, motifs, and melodic hooks.</p>
       <ul>
-        <li>Upper two rows: collapsed in-scale pitch pool</li>
-        <li>Lower two rows: 16 visible steps</li>
+        <li>Row 1: clip row</li>
+        <li>Row 2: compact 16-note in-scale pitch pool</li>
+        <li>Rows 3-4: 32 visible steps</li>
         <li>generated phrases are constrained to the current pitch pool</li>
         <li>different generator modes provide different phrase grammars such as <code>Acid</code>, <code>Motif</code>, <code>Call/Resp</code>, <code>Euclid</code>, <code>Rolling</code>, and <code>Octave</code></li>
       </ul>
@@ -275,6 +276,7 @@
       </ul>
       <p>Important gestures:</p>
       <ul>
+        <li>top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode</li>
         <li>tap a pitch pad: add or remove that note from the pool</li>
         <li>tap a step pad: place, clear, or load that step depending on state</li>
         <li>hold a step pad and turn encoders: edit that held step directly</li>
@@ -291,9 +293,23 @@
       <p>Encoder pages:</p>
       <ul>
         <li><code>Channel</code>: generator, density, shape, mutation type</li>
-        <li><code>Mixer</code>: track volume, pan, send 1, send 2</li>
+        <li><code>Mixer</code>: melodic process transforms</li>
         <li><code>User 1</code>: tension, Euclid pulses, Euclid rotation, mutation amount</li>
         <li><code>User 2</code>: selected or held step octave, gate, velocity, articulation</li>
+      </ul>
+      <p>Melodic left-side buttons now align with the shared sequencer clip/edit workflow:</p>
+      <ul>
+        <li><code>MUTE_1</code>: select clip without launch</li>
+        <li><code>MUTE_2</code>: last-step target mode</li>
+        <li><code>MUTE_3</code>: paste to clip slot</li>
+        <li><code>MUTE_4</code>: delete step or clip</li>
+      </ul>
+      <p>Melodic transforms moved to the <code>Mixer</code> page:</p>
+      <ul>
+        <li>Encoder 1: halve / double length</li>
+        <li>Encoder 2: swivel / mirror-double</li>
+        <li>Encoder 3: reverse</li>
+        <li>Encoder 4: invert down / up</li>
       </ul>
       <p>Notes on generation:</p>
       <ul>
@@ -307,15 +323,16 @@
       <h3>Chord Step workflow</h3>
       <p><code>Chord Step</code> is the current chord-oriented note-step workflow.</p>
       <ul>
-        <li>Upper two rows: curated chord slots</li>
-        <li>Lower two rows: 16 visible steps</li>
+        <li>Row 1: clip row</li>
+        <li>Row 2: curated chord slots or builder notes</li>
+        <li>Rows 3-4: 32 visible steps</li>
         <li>The builder defaults to in-key view and uses the same shared root/scale as live NOTE</li>
         <li>The default workflow mirrors Drum sequencing: pick a chord, then place or remove it on as many steps as you like</li>
         <li>Holding one or more step pads while pressing a chord pad rewrites those held steps with the chosen chord</li>
       </ul>
       <p>Important gestures:</p>
       <ul>
-        <li><code>MUTE_1..4</code>: chord octave and root offsets</li>
+        <li>top row clip pads: launch, select, create, copy, and delete clips using the same clip-row behavior as Drum mode</li>
         <li><code>PATTERN DOWN/UP</code>: next/previous chord family</li>
         <li><code>ALT + PATTERN DOWN/UP</code>: next/previous page within the current family</li>
         <li><code>STEP SEQ</code>: enter <code>Melodic Step</code></li>
@@ -327,8 +344,13 @@
         <li><code>SHIFT + BANK LEFT/RIGHT</code>: adjust held chord-step note duration</li>
         <li><code>ALT + BANK LEFT/RIGHT</code>: halve / double clip length</li>
         <li><code>SHIFT + ALT + PATTERN DOWN</code>: clear the selected clip contents</li>
+        <li><code>MUTE_1</code>: select / load step</li>
+        <li><code>MUTE_2</code>: last-step target mode</li>
+        <li><code>MUTE_3</code>: paste to target step or clip slot</li>
+        <li><code>MUTE_4</code>: delete target step or clip</li>
+        <li><code>ALT + MUTE_4</code>: invert chord</li>
+        <li><code>SHIFT + ALT + MUTE_4</code>: invert chord in the opposite direction</li>
       </ul>
-      <p>In <code>Chord Step</code>, hold <code>Paste</code> and press a step. The currently selected step is used as the source to copy from.</p>
 
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the clip-launch and performance surface.</p>

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicEngineTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicEngineTest.java
@@ -171,6 +171,25 @@ class MelodicEngineTest {
         assertTrue(mirroredHits >= 3);
     }
 
+    @Test
+    void generatorsWithFamiliesExposeAnyAndNamedSubtypeCycling() {
+        final MelodicGenerator[] generators = {
+                new AcidGenerator(),
+                new MotifGenerator(),
+                new CallResponseGenerator(),
+                new RollingBassGenerator()
+        };
+
+        for (final MelodicGenerator generator : generators) {
+            assertTrue(generator.supportsSubtypeSelection());
+            assertEquals("Any", generator.currentSubtypeLabel());
+            generator.cycleSubtype(1);
+            assertNotEquals("Any", generator.currentSubtypeLabel());
+            generator.cycleSubtype(-1);
+            assertEquals("Any", generator.currentSubtypeLabel());
+        }
+    }
+
     private MelodicPhraseContext context() {
         return new MelodicPhraseContext(
                 MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/OikordBankTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/OikordBankTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OikordBankTest {
@@ -47,17 +48,47 @@ class OikordBankTest {
         assertEquals("Q stack 1", bank.slot(1, 0, 0).shortLabel());
         assertEquals("Q stack 8", bank.slot(1, 0, 7).shortLabel());
         assertEquals("quartal stack with b7 and 9", bank.slot(1, 0, 8).name());
-        assertEquals("quartal add6 with upper 10", bank.slot(1, 1, 31).name());
+        assertEquals("quartal add6 with upper 10", bank.slot(1, 3, 15).name());
     }
 
     @Test
     void audibleUsesAllSeventeenConcreteSourceEntries() {
         final OikordBank bank = new OikordBank();
 
-        assertEquals(1, bank.pageCount(0));
+        assertEquals(2, bank.pageCount(0));
         assertEquals("Oct", bank.slot(0, 0, 0).shortLabel());
         assertEquals("Major 7th", bank.slot(0, 0, 7).name());
-        assertEquals("Fully diminished", bank.slot(0, 0, 16).name());
+        assertEquals("Fully diminished", bank.slot(0, 1, 0).name());
+    }
+
+    @Test
+    void respectsSixteenSlotPageBoundariesForCuratedFamilies() {
+        final OikordBank bank = new OikordBank();
+
+        assertTrue(bank.hasSlot(0, 0, 15));
+        assertFalse(bank.hasSlot(0, 0, 16));
+        assertTrue(bank.hasSlot(0, 1, 0));
+        assertFalse(bank.hasSlot(0, 1, 1));
+
+        assertThrows(IllegalArgumentException.class, () -> bank.slot(0, 0, 16));
+    }
+
+    @Test
+    void lastBarkerVariantLivesOnFourthSixteenSlotPage() {
+        final OikordBank bank = new OikordBank();
+
+        assertEquals(4, bank.pageCount(1));
+        assertTrue(bank.hasSlot(1, 3, 15));
+        assertFalse(bank.hasSlot(1, 4, 0));
+        assertEquals("quartal add6 with upper 10", bank.slot(1, 3, 15).name());
+    }
+
+    @Test
+    void rejectsOutOfRangePageRequests() {
+        final OikordBank bank = new OikordBank();
+
+        assertThrows(IllegalArgumentException.class, () -> bank.slot(0, 2, 0));
+        assertThrows(IllegalArgumentException.class, () -> bank.slot(1, 4, 0));
     }
 
     @Test

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/AccentButtonModelTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/AccentButtonModelTest.java
@@ -1,0 +1,66 @@
+package com.oikoaudio.fire.sequence;
+
+import com.oikoaudio.fire.lights.BiColorLightState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccentButtonModelTest {
+
+    @Test
+    void togglesAndReportsMatchingLightAndLabel() {
+        final AccentButtonModel model = new AccentButtonModel();
+
+        assertEquals("Off", model.label());
+        assertEquals(BiColorLightState.AMBER_HALF, model.lightState());
+        assertEquals(AccentLatchState.Transition.PRESSED, model.handlePressed(true));
+        assertTrue(model.isHolding());
+
+        assertEquals(AccentLatchState.Transition.TOGGLED_ON_RELEASE, model.handlePressed(false));
+        assertFalse(model.isHolding());
+        assertTrue(model.isActive());
+        assertEquals("On", model.label());
+        assertEquals(BiColorLightState.AMBER_FULL, model.lightState());
+    }
+
+    @Test
+    void heldModificationSuppressesReleaseToggle() {
+        final AccentButtonModel model = new AccentButtonModel();
+
+        model.handlePressed(true);
+        model.markModified();
+
+        assertEquals(AccentLatchState.Transition.MODIFIED_RELEASE, model.handlePressed(false));
+        assertFalse(model.isActive());
+        assertEquals("Off", model.label());
+        assertEquals(BiColorLightState.AMBER_HALF, model.lightState());
+    }
+
+    @Test
+    void latchedEditsDoNotBlockLaterToggleOff() {
+        final AccentButtonModel model = new AccentButtonModel();
+
+        model.handlePressed(true);
+        model.handlePressed(false);
+        assertTrue(model.isActive());
+
+        model.markModified();
+
+        model.handlePressed(true);
+        assertEquals(AccentLatchState.Transition.TOGGLED_ON_RELEASE, model.handlePressed(false));
+        assertFalse(model.isActive());
+        assertEquals("Off", model.label());
+    }
+
+    @Test
+    void currentVelocityTracksLatchState() {
+        final AccentButtonModel model = new AccentButtonModel();
+
+        assertEquals(96, model.currentVelocity(96));
+        model.handlePressed(true);
+        model.handlePressed(false);
+        assertEquals(model.accentedVelocity(), model.currentVelocity(96));
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/AccentLatchStateTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/AccentLatchStateTest.java
@@ -1,0 +1,46 @@
+package com.oikoaudio.fire.sequence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccentLatchStateTest {
+
+    @Test
+    void togglesOnReleaseWhenUnmodified() {
+        final AccentLatchState state = new AccentLatchState();
+
+        assertEquals(AccentLatchState.Transition.PRESSED, state.handlePressed(true));
+        assertTrue(state.isHeld());
+        assertFalse(state.isActive());
+
+        assertEquals(AccentLatchState.Transition.TOGGLED_ON_RELEASE, state.handlePressed(false));
+        assertFalse(state.isHeld());
+        assertTrue(state.isActive());
+    }
+
+    @Test
+    void modifiedPressDoesNotToggleOnRelease() {
+        final AccentLatchState state = new AccentLatchState();
+
+        state.handlePressed(true);
+        state.markModified();
+
+        assertEquals(AccentLatchState.Transition.MODIFIED_RELEASE, state.handlePressed(false));
+        assertFalse(state.isHeld());
+        assertFalse(state.isActive());
+    }
+
+    @Test
+    void clearsHeldStateWithoutChangingLatch() {
+        final AccentLatchState state = new AccentLatchState();
+
+        state.handlePressed(true);
+        state.clearHeld();
+
+        assertFalse(state.isHeld());
+        assertFalse(state.isActive());
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/SeqClipCopySourceResolverTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/SeqClipCopySourceResolverTest.java
@@ -1,0 +1,36 @@
+package com.oikoaudio.fire.sequence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SeqClipCopySourceResolverTest {
+
+    @Test
+    void prefersExplicitSelection() {
+        assertEquals(3, SeqClipCopySourceResolver.resolve(3,
+                new boolean[]{false, true, false, false},
+                new boolean[]{false, false, false, false}));
+    }
+
+    @Test
+    void fallsBackToPlayingClipWhenNothingSelected() {
+        assertEquals(1, SeqClipCopySourceResolver.resolve(-1,
+                new boolean[]{false, true, false, false},
+                new boolean[]{false, false, true, false}));
+    }
+
+    @Test
+    void fallsBackToRecordingClipWhenNothingSelectedOrPlaying() {
+        assertEquals(2, SeqClipCopySourceResolver.resolve(-1,
+                new boolean[]{false, false, false, false},
+                new boolean[]{false, false, true, false}));
+    }
+
+    @Test
+    void returnsMissingWhenNoUsableSourceExists() {
+        assertEquals(-1, SeqClipCopySourceResolver.resolve(-1,
+                new boolean[]{false, false, false, false},
+                new boolean[]{false, false, false, false}));
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/SeqClipRowActionResolverTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/SeqClipRowActionResolverTest.java
@@ -1,0 +1,74 @@
+package com.oikoaudio.fire.sequence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SeqClipRowActionResolverTest {
+
+    @Test
+    void ignoresReleasedPads() {
+        assertEquals(SeqClipRowActionResolver.Action.IGNORE,
+                SeqClipRowActionResolver.resolve(false, true, false, false, false, false, -1, 0));
+    }
+
+    @Test
+    void launchesExistingClipByDefault() {
+        assertEquals(SeqClipRowActionResolver.Action.SELECT_AND_LAUNCH,
+                SeqClipRowActionResolver.resolve(true, true, false, false, false, false, -1, 0));
+    }
+
+    @Test
+    void createsEmptyClipOnEmptySlotByDefault() {
+        assertEquals(SeqClipRowActionResolver.Action.CREATE_EMPTY,
+                SeqClipRowActionResolver.resolve(true, false, false, false, false, false, -1, 0));
+    }
+
+    @Test
+    void selectsWithoutLaunchWhenSelectHeld() {
+        assertEquals(SeqClipRowActionResolver.Action.SELECT_ONLY,
+                SeqClipRowActionResolver.resolve(true, true, false, false, true, false, -1, 0));
+    }
+
+    @Test
+    void clearsStepsWhenDeleteHeld() {
+        assertEquals(SeqClipRowActionResolver.Action.CLEAR_STEPS,
+                SeqClipRowActionResolver.resolve(true, true, true, false, false, false, -1, 0));
+    }
+
+    @Test
+    void deletesObjectWhenShiftDeleteHeld() {
+        assertEquals(SeqClipRowActionResolver.Action.DELETE_OBJECT,
+                SeqClipRowActionResolver.resolve(true, true, true, false, false, true, -1, 0));
+    }
+
+    @Test
+    void copiesIntoDifferentExistingSlot() {
+        assertEquals(SeqClipRowActionResolver.Action.COPY_TO_TARGET,
+                SeqClipRowActionResolver.resolve(true, true, false, true, false, false, 1, 2));
+    }
+
+    @Test
+    void copiesIntoDifferentEmptySlot() {
+        assertEquals(SeqClipRowActionResolver.Action.COPY_TO_TARGET,
+                SeqClipRowActionResolver.resolve(true, false, false, true, false, false, 1, 2));
+    }
+
+    @Test
+    void ignoresCopyWhenNoSourceSelected() {
+        assertEquals(SeqClipRowActionResolver.Action.IGNORE,
+                SeqClipRowActionResolver.resolve(true, true, false, true, false, false, -1, 2));
+    }
+
+    @Test
+    void ignoresCopyToSameSlot() {
+        assertEquals(SeqClipRowActionResolver.Action.IGNORE,
+                SeqClipRowActionResolver.resolve(true, true, false, true, false, false, 2, 2));
+    }
+
+    @Test
+    void cyclesColorOnShiftPress() {
+        assertEquals(SeqClipRowActionResolver.Action.CYCLE_COLOR,
+                SeqClipRowActionResolver.resolve(true, true, false, false, false, true, -1, 0));
+    }
+}


### PR DESCRIPTION
This release extends the shared clip-row workflow from Drum Sequencer to Melodic Step and Chord Step, bringing clip launch, selection, paste, clear, delete, color handling, and play-state blinking into a consistent sequencer surface. It also tightens chord-step paging and melodic-step generator controls, and fixes a browser regression so the `SELECT` encoder immediately navigates popup browser results again.

- add shared clip row to Melodic Step and Chord Step
- fix popup browser control so opening the browser immediately hands `SELECT` back to result navigation and OLED result display
- clarify clip delete grammar: `Delete` clears notes, `Shift + Delete` deletes the clip object
- improved visibility of the playhead indicator
- implicitly use the playing clip as the copy/paste-source when no clip is explicitly selected
- fix melodic/chord step clip-bank and track-switch selection edge cases
- restore chord-step `PATTERN` buttons to step paging and move family paging to `ALT + Encoder 3`
- cap Melodic Step as a 32-step / 2-bar editing window without silently shortening longer clips on track selection
- remove Euclid from Melodic Step and clean up generator controls:
  - `ALT + Encoder 1` subtype/family selection
  - engine-specific macro on encoder 3
  - `ALT + Encoder 4` mutation strength
- fix stale OLED labels and remove redundant clip-clear shortcuts now covered by the shared clip row
- update user docs and add regression coverage for clip-row actions, copy-source fallback, chord seq paging, and melodic generator subtype behavior
