### PR TITLE
v2.3.1 Akai Fire - Fix bidirectional clip selection sync

### DIFF
--- a/modules/akai-fire/build.gradle
+++ b/modules/akai-fire/build.gradle
@@ -1,4 +1,4 @@
-version = '2.3.0'
+version = '2.3.1'
 
 jar {
     archiveBaseName.set('OikontrolFire')

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
@@ -25,7 +25,7 @@ public class AkaiFireOikontrolDefinition extends ControllerExtensionDefinition {
 
     @Override
     public String getVersion() {
-        return "2.3.0";
+        return "2.3.1";
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/ViewCursorControl.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/ViewCursorControl.java
@@ -19,6 +19,7 @@ public class ViewCursorControl {
 	private final DrumPadBank drumPadBank;
 	private final TrackBank trackBank;
 	private int selectedTrackIndex = -1;
+	private int selectedClipSlotIndex = -1;
 	// private final Device drumDevice;
 
 	public ViewCursorControl(final ControllerHost host, final int sends) {
@@ -44,11 +45,16 @@ public class ViewCursorControl {
 		cursorTrack.isPinned().markInterested();
 		cursorTrack.position().markInterested();
 		cursorTrack.name().markInterested();
-
-		cursorTrack.clipLauncherSlotBank().cursorIndex().addValueObserver(index -> {
-			// RemoteConsole.out.println(" => {}", index);
-		});
-		cursorTrack.clipLauncherSlotBank().cursorIndex().markInterested();
+		for (int index = 0; index < cursorTrack.clipLauncherSlotBank().getSizeOfBank(); index++) {
+			final int slotIndex = index;
+			cursorTrack.clipLauncherSlotBank().getItemAt(index).exists().markInterested();
+			cursorTrack.clipLauncherSlotBank().getItemAt(index).isSelected().markInterested();
+			cursorTrack.clipLauncherSlotBank().getItemAt(index).isSelected().addValueObserver(selected -> {
+				if (selected) {
+					selectedClipSlotIndex = slotIndex;
+				}
+			});
+		}
 
 		deviceBank = cursorTrack.createDeviceBank(8);
 		primaryDevice = cursorTrack.createCursorDevice("drumdetection", "Pad Device", 8,
@@ -72,7 +78,14 @@ public class ViewCursorControl {
 	}
 
 	public int getSelectedClipSlotIndex() {
-		return cursorTrack.clipLauncherSlotBank().cursorIndex().get();
+		for (int index = 0; index < cursorTrack.clipLauncherSlotBank().getSizeOfBank(); index++) {
+			if (cursorTrack.clipLauncherSlotBank().getItemAt(index).exists().get()
+					&& cursorTrack.clipLauncherSlotBank().getItemAt(index).isSelected().get()) {
+				selectedClipSlotIndex = index;
+				return index;
+			}
+		}
+		return selectedClipSlotIndex;
 	}
 
 	public int getSelectedTrackIndex() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -1689,20 +1689,20 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private void refreshClipCursor() {
+        refreshSelectedClipState();
         boolean clipSelected = false;
         final int preferredSlotIndex = driver.getViewControl().getSelectedClipSlotIndex();
         if (preferredSlotIndex >= 0 && preferredSlotIndex < clipSlotBank.getSizeOfBank()) {
             final ClipLauncherSlot preferredSlot = clipSlotBank.getItemAt(preferredSlotIndex);
             if (preferredSlot.exists().get() && preferredSlot.isSelected().get()) {
-                preferredSlot.select();
                 clipSelected = true;
             }
         }
-        if (!clipSelected) {
-            clipSelected = selectPlayingClipSlot();
+        if (!clipSelected && selectedClipSlotIndex >= 0) {
+            clipSelected = true;
         }
         if (!clipSelected) {
-            selectSelectedClipSlot();
+            clipSelected = selectPlayingClipSlot();
         }
         cursorClip.scrollToKey(0);
         cursorClip.scrollToStep(0);
@@ -1717,16 +1717,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             }
         }
         return false;
-    }
-
-    private void selectSelectedClipSlot() {
-        for (int i = 0; i < clipSlotBank.getSizeOfBank(); i++) {
-            final ClipLauncherSlot slot = clipSlotBank.getItemAt(i);
-            if (slot.exists().get() && slot.isSelected().get()) {
-                slot.select();
-                return;
-            }
-        }
     }
 
     private MelodicPhraseContext phraseContext() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -3616,20 +3616,20 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private void refreshChordStepObservationPass() {
         clearObservedChordCaches();
+        refreshSelectedNoteClipState();
         boolean clipSelected = false;
         final int preferredSlotIndex = driver.getViewControl().getSelectedClipSlotIndex();
         if (preferredSlotIndex >= 0 && preferredSlotIndex < noteClipSlotBank.getSizeOfBank()) {
             final ClipLauncherSlot preferredSlot = noteClipSlotBank.getItemAt(preferredSlotIndex);
-            if (preferredSlot.exists().get()) {
-                preferredSlot.select();
+            if (preferredSlot.exists().get() && preferredSlot.isSelected().get()) {
                 clipSelected = true;
             }
         }
-        if (!clipSelected) {
-            clipSelected = selectPlayingNoteClipSlot();
+        if (!clipSelected && selectedNoteClipSlotIndex >= 0) {
+            clipSelected = true;
         }
         if (!clipSelected) {
-            selectSelectedNoteClipSlot();
+            clipSelected = selectPlayingNoteClipSlot();
         }
         noteStepClip.scrollToKey(0);
         observedNoteClip.scrollToKey(0);
@@ -3647,17 +3647,6 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         }
         return false;
     }
-
-    private void selectSelectedNoteClipSlot() {
-        for (int i = 0; i < noteClipSlotBank.getSizeOfBank(); i++) {
-            final ClipLauncherSlot slot = noteClipSlotBank.getItemAt(i);
-            if (slot.exists().get() && slot.isSelected().get()) {
-                slot.select();
-                return;
-            }
-        }
-    }
-
     private void clearObservedChordCaches() {
         observedClipNotesByStep.clear();
         observedFineOccupancyByStep.clear();


### PR DESCRIPTION
What’s in the release:
- [fix] shared selected clip slot now follows real isSelected() state instead of the controller cursor index
- [fix] chord/melodic step refresh paths now trust an actually selected clip on the current track before falling back to the playing clip
- [fix] passive refresh no longer re-selects slots unnecessarily