### PR TITLE
Akai Fire: Shared Pitch Context, Melodic Recurrence Editing, and Encoder Workflow Rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ High-level controller summary:
 
 - **Launch Control XL (Mk2)** keeps the Bitwig factory-template workflow intact, while adding user-templates for drum machine control, the Richie Hawtin / Eric Ahrens arp workflow from `rhbitwig` and a mode targeting 6-7 remote pages in one view.
 
-- **Akai Fire** provides OLED and optional on-screen feedback for most parameters, shared root/scale control, step micro-timing, configurable device pinning and four top-level modes: 
+- **Akai Fire** provides OLED and optional on-screen feedback for most parameters, shared root/scale/octave control, step micro-timing, configurable device pinning and four top-level modes: 
 
 `STEP` - a generative melodic step sequencer
 
@@ -36,7 +36,7 @@ High-level controller summary:
 
 `DRUM` - an X0X sequencer mode forked from the rhbitwig extension (see attribution section)
 
-`SHIFT + PERFORM` - a latched global `Settings` page for shared `Root Key` and `Scale`
+`SHIFT + PERFORM` - a latched global `Settings` page for shared `Root Key`, `Scale`, and `Octave`
 
 ## Requirements
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -242,7 +242,7 @@ The chord builder defaults to showing in-key notes only. If it auto-seeds a note
 | --- | --- | --- | --- | --- |
 | `Channel` | Chord octave (`ALT`: Shared root key) | Velocity sensitivity (`SHIFT`: Default velocity) | Chord family (`ALT`: family page) | Chord render / interpretation |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
-| `User 1` | Note velocity edit | Note chance edit | Note recurrence length | Note recurrence count |
+| `User 1` | Note velocity edit | Note chance edit | Recurrence-oriented note editing | Recurrence-oriented note editing |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
 
 `Chord Step` no longer owns a separate root/key state. `ALT + Encoder 1` updates the same shared root used by live NOTE input.
@@ -330,6 +330,14 @@ Current `User 1` page:
 | 2 | Tension |
 | 3 | Legato |
 | 4 | Recurrence span helper |
+
+Melodic recurrence editing:
+
+- Hold one or more active melodic steps.
+- While those steps are held, the top clip row switches into an 8-pad recurrence editor.
+- Tap top-row pads to toggle recurrence hits within the current span.
+- Hold the first top-row pad as a span anchor, then tap another top-row pad to set the recurrence span.
+- `User 1 / Encoder 4` shows the current recurrence summary for the held target step(s).
 
 ## PERFORM Mode
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -141,7 +141,7 @@ Drum grid resolution is now adjusted from the `SELECT` encoder when its role is 
 
 `NOTE` is the live note-input surface, with note-step workflows behind `STEP SEQ`.
 
-`NOTE`, `Chord Step`, and `SHIFT + PERFORM` now share one global pitch context for `Root Key` and `Scale`. Octave and layout remain mode-local.
+`NOTE`, `Chord Step`, `Melodic Step`, and `SHIFT + PERFORM` now share one global pitch context for `Root Key`, `Scale`, and `Octave`. Layout remains mode-local to NOTE-oriented surfaces.
 
 ### Live Note Layout
 
@@ -160,7 +160,7 @@ Drum grid resolution is now adjusted from the `SELECT` encoder when its role is 
 | `MUTE_3` | Note Repeat toggle |
 | `KNOB MODE` | Cycle live-note encoder pages |
 
-The default note octave is initialized from the `Default Note Input Octave` preference.
+The shared note octave is initialized from the `Default Note Input Octave` preference.
 
 In live NOTE mode:
 
@@ -168,12 +168,14 @@ In live NOTE mode:
 - Encoder 3 adjusts `Velocity Sensitivity`
 - `SHIFT + Encoder 3` adjusts `Default Velocity`
 - Encoder 4 adjusts the shared `Scale`
+- `ALT + Encoder 4` adjusts the shared `Root Key`
+- `PATTERN UP/DOWN` adjusts the shared `Octave`
 
 ### Live Note Encoder Pages
 
 | Encoder page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
 | --- | --- | --- | --- | --- |
-| `Channel` | Mod | Pitch Gliss | Velocity sensitivity (`SHIFT`: Default velocity) | Shared scale |
+| `Channel` | Mod | Pitch Gliss | Velocity sensitivity (`SHIFT`: Default velocity) | Shared scale (`ALT`: Shared root key) |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
 | `User 1` | Aftertouch | Pressure | Timbre | Pitch expression |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
@@ -193,7 +195,7 @@ The current note-step sub-modes are:
 
 `Chord Step` repurposes the `NOTE` surface into a chord-and-step editor.
 
-It uses the shared `Root Key` and `Scale` from live NOTE input and `SHIFT + PERFORM`. Changing key or scale in one of those places updates all of them.
+It uses the shared `Root Key`, `Scale`, and `Octave` from live NOTE input and `SHIFT + PERFORM`. Changing pitch context in one of those places updates all of them.
 
 ### Pad Layout
 
@@ -315,15 +317,25 @@ Current `Channel` page:
 | 1 | Engine |
 | `ALT + 1` | Engine subtype / family when available |
 | 2 | Density |
-| 3 | Engine-specific macro (`Motion`, `Contour`, `Answer`, `Movement`, `Jump`) |
+| 3 | Pitch-pool octave center |
+| `ALT + 3` | Shared root key |
 | 4 | Mutation type |
 | `ALT + 4` | Mutation strength |
+
+Current `User 1` page:
+
+| Slot | Function |
+| --- | --- |
+| 1 | Engine-specific macro (`Motion`, `Contour`, `Answer`, `Movement`, `Jump`) |
+| 2 | Tension |
+| 3 | Legato |
+| 4 | Recurrence span helper |
 
 ## PERFORM Mode
 
 `PERFORM` is the `16x4` clip-launch and performance surface.
 
-`SHIFT + PERFORM` opens a latched `Settings` page on the `Channel` encoder page. From there, Encoder 1 adjusts the shared `Root Key` and Encoder 2 adjusts the shared `Scale`. Press `PERFORM` again to leave `Settings`.
+`SHIFT + PERFORM` opens a latched `Settings` page on the `Channel` encoder page. From there, Encoder 1 adjusts the shared `Root Key`, Encoder 2 adjusts the shared `Scale`, and Encoder 3 adjusts the shared `Octave`. Press `PERFORM` again to leave `Settings`.
 
 ### Pad Layout
 
@@ -375,7 +387,8 @@ While `Settings` is active in `PERFORM`:
 
 - Encoder 1 edits shared `Root Key`
 - Encoder 2 edits shared `Scale`
-- Encoders 3-4 are reserved for future shared settings
+- Encoder 3 edits shared `Octave`
+- Encoder 4 is currently unused on the settings page
 
 ## Preferences That Affect Layout
 
@@ -397,7 +410,7 @@ These preferences materially change how the Fire feels in use:
 - `Pad Brightness`
 - `Pad Saturation`
 
-`Default Root Key`, `Default Scale`, `Default Note Input Octave`, and `Default Velocity Sensitivity` are startup defaults. They initialize the shared pitch context and live NOTE response when the script starts; changing key, scale, or velocity sensitivity from the controller does not currently write those defaults back into Bitwig preferences.
+`Default Root Key`, `Default Scale`, `Default Note Input Octave`, and `Default Velocity Sensitivity` are startup defaults. They initialize the shared pitch context and live NOTE response when the script starts; changing key, scale, octave, or velocity sensitivity from the controller does not currently write those defaults back into Bitwig preferences.
 
 `Melodic Seed Mode` controls how `Melodic Step` chooses its initial generator seed when the controller session starts. `Random` starts each session from a new seed. `Fixed` starts from the configured `Melodic Fixed Seed` value, which makes the sequence of generated melodic phrases reproducible across reconnects or reloads. Each `Generate` press still advances forward from that starting point.
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -386,7 +386,9 @@ These preferences materially change how the Fire feels in use:
 - `Default Clip Length`
 - `Default Root Key`
 - `Default Note Input Octave`
+- `Melodic Seed Mode`
 - `Default Velocity Sensitivity`
+- `Melodic Fixed Seed`
 - `SELECT Encoder Startup`
 - `SELECT Encoder`
 - `Drum Mode Pinning`
@@ -396,6 +398,10 @@ These preferences materially change how the Fire feels in use:
 - `Pad Saturation`
 
 `Default Root Key`, `Default Scale`, `Default Note Input Octave`, and `Default Velocity Sensitivity` are startup defaults. They initialize the shared pitch context and live NOTE response when the script starts; changing key, scale, or velocity sensitivity from the controller does not currently write those defaults back into Bitwig preferences.
+
+`Melodic Seed Mode` controls how `Melodic Step` chooses its initial generator seed when the controller session starts. `Random` starts each session from a new seed. `Fixed` starts from the configured `Melodic Fixed Seed` value, which makes the sequence of generated melodic phrases reproducible across reconnects or reloads. Each `Generate` press still advances forward from that starting point.
+
+The melodic seed controls are grouped into their own `Generative control` preference section so they stay together in Bitwig's settings UI.
 
 ## Known Gaps
 

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -213,7 +213,7 @@ It uses the shared `Root Key`, `Scale`, and `Octave` from live NOTE input and `S
 | Tap lit step | Remove chord from that step |
 | Hold step pad(s) + tap chord pad | Rewrite held steps with that chord |
 | Tap chord pad with no held step | Audition chord, if enabled |
-| `STEP SEQ` | Toggle `As Is` / `Cast` rendering |
+| `STEP SEQ` | Toggle `As Is` / `In Scale` rendering |
 | `SHIFT + STEP SEQ` | Cycle note-step sub-mode |
 | `PATTERN UP/DOWN` | Page the visible chord-step window |
 | `ALT + BANK LEFT/RIGHT` | Halve / double clip length |
@@ -240,12 +240,14 @@ The chord builder defaults to showing in-key notes only. If it auto-seeds a note
 
 | Encoder page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
 | --- | --- | --- | --- | --- |
-| `Channel` | Chord octave (`ALT`: Shared root key) | Velocity sensitivity (`SHIFT`: Default velocity) | Chord family (`ALT`: family page) | Chord render / interpretation |
+| `Channel` | Chord octave (`ALT`: Shared root key) | Velocity sensitivity (`SHIFT`: Default velocity) | Chord family (`ALT`: family page) | Interpretation (`SHIFT`: Shared scale, `ALT`: Shared root key) |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
 | `User 1` | Note velocity edit | Note chance edit | Recurrence-oriented note editing | Recurrence-oriented note editing |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
 
-`Chord Step` no longer owns a separate root/key state. `ALT + Encoder 1` updates the same shared root used by live NOTE input.
+`Chord Step` no longer owns a separate root/key state. `ALT + Encoder 1` and `ALT + Encoder 4` both update the same shared root used by live NOTE input, while `SHIFT + Encoder 4` updates the shared scale that `In Scale` interpretation uses.
+
+Chord banks themselves are static. Changing shared `Root Key` or `Scale` does not select a different bank, page, or slot; it only changes how the current slot is rendered. `As Is` transposes the stored chord shape from the current root. `In Scale` rebuilds that same slot against the current shared scale and root, so scale changes can reharmonize the chord.
 
 ## Melodic Step
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -230,6 +230,11 @@ Important gestures:
 - `SHIFT + ALT + MUTE_4`: invert chord in the opposite direction
 - `Encoder 3`: chord family
 - `ALT + Encoder 3`: chord family page
+- `Encoder 4`: interpretation (`As Is` / `In Scale`)
+- `SHIFT + Encoder 4`: shared scale
+- `ALT + Encoder 4`: shared root
+
+Chord banks are static libraries of chord formulas and voicing variants. Changing shared `Root Key` or `Scale` does not switch to a different bank or slot; it only changes how the selected slot is rendered. In `As Is`, the stored chord shape is transposed from the current root. In `In Scale`, the same slot is rebuilt from the current shared scale and root, so changing scale can reharmonize the result.
 
 Timing note:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -272,9 +272,9 @@ Important gestures:
 
 Encoder pages:
 
-- `Channel`: engine, density, engine macro, mutation type
+- `Channel`: engine, density, pitch-pool octave center, mutation type
 - `Mixer`: melodic process transforms
-- `User 1`: reserved for future melodic advanced controls
+- `User 1`: engine macro, tension, legato, recurrence helper
 - `User 2`: selected or held step octave, gate, velocity, articulation
 
 Channel page details:
@@ -293,6 +293,15 @@ User 1 page details:
 - Encoder 2: tension
 - Encoder 3: legato
 - Encoder 4: recurrence span helper
+
+Recurrence editing:
+
+- hold one or more active melodic steps to enter recurrence targeting
+- while steps are held, the top clip row becomes an 8-pad recurrence editor instead of clip launch
+- tap pads on that top row to toggle recurrence hits within the current span
+- hold the first top-row pad as a span anchor, then tap another top-row pad to set the recurrence span
+- touch `User 1 / Encoder 4` to see the current recurrence summary for the held step set
+- recurrence editing currently applies only to held active note steps
 
 Melodic left-side buttons now align with the shared sequencer clip/edit workflow:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -170,30 +170,32 @@ Quick start:
 `NOTE` provides a 16x4 isomorphic playing surface.
 
 - `Chromatic` and `In Key` layouts
-- shared root key and scale, with local octave and layout controls
+- shared root key, scale, and octave center, with local layout controls
 - LED and OLED note feedback
 - `Pitch Gliss` on the Channel encoder page
 - `Velocity Sensitivity` with `SHIFT + Encoder 3` for `Default Velocity`
 
 Useful live-note controls:
 
-- `PATTERN UP/DOWN`: octave
-- `SHIFT + PATTERN UP/DOWN`: root
+- `PATTERN UP/DOWN`: shared octave
+- `Encoder 4`: shared scale
+- `ALT + Encoder 4`: shared root
 - `MUTE_1`: sustain
 - `MUTE_2`: sostenuto
 
 The current note-step sub-modes are:
 
-- `Melodic Step`
 - `Chord Step`
 - `Clip Step Record` placeholder
+
+`Melodic Step` is a separate top-level mode entered from `STEP SEQ`, not a NOTE sub-mode.
 
 Quick start:
 
 1. Enter `NOTE`.
 2. Play notes directly on the pad grid.
 3. Press `NOTE` again to move between the primary note-family surfaces.
-4. Use `PATTERN UP/DOWN` for octave, `SHIFT + PATTERN UP/DOWN` for shared root, and the Channel page for `Scale`, `Pitch Gliss`, and live velocity response.
+4. Use `PATTERN UP/DOWN` for shared octave, `Encoder 4` for shared scale, `ALT + Encoder 4` for shared root, and the Channel page for `Pitch Gliss` and live velocity response.
 
 ### Chord Step workflow
 To get to this mode from the Note live input mode, press the `NOTE` controller button. From any other mode, press the `NOTE` button twice to cycle past the Note input mode.
@@ -251,6 +253,7 @@ Main ideas:
 - `Pattern Down` works on the phrase
 - if you manually edit the pitch pool, it is treated as user-owned and is not auto-replaced on mode switch
 - if the pool was auto-generated, first generation in a different mode can rebuild it for that mode
+- changing pool octave center no longer rewrites the selected clip immediately
 
 Important gestures:
 
@@ -279,9 +282,17 @@ Channel page details:
 - Encoder 1: `Engine`
 - `ALT + Encoder 1`: engine subtype / family when available
 - Encoder 2: `Density`
-- Encoder 3: engine-specific macro such as motion, contour, answer, movement, or jump
+- Encoder 3: pitch-pool octave center
+- `ALT + Encoder 3`: shared root key
 - Encoder 4: `Mutation Type`
 - `ALT + Encoder 4`: mutation strength
+
+User 1 page details:
+
+- Encoder 1: engine-specific macro such as motion, contour, answer, movement, or jump
+- Encoder 2: tension
+- Encoder 3: legato
+- Encoder 4: recurrence span helper
 
 Melodic left-side buttons now align with the shared sequencer clip/edit workflow:
 
@@ -339,6 +350,7 @@ Encoder pages:
 
 - Encoder 1 adjusts the shared `Root Key`
 - Encoder 2 adjusts the shared `Scale`
+- Encoder 3 adjusts the shared `Octave`
 - the pad grid becomes a non-performance settings display
 - press `PERFORM` again to leave `Settings`
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -403,7 +403,9 @@ Shared transport behavior:
 - `Default Root Key`
 - `Default Scale`
 - `Default Note Input Octave`
+- `Melodic Seed Mode`
 - `Default Velocity Sensitivity`
+- `Melodic Fixed Seed`
 - `Pad Brightness`
 - `Pad Saturation`
 - `Encoder touch reset`
@@ -414,6 +416,10 @@ Shared transport behavior:
 - `On-screen action notifications`
 
 `Pad Brightness` and `Pad Saturation` interact with the Bitwig track colors used by `DRUM` and `PERFORM`, so the same settings can read differently across different project palettes.
+
+`Melodic Seed Mode` controls how `Melodic Step` chooses its initial generator seed when the controller session starts. `Random` starts each session from a new seed. `Fixed` starts from the configured `Melodic Fixed Seed` value, which makes the sequence of generated melodic phrases reproducible across reconnects or reloads. Each `Generate` press still advances forward from that starting point.
+
+The melodic seed controls are grouped into their own `Generative control` preference section so they stay together in Bitwig's settings UI.
 
 ## Troubleshooting
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -114,6 +114,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private boolean encoderTouchResetEnabled = FireControlPreferences.ENCODER_TOUCH_RESET_DEFAULT;
     private int sharedRootNote = 0;
     private int sharedScaleIndex = -1;
+    private int sharedOctave = 3;
 
     private PatternButtons patternButtons;
     private NoteMode noteMode;
@@ -206,6 +207,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         setUpHardware();
         setUpTransportControl();
         setUpPreferences();
+        initializeSharedPitchContext();
 
         patternButtons = new PatternButtons(this, mainLayer);
         drumSequenceMode = new DrumSequenceMode(this, noteRepeatHandler);
@@ -816,6 +818,38 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         sharedScaleIndex = scaleIndex;
     }
 
+    public boolean adjustSharedScaleIndex(final int amount, final int minimumScaleIndex) {
+        if (amount == 0) {
+            return false;
+        }
+        final int nextScaleIndex = sharedScaleIndex + amount;
+        if (nextScaleIndex < minimumScaleIndex
+                || nextScaleIndex >= MusicalScaleLibrary.getInstance().getMusicalScalesCount()) {
+            return false;
+        }
+        setSharedScaleIndex(nextScaleIndex);
+        return true;
+    }
+
+    public int getSharedOctave() {
+        return sharedOctave;
+    }
+
+    public void setSharedOctave(final int octave) {
+        sharedOctave = Math.max(0, Math.min(7, octave));
+    }
+
+    public void adjustSharedOctave(final int amount) {
+        if (amount == 0) {
+            return;
+        }
+        setSharedOctave(sharedOctave + amount);
+    }
+
+    public int getSharedBaseMidiNote() {
+        return sharedOctave * 12 + sharedRootNote;
+    }
+
     public String getSharedScaleDisplayName() {
         if (sharedScaleIndex == -1) {
             return "Piano";
@@ -823,6 +857,35 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         final int safeIndex = Math.max(0, Math.min(MusicalScaleLibrary.getInstance().getMusicalScalesCount() - 1,
                 sharedScaleIndex));
         return MusicalScaleLibrary.getInstance().getMusicalScale(safeIndex).getName();
+    }
+
+    private void initializeSharedPitchContext() {
+        setSharedScaleIndex(resolveDefaultSharedScaleIndex());
+        setSharedRootNote(getDefaultRootKeyPreference());
+        setSharedOctave(getDefaultNoteInputOctavePreference());
+    }
+
+    private int resolveDefaultSharedScaleIndex() {
+        return switch (getDefaultScalePreference()) {
+            case FireControlPreferences.DEFAULT_SCALE_MAJOR -> findScaleIndex("Ionan (Major)", 1);
+            case FireControlPreferences.DEFAULT_SCALE_MINOR -> findScaleIndex("Aeolian (Minor)", 2);
+            case FireControlPreferences.DEFAULT_SCALE_HARMONIC_MINOR -> findScaleIndex("Harmonic Minor", 2);
+            case FireControlPreferences.DEFAULT_SCALE_MELODIC_MINOR -> findScaleIndex("Melodic Minor (ascending)", 2);
+            case FireControlPreferences.DEFAULT_SCALE_MINOR_PENTATONIC -> findScaleIndex("Minor Pentatonic", 2);
+            case FireControlPreferences.DEFAULT_SCALE_DORIAN -> findScaleIndex("Dorian", 2);
+            case FireControlPreferences.DEFAULT_SCALE_MIXOLYDIAN -> findScaleIndex("Mixolydian", 1);
+            default -> -1;
+        };
+    }
+
+    private int findScaleIndex(final String scaleName, final int fallbackIndex) {
+        final MusicalScaleLibrary scaleLibrary = MusicalScaleLibrary.getInstance();
+        for (int i = 0; i < scaleLibrary.getMusicalScalesCount(); i++) {
+            if (scaleLibrary.getMusicalScale(i).getName().equals(scaleName)) {
+                return i;
+            }
+        }
+        return fallbackIndex;
     }
 
     private void onMidi0(final ShortMidiMessage msg) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -25,6 +25,7 @@ import com.bitwig.extensions.framework.values.Midi;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class AkaiFireOikontrolExtension extends ControllerExtension {
     private static final double MAIN_ENCODER_STEP = 0.01;
@@ -90,10 +91,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private SettableEnumValue defaultRootKeyPref;
     private SettableEnumValue defaultNoteInputOctavePref;
     private SettableEnumValue defaultVelocitySensitivityPref;
+    private SettableEnumValue melodicSeedModePref;
     private SettableEnumValue livePitchOffsetBehaviorPref;
     private SettableBooleanValue encoderTouchResetPref;
     private SettableRangedValue padBrightnessPref;
     private SettableRangedValue padSaturationPref;
+    private SettableRangedValue melodicFixedSeedPref;
     private SettableBooleanValue stepSeqPadAuditionPref;
     private SettableBooleanValue screenNotificationsPref;
     private String tempoDisplayValue = "";
@@ -299,11 +302,26 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
                 FireControlPreferences.DEFAULT_NOTE_INPUT_OCTAVE);
         defaultNoteInputOctavePref.markInterested();
 
+        melodicSeedModePref = preferences.getEnumSetting("Melodic Seed Mode",
+                FireControlPreferences.CATEGORY_GENERATIVE_CONTROL,
+                FireControlPreferences.MELODIC_SEED_MODES,
+                FireControlPreferences.MELODIC_SEED_MODE_RANDOM);
+        melodicSeedModePref.markInterested();
+
         defaultVelocitySensitivityPref = preferences.getEnumSetting("Default Velocity Sensitivity",
                 FireControlPreferences.CATEGORY_FUNCTIONALITIES,
                 FireControlPreferences.DEFAULT_VELOCITY_SENSITIVITIES,
                 FireControlPreferences.DEFAULT_VELOCITY_SENSITIVITY);
         defaultVelocitySensitivityPref.markInterested();
+
+        melodicFixedSeedPref = preferences.getNumberSetting("Melodic Fixed Seed",
+                FireControlPreferences.CATEGORY_GENERATIVE_CONTROL,
+                FireControlPreferences.MELODIC_FIXED_SEED_MIN,
+                FireControlPreferences.MELODIC_FIXED_SEED_MAX,
+                1,
+                "",
+                FireControlPreferences.MELODIC_FIXED_SEED_DEFAULT);
+        melodicFixedSeedPref.markInterested();
 
         drumPinModePref = preferences.getEnumSetting("Drum Mode Pinning",
                 FireControlPreferences.CATEGORY_PINNING,
@@ -983,6 +1001,22 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
                 ? FireControlPreferences.toDefaultVelocitySensitivity(
                 FireControlPreferences.DEFAULT_VELOCITY_SENSITIVITY)
                 : FireControlPreferences.toDefaultVelocitySensitivity(defaultVelocitySensitivityPref.get());
+    }
+
+    public long initialMelodicSeed() {
+        final String seedMode = melodicSeedModePref == null
+                ? FireControlPreferences.MELODIC_SEED_MODE_RANDOM
+                : FireControlPreferences.normalizeMelodicSeedMode(melodicSeedModePref.get());
+        if (FireControlPreferences.MELODIC_SEED_MODE_FIXED.equals(seedMode)) {
+            final long fixedSeed = melodicFixedSeedPref == null
+                    ? FireControlPreferences.MELODIC_FIXED_SEED_DEFAULT
+                    : Math.round(melodicFixedSeedPref.getRaw());
+            return Math.max(FireControlPreferences.MELODIC_FIXED_SEED_MIN,
+                    Math.min(FireControlPreferences.MELODIC_FIXED_SEED_MAX, fixedSeed));
+        }
+        return ThreadLocalRandom.current().nextLong(
+                FireControlPreferences.MELODIC_FIXED_SEED_MIN,
+                FireControlPreferences.MELODIC_FIXED_SEED_MAX + 1);
     }
 
     public void exitMelodicStepMode() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -5,6 +5,7 @@ public final class FireControlPreferences {
     public static final String CATEGORY_CLIP_LAUNCH = "Clip Launch";
     public static final String CATEGORY_PINNING = "Pinning";
     public static final String CATEGORY_HARDWARE = "Hardware";
+    public static final String CATEGORY_GENERATIVE_CONTROL = "Generative control";
 
     public static final double PAD_BRIGHTNESS_MIN = 20.0;
     public static final double PAD_BRIGHTNESS_MAX = 100.0;
@@ -134,6 +135,16 @@ public final class FireControlPreferences {
     };
     public static final String DEFAULT_VELOCITY_SENSITIVITY = "80";
 
+    public static final String MELODIC_SEED_MODE_RANDOM = "Random";
+    public static final String MELODIC_SEED_MODE_FIXED = "Fixed";
+    public static final String[] MELODIC_SEED_MODES = {
+            MELODIC_SEED_MODE_RANDOM,
+            MELODIC_SEED_MODE_FIXED
+    };
+    public static final long MELODIC_FIXED_SEED_DEFAULT = 1234L;
+    public static final long MELODIC_FIXED_SEED_MIN = 1L;
+    public static final long MELODIC_FIXED_SEED_MAX = 999999L;
+
     public static final String DRUM_PIN_MODE_FOLLOW_SELECTION = "Follow Selection";
     public static final String DRUM_PIN_MODE_FIRST_DRUM_MACHINE = "Auto-select First Drum Machine";
     public static final String[] DRUM_PIN_MODES = {
@@ -224,6 +235,16 @@ public final class FireControlPreferences {
         }
         return DEFAULT_SCALE_PIANO;
     }
+
+    public static String normalizeMelodicSeedMode(final String preferenceValue) {
+        for (final String value : MELODIC_SEED_MODES) {
+            if (value.equals(preferenceValue)) {
+                return value;
+            }
+        }
+        return MELODIC_SEED_MODE_RANDOM;
+    }
+
 
     public static String normalizeDefaultRootKey(final String preferenceValue) {
         for (final String value : DEFAULT_ROOT_KEYS) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -91,13 +91,23 @@ public final class FireControlPreferences {
             LIVE_PITCH_OFFSET_RETUNE_HELD
     };
 
-    public static final String DEFAULT_SCALE_PIANO = "Piano";
+    public static final String DEFAULT_SCALE_PIANO = "Piano/Chromatic";
     public static final String DEFAULT_SCALE_MINOR = "Minor";
+    public static final String DEFAULT_SCALE_HARMONIC_MINOR = "Harmonic Minor";
+    public static final String DEFAULT_SCALE_MELODIC_MINOR = "Melodic Minor";
     public static final String DEFAULT_SCALE_MAJOR = "Major";
+    public static final String DEFAULT_SCALE_MINOR_PENTATONIC = "Minor Pentatonic";
+    public static final String DEFAULT_SCALE_DORIAN = "Dorian";
+    public static final String DEFAULT_SCALE_MIXOLYDIAN = "Mixolydian";
     public static final String[] DEFAULT_SCALES = {
             DEFAULT_SCALE_PIANO,
+            DEFAULT_SCALE_MAJOR,
             DEFAULT_SCALE_MINOR,
-            DEFAULT_SCALE_MAJOR
+            DEFAULT_SCALE_HARMONIC_MINOR,
+            DEFAULT_SCALE_MELODIC_MINOR,
+            DEFAULT_SCALE_MINOR_PENTATONIC,
+            DEFAULT_SCALE_DORIAN,
+            DEFAULT_SCALE_MIXOLYDIAN
     };
     public static final String[] DEFAULT_ROOT_KEYS = {
             "C",

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/AcidGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/AcidGenerator.java
@@ -61,13 +61,13 @@ public final class AcidGenerator implements MelodicGenerator {
             final boolean accent = accents[i] || anchor;
             final boolean slide = slides[i] && nextActive(active, i, loopSteps);
             final int pitch = context.pitchForDegree(octaveOffsets[i], degrees[i]);
-            final double gate = slide ? 1.12 : gateFor(degrees[i], accent, anchor);
+            final double gate = slide ? 0.98 + parameters.legato() * 0.22 : gateFor(degrees[i], accent, anchor, parameters.legato());
             final int velocity = accent ? 116 + random.nextInt(8) : 86 + random.nextInt(14);
             steps.add(new MelodicPattern.Step(i, true, false, pitch, velocity, gate, accent, slide));
         }
 
         MelodicPattern pattern = new MelodicPattern(steps, loopSteps);
-        pattern = addAnchorTies(pattern, active, random, parameters.tension());
+        pattern = addAnchorTies(pattern, active, random, parameters.tension(), parameters.legato());
         if (distinctActivePitchCount(pattern) < 3) {
             pattern = forceThirdPitch(pattern, context, active);
         }
@@ -234,7 +234,7 @@ public final class AcidGenerator implements MelodicGenerator {
     }
 
     private MelodicPattern addAnchorTies(final MelodicPattern pattern, final boolean[] active,
-                                         final Random random, final double tension) {
+                                         final Random random, final double tension, final double legato) {
         MelodicPattern out = pattern;
         for (int i = 0; i < pattern.loopSteps() - 1; i++) {
             if (!activeAt(active, i) || activeAt(active, i + 1)) {
@@ -243,7 +243,7 @@ public final class AcidGenerator implements MelodicGenerator {
             if (!isAnchorStep(i, pattern.loopSteps())) {
                 continue;
             }
-            if (random.nextDouble() < 0.08 + tension * 0.14) {
+            if (random.nextDouble() < 0.04 + tension * 0.08 + legato * 0.24) {
                 out = out.withStep(out.step(i + 1).withTieFromPrevious(true));
             }
         }
@@ -336,11 +336,11 @@ public final class AcidGenerator implements MelodicGenerator {
         return step == 0 || step == loopSteps - 1 || step % 4 == 0;
     }
 
-    private double gateFor(final int degree, final boolean accent, final boolean anchor) {
+    private double gateFor(final int degree, final boolean accent, final boolean anchor, final double legato) {
         if (anchor || degree == 0) {
-            return accent ? 1.04 : 0.98;
+            return (accent ? 1.00 : 0.94) + legato * 0.10;
         }
-        return accent ? 0.92 : 0.82;
+        return (accent ? 0.86 : 0.76) + legato * 0.18;
     }
 
     private int nearestRingIndex(final int degree) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/CallResponseGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/CallResponseGenerator.java
@@ -47,8 +47,10 @@ public final class CallResponseGenerator implements MelodicGenerator {
             final int pitch = context.pitchForDegree(octaveOffset, degrees[i]);
             final boolean accent = anchor || (responseSide && i % 4 == 2);
             final boolean slide = !anchor && responseSide && i < loopSteps - 1
-                    && active[i + 1] && random.nextDouble() < parameters.tension() * 0.08;
-            final double gate = slide ? 1.02 : (responseSide ? 0.80 : 0.88) + parameters.density() * 0.10;
+                    && active[i + 1] && random.nextDouble() < parameters.tension() * 0.05 + parameters.legato() * 0.14;
+            final double gate = slide
+                    ? 0.94 + parameters.legato() * 0.16
+                    : (responseSide ? 0.76 : 0.84) + parameters.density() * 0.10 + parameters.legato() * (responseSide ? 0.12 : 0.06);
             final int velocity = accent ? 114 : 86 + random.nextInt(12);
             steps.add(new MelodicPattern.Step(i, true, false, pitch, velocity, gate, accent, slide));
         }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/EuclideanPhraseGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/EuclideanPhraseGenerator.java
@@ -29,7 +29,7 @@ public final class EuclideanPhraseGenerator implements MelodicGenerator {
             final int pitch = context.pitchForDegree(octaveOffset, degree);
             final boolean accent = anchor || phraseIndex % 3 == 0;
             final boolean slide = !anchor && random.nextDouble() < parameters.tension() * 0.1;
-            final double gate = slide ? 1.08 : 0.7 + parameters.density() * 0.2;
+            final double gate = slide ? 0.96 + parameters.legato() * 0.18 : 0.7 + parameters.density() * 0.2;
             final int velocity = accent ? 116 : 82 + random.nextInt(20);
             steps.add(new MelodicPattern.Step(i, true, false, pitch, velocity, gate, accent, slide));
             phraseIndex++;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicClipAdapter.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicClipAdapter.java
@@ -35,8 +35,8 @@ public final class MelodicClipAdapter {
             final double duration = Math.max(stepLength * 0.25, note.duration());
             final int tiedSteps = (int) Math.floor((duration - stepLength * 0.98) / stepLength);
             steps.set(i, new MelodicPattern.Step(i, true, false, note.y(), (int) Math.round(note.velocity() * 127.0),
-                    Math.max(0.1, duration / stepLength), note.velocity() >= 0.87,
-                    duration > stepLength * 1.05));
+                    Math.max(0.1, duration / stepLength), note.chance(), note.velocity() >= 0.87,
+                    duration > stepLength * 1.05, note.recurrenceLength(), note.recurrenceMask()));
             for (int offset = 1; offset <= tiedSteps && i + offset < MelodicPattern.MAX_STEPS; offset++) {
                 steps.set(i + offset, MelodicPattern.Step.rest(i + offset).withTieFromPrevious(true));
             }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicGenerator.java
@@ -19,6 +19,6 @@ public interface MelodicGenerator {
     }
 
     record GenerateParameters(int loopSteps, double density, double tension, double octaveActivity,
-                              int pulses, int rotation, long seed) {
+                              double legato, int pulses, int rotation, double timeVariance, long seed) {
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicPattern.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicPattern.java
@@ -1,5 +1,7 @@
 package com.oikoaudio.fire.melodic;
 
+import com.oikoaudio.fire.sequence.RecurrencePattern;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -94,43 +96,77 @@ public final class MelodicPattern {
     }
 
     public record Step(int index, boolean active, boolean tieFromPrevious, Integer pitch, int velocity,
-                       double gate, boolean accent, boolean slide) {
+                       double gate, double chance, boolean accent, boolean slide, int recurrenceLength, int recurrenceMask) {
+        public Step {
+            final RecurrencePattern recurrence = RecurrencePattern.of(recurrenceLength, recurrenceMask);
+            recurrenceLength = recurrence.length();
+            recurrenceMask = recurrence.mask();
+            chance = Math.max(0.0, Math.min(1.0, chance));
+        }
+
+        public Step(final int index, final boolean active, final boolean tieFromPrevious, final Integer pitch,
+                    final int velocity, final double gate, final boolean accent, final boolean slide) {
+            this(index, active, tieFromPrevious, pitch, velocity, gate, 1.0, accent, slide, 0, 0);
+        }
+
         public static Step rest(final int index) {
-            return new Step(index, false, false, null, 96, 0.8, false, false);
+            return new Step(index, false, false, null, 96, 0.8, 1.0, false, false, 0, 0);
         }
 
         public Step withIndex(final int newIndex) {
-            return new Step(newIndex, active, tieFromPrevious, pitch, velocity, gate, accent, slide);
+            return new Step(newIndex, active, tieFromPrevious, pitch, velocity, gate, chance, accent, slide,
+                    recurrenceLength, recurrenceMask);
         }
 
         public Step withActive(final boolean newActive) {
-            return new Step(index, newActive, tieFromPrevious, pitch, velocity, gate, accent, slide);
+            return new Step(index, newActive, tieFromPrevious, pitch, velocity, gate, chance, accent, slide,
+                    recurrenceLength, recurrenceMask);
         }
 
         public Step withTieFromPrevious(final boolean tie) {
-            return new Step(index, active, tie, pitch, velocity, gate, accent, slide);
+            return new Step(index, active, tie, pitch, velocity, gate, chance, accent, slide, recurrenceLength, recurrenceMask);
         }
 
         public Step withPitch(final Integer newPitch) {
-            return new Step(index, active, tieFromPrevious, newPitch, velocity, gate, accent, slide);
+            return new Step(index, active, tieFromPrevious, newPitch, velocity, gate, chance, accent, slide,
+                    recurrenceLength, recurrenceMask);
         }
 
         public Step withVelocity(final int newVelocity) {
             return new Step(index, active, tieFromPrevious, pitch, Math.max(1, Math.min(127, newVelocity)),
-                    gate, accent, slide);
+                    gate, chance, accent, slide, recurrenceLength, recurrenceMask);
         }
 
         public Step withGate(final double newGate) {
             return new Step(index, active, tieFromPrevious, pitch, velocity, Math.max(0.1, Math.min(1.25, newGate)),
-                    accent, slide);
+                    chance, accent, slide, recurrenceLength, recurrenceMask);
+        }
+
+        public Step withChance(final double newChance) {
+            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, newChance,
+                    accent, slide, recurrenceLength, recurrenceMask);
         }
 
         public Step withAccent(final boolean newAccent) {
-            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, newAccent, slide);
+            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, chance, newAccent, slide,
+                    recurrenceLength, recurrenceMask);
         }
 
         public Step withSlide(final boolean newSlide) {
-            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, accent, newSlide);
+            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, chance, accent, newSlide,
+                    recurrenceLength, recurrenceMask);
+        }
+
+        public Step withRecurrence(final int length, final int mask) {
+            return new Step(index, active, tieFromPrevious, pitch, velocity, gate, chance, accent, slide, length, mask);
+        }
+
+        public int bitwigRecurrenceLength() {
+            return RecurrencePattern.of(recurrenceLength, recurrenceMask).bitwigLength();
+        }
+
+        public int bitwigRecurrenceMask() {
+            return RecurrencePattern.of(recurrenceLength, recurrenceMask).bitwigMask();
         }
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -31,6 +31,7 @@ import com.oikoaudio.fire.sequence.EncoderMode;
 import com.oikoaudio.fire.sequence.EncoderSlotBinding;
 import com.oikoaudio.fire.control.MixerEncoderProfile;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
+import com.oikoaudio.fire.sequence.RecurrencePattern;
 import com.oikoaudio.fire.sequence.SeqClipHandler;
 import com.oikoaudio.fire.sequence.SeqClipRowHost;
 import com.oikoaudio.fire.sequence.AccentLatchState;
@@ -78,6 +79,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private final StepSequencerEncoderHandler encoderLayer;
     private final EncoderBankLayout encoderBankLayout;
     private final Map<Integer, Map<Integer, NoteStep>> noteStepsByPosition = new HashMap<>();
+    private final Map<Integer, MelodicPattern.Step> pendingWrittenSteps = new HashMap<>();
     private final BooleanValueObject lengthDisplay = new BooleanValueObject();
     private final BooleanValueObject selectHeld = new BooleanValueObject();
     private final BooleanValueObject copyHeld = new BooleanValueObject();
@@ -96,7 +98,10 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private MelodicPattern basePattern = MelodicPattern.empty(DEFAULT_LOOP_STEPS);
     private int selectedStep = 0;
     private Integer heldStep = null;
+    private final LinkedHashSet<Integer> heldSteps = new LinkedHashSet<>();
     private boolean heldStepConsumed = false;
+    private boolean recurrenceSpanAnchorHeld = false;
+    private boolean recurrenceSpanGestureUsed = false;
     private int playingStep = -1;
     private int selectedClipSlotIndex = -1;
     private RgbLigthState selectedClipColor = MelodicRenderer.ACTIVE_STEP;
@@ -107,8 +112,10 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private final AccentLatchState accentState = new AccentLatchState();
     private boolean mainEncoderPressConsumed = false;
     private double density = 0.45;
+    private double timeVariance = 0.0;
     private double tension = 0.25;
     private double octaveActivity = 0.1;
+    private double legato = 0.1;
     private int euclideanPulses = 5;
     private int euclideanRotation = 0;
     private double mutateIntensity = 0.45;
@@ -286,6 +293,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private void handlePadPress(final int padIndex, final boolean pressed) {
+        if (!heldSteps.isEmpty() && padIndex < CLIP_ROW_PAD_COUNT && handleRecurrencePadPress(padIndex, pressed)) {
+            return;
+        }
         if (padIndex < CLIP_ROW_PAD_COUNT) {
             clipHandler.handlePadPress(padIndex, pressed);
             return;
@@ -297,12 +307,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (padIndex >= STEP_PAD_OFFSET && !pressed) {
             final int stepIndex = padIndex - STEP_PAD_OFFSET;
             final boolean accentGesture = accentState.isHeld() || accentState.isActive();
-            if (heldStep != null && heldStep == stepIndex) {
-                if (!heldStepConsumed && !accentGesture && !fixedLengthHeld.get() && !deleteHeld.get()) {
+            if (heldSteps.remove(stepIndex)) {
+                if (!heldStepConsumed && heldSteps.isEmpty() && !accentGesture && !fixedLengthHeld.get() && !deleteHeld.get()) {
                     toggleStep(stepIndex);
                 }
-                heldStep = null;
-                heldStepConsumed = false;
+                heldStep = heldSteps.isEmpty() ? null : heldSteps.iterator().next();
+                if (heldSteps.isEmpty()) {
+                    heldStepConsumed = false;
+                    recurrenceSpanAnchorHeld = false;
+                    recurrenceSpanGestureUsed = false;
+                }
             }
             return;
         }
@@ -315,8 +329,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
         final boolean accentGesture = accentState.isHeld() || accentState.isActive();
+        heldSteps.add(stepIndex);
         heldStep = stepIndex;
-        heldStepConsumed = false;
+        heldStepConsumed = heldSteps.size() > 1;
         if (accentGesture) {
             heldStepConsumed = true;
             if (accentState.isHeld()) {
@@ -401,6 +416,45 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         applyPattern(cachedPattern.withStep(step.withPitch(pitch)), "Pitch", pitchName(pitch));
     }
 
+    private boolean handleRecurrencePadPress(final int padIndex, final boolean pressed) {
+        if (heldSteps.isEmpty() || padIndex >= 8) {
+            return false;
+        }
+        if (padIndex == 0 && !pressed && recurrenceSpanAnchorHeld) {
+            recurrenceSpanAnchorHeld = false;
+            if (recurrenceSpanGestureUsed) {
+                recurrenceSpanGestureUsed = false;
+                return true;
+            }
+        } else if (!pressed) {
+            return true;
+        }
+        final List<Integer> targets = heldRecurrenceTargets();
+        if (targets.isEmpty()) {
+            return true;
+        }
+        heldStepConsumed = true;
+        if (padIndex == 0) {
+            recurrenceSpanAnchorHeld = true;
+            recurrenceSpanGestureUsed = false;
+            return true;
+        }
+        if (recurrenceSpanAnchorHeld) {
+            recurrenceSpanGestureUsed = true;
+            applyHeldRecurrenceSpan(targets, padIndex + 1);
+            return true;
+        }
+        final MelodicPattern.Step step = cachedPattern.step(targets.get(0));
+        final RecurrencePattern recurrence = recurrenceOf(step);
+        final int span = recurrence.effectiveSpan();
+        if (padIndex >= span) {
+            return true;
+        }
+        final RecurrencePattern updated = recurrence.toggledAt(padIndex);
+        applyHeldRecurrence(targets, recurrencePattern -> recurrencePattern.toggledAt(padIndex), "Recurrence");
+        return true;
+    }
+
     private void setView(final View newView) {
         view = newView;
         oled.valueInfo("View", newView.label);
@@ -426,28 +480,38 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         switch (selectedGenerator) {
             case MOTIF -> {
                 density = 0.40;
+                timeVariance = 0.0;
                 tension = 0.25;
                 octaveActivity = 1.0;
+                legato = 0.10;
             }
             case CALL_RESPONSE -> {
                 density = 0.46;
+                timeVariance = 0.0;
                 tension = 0.28;
                 octaveActivity = 1.0;
+                legato = 0.08;
             }
             case ACID -> {
                 density = 0.52;
+                timeVariance = 0.0;
                 tension = 0.62;
                 octaveActivity = 1.0;
+                legato = 0.36;
             }
             case ROLLING -> {
                 density = 1.0;
+                timeVariance = 0.0;
                 tension = 0.24;
                 octaveActivity = 1.0;
+                legato = 0.0;
             }
             case OCTAVE -> {
                 density = 0.48;
+                timeVariance = 0.0;
                 tension = 0.22;
                 octaveActivity = 0.60;
+                legato = 0.06;
             }
         }
     }
@@ -736,33 +800,39 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private MelodicGenerator.GenerateParameters generatorParametersForCurrentEngine(final long generationSeed) {
         return switch (generator) {
             case MOTIF -> new MelodicGenerator.GenerateParameters(
-                    loopSteps, density, tension, octaveActivity, euclideanPulses, euclideanRotation, generationSeed);
+                    loopSteps, density, tension, octaveActivity, legato, euclideanPulses, euclideanRotation, timeVariance, generationSeed);
             case CALL_RESPONSE -> new MelodicGenerator.GenerateParameters(
                     loopSteps, Math.max(0.35, density), Math.max(0.2, tension),
-                    octaveActivity, euclideanPulses, euclideanRotation, generationSeed);
+                    octaveActivity, legato, euclideanPulses, euclideanRotation, timeVariance, generationSeed);
             case ACID -> new MelodicGenerator.GenerateParameters(
                     loopSteps,
                     Math.max(0.35, density),
                     Math.max(0.55, tension),
                     Math.max(0.15, octaveActivity),
+                    legato,
                     Math.max(4, euclideanPulses),
                     euclideanRotation,
+                    timeVariance,
                     generationSeed);
             case ROLLING -> new MelodicGenerator.GenerateParameters(
                     loopSteps,
                     density,
                     Math.max(0.2, tension),
                     Math.min(0.25, Math.max(0.05, octaveActivity)),
+                    legato,
                     Math.max(6, euclideanPulses),
                     euclideanRotation,
+                    timeVariance,
                     generationSeed);
             case OCTAVE -> new MelodicGenerator.GenerateParameters(
                     loopSteps,
                     Math.max(0.35, density),
                     Math.max(0.15, tension),
                     Math.max(0.45, octaveActivity),
+                    legato,
                     Math.max(4, euclideanPulses),
                     euclideanRotation,
+                    timeVariance,
                     generationSeed);
         };
     }
@@ -777,7 +847,8 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             return;
         }
         final long mutationSeed = seed;
-        MelodicPattern mutated = mutator.mutate(sourcePattern, phraseContext(), mutationMode, mutateIntensity, 0.7, mutationSeed);
+        MelodicPattern mutated = mutator.mutate(sourcePattern, phraseContext(),
+                mutationMode, mutateIntensity, 0.7, mutationSeed);
         mutated = enrichLatentSteps(mutated);
         mutated = mutationMode == MelodicMutator.Mode.PRESERVE_RHYTHM
                 ? revoicePatternToPoolVariant(mutated, mutateIntensity, mutationSeed)
@@ -878,9 +949,32 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         refreshClipCursor();
         loopSteps = pattern.loopSteps();
         cachedPattern = pattern.withLoopSteps(loopSteps);
+        pendingWrittenSteps.clear();
+        for (int i = 0; i < cachedPattern.loopSteps(); i++) {
+            final MelodicPattern.Step step = cachedPattern.step(i);
+            if (step.active() && !step.tieFromPrevious() && step.pitch() != null) {
+                pendingWrittenSteps.put(i, step);
+            }
+        }
         MelodicClipAdapter.writeToClip(cursorClip, cachedPattern, STEP_LENGTH);
         oled.valueInfo(label, value);
         driver.notifyPopup(label, value);
+    }
+
+    private void applyStepRecurrence(final int stepIndex, final MelodicPattern.Step updated, final String label) {
+        if (!ensureClipAvailable()) {
+            return;
+        }
+        final NoteStep liveStep = primaryNoteStepAt(stepIndex);
+        if (liveStep == null) {
+            oled.valueInfo(label, "No note");
+            return;
+        }
+        cachedPattern = cachedPattern.withStep(updated);
+        basePattern = basePattern.withStep(updated.withIndex(stepIndex));
+        liveStep.setRecurrence(updated.bitwigRecurrenceLength(), updated.bitwigRecurrenceMask());
+        oled.valueInfo(label, recurrenceOf(updated).summary());
+        driver.notifyPopup(label, recurrenceOf(updated).summary());
     }
 
     private void applyTransform(final MelodicPattern pattern, final String label, final String value,
@@ -937,7 +1031,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }
         final MelodicPattern.Step step = ensureStep(editingStepIndex());
         applyPattern(cachedPattern.withStep(step.withGate(step.gate() + amount * 0.05)),
-                "Gate", "%.2f".formatted(step.gate() + amount * 0.05));
+                "Gate Len", "%.2f".formatted(step.gate() + amount * 0.05));
     }
 
     private void adjustSelectedVelocity(final int amount) {
@@ -947,6 +1041,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final MelodicPattern.Step step = ensureStep(editingStepIndex());
         applyPattern(cachedPattern.withStep(step.withVelocity(step.velocity() + amount)),
                 "Velocity", Integer.toString(step.velocity() + amount));
+    }
+
+    private void adjustSelectedChance(final int amount) {
+        if (amount == 0) {
+            return;
+        }
+        final MelodicPattern.Step step = ensureStep(editingStepIndex());
+        final double nextChance = Math.max(0.0, Math.min(1.0, step.chance() + amount * 0.05));
+        applyPattern(cachedPattern.withStep(step.withChance(nextChance)),
+                "Chance", "%d%%".formatted((int) Math.round(nextChance * 100.0)));
     }
 
     private void cycleArticulation(final int amount) {
@@ -1059,6 +1163,41 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         oled.valueInfo("Density", "%.2f".formatted(density));
     }
 
+    private void adjustPoolOctave(final int amount) {
+        if (amount == 0) {
+            return;
+        }
+        if (allowedPitches.isEmpty()) {
+            buildGeneratedPitchPool(seed, false);
+        }
+        if (allowedPitches.isEmpty()) {
+            oled.valueInfo("Pool Oct", "No pool");
+            return;
+        }
+        final List<Integer> layout = pitchPoolLayoutPitches();
+        if (layout.isEmpty()) {
+            return;
+        }
+        final LinkedHashSet<Integer> shifted = new LinkedHashSet<>();
+        for (final int pitch : allowedPitches) {
+            final int targetPitch = Math.max(0, Math.min(127, pitch + amount * 12));
+            shifted.add(nearestLayoutPitch(targetPitch, layout));
+        }
+        if (shifted.equals(allowedPitches)) {
+            oled.valueInfo("Pool Oct", poolOctaveSummary(shifted));
+            return;
+        }
+        allowedPitches.clear();
+        allowedPitches.addAll(shifted);
+        poolUserEdited = true;
+        revoiceCurrentPatternToPool("Pool Oct", poolOctaveSummary(shifted));
+    }
+
+    private void adjustTimeVariance(final int amount) {
+        timeVariance = clampUnit(timeVariance + amount * 0.05);
+        oled.valueInfo("Time Var", "%.2f".formatted(timeVariance));
+    }
+
     private void adjustChannelShape(final int amount) {
         adjustOctaveActivity(amount);
     }
@@ -1130,6 +1269,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         oled.valueInfo(channelShapeLabel(), "%.2f".formatted(octaveActivity));
     }
 
+    private void adjustLegato(final int amount) {
+        legato = clampUnit(legato + amount * 0.05);
+        oled.valueInfo("Legato", "%.2f".formatted(legato));
+    }
+
     private void adjustEuclideanPulses(final int amount) {
         euclideanPulses = Math.max(1, Math.min(loopSteps, euclideanPulses + amount));
         oled.valueInfo("Pulses", Integer.toString(euclideanPulses));
@@ -1143,6 +1287,22 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private void adjustMutateIntensity(final int amount) {
         mutateIntensity = clampUnit(mutateIntensity + amount * 0.05);
         oled.valueInfo("Mut %", "%.2f".formatted(mutateIntensity));
+    }
+
+    private void showRecurrenceEditInfo(final int ignored) {
+        final List<Integer> targets = heldRecurrenceTargets();
+        if (targets.isEmpty()) {
+            oled.valueInfo("Recurrence", "Hold step");
+            return;
+        }
+        final MelodicPattern.Step step = cachedPattern.step(targets.get(0));
+        oled.valueInfo("Recurrence", targets.size() == 1
+                ? recurrenceOf(step).summary()
+                : "%d steps".formatted(targets.size()));
+    }
+
+    private void applyHeldRecurrenceSpan(final List<Integer> stepIndices, final int newSpan) {
+        applyHeldRecurrence(stepIndices, recurrence -> recurrence.applySpanGesture(newSpan), "Recurrence");
     }
 
     private void cycleMutationMode(final int direction) {
@@ -1172,6 +1332,14 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             return allowedPitches.iterator().next();
         }
         return phraseContext().baseMidiNote();
+    }
+
+    private String poolOctaveSummary(final Iterable<Integer> pitches) {
+        int lowestPitch = Integer.MAX_VALUE;
+        for (final int pitch : pitches) {
+            lowestPitch = Math.min(lowestPitch, pitch);
+        }
+        return lowestPitch == Integer.MAX_VALUE ? "No pool" : pitchName(lowestPitch);
     }
 
     private void seedPitchPoolFromPattern(final MelodicPattern pattern) {
@@ -1608,6 +1776,17 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             }
         } else {
             notesAtStep.put(y, noteStep);
+            final MelodicPattern.Step pending = pendingWrittenSteps.get(x);
+            if (pending != null && pending.pitch() != null && pending.pitch() == y) {
+                if (Math.abs(noteStep.chance() - pending.chance()) > 0.0001) {
+                    noteStep.setChance(pending.chance());
+                }
+                if (noteStep.recurrenceLength() != pending.bitwigRecurrenceLength()
+                        || noteStep.recurrenceMask() != pending.bitwigRecurrenceMask()) {
+                    noteStep.setRecurrence(pending.bitwigRecurrenceLength(), pending.bitwigRecurrenceMask());
+                }
+                pendingWrittenSteps.remove(x);
+            }
         }
         rebuildCachedPattern();
     }
@@ -1718,7 +1897,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         }
         return false;
     }
-
     private MelodicPhraseContext phraseContext() {
         final NoteMode noteMode = driver.getNoteMode();
         return new MelodicPhraseContext(noteMode.getCurrentScale(), noteMode.getMelodicStepRootNoteClass(),
@@ -1727,14 +1905,102 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private RgbLigthState getPadLight(final int padIndex) {
         if (padIndex < CLIP_ROW_PAD_COUNT) {
+            if (!heldSteps.isEmpty()) {
+                return getRecurrencePadLight(padIndex);
+            }
             return clipHandler.getPadLight(padIndex);
         }
         if (padIndex < STEP_PAD_OFFSET) {
             return getPitchPoolPadLight(padIndex - PITCH_POOL_PAD_OFFSET);
         }
         final int stepIndex = padIndex - STEP_PAD_OFFSET;
-        return MelodicRenderer.stepLight(cachedPattern.step(stepIndex), heldStep != null && heldStep == stepIndex,
+        return MelodicRenderer.stepLight(cachedPattern.step(stepIndex), heldSteps.contains(stepIndex),
                 stepIndex < loopSteps, stepIndex == playingStep, stepIndex, selectedClipColor);
+    }
+
+    private RgbLigthState getRecurrencePadLight(final int padIndex) {
+        final List<Integer> targets = heldRecurrenceTargets();
+        if (targets.isEmpty() || padIndex >= 8) {
+            return RgbLigthState.OFF;
+        }
+        final MelodicPattern.Step step = cachedPattern.step(targets.get(0));
+        if (!step.active() || step.pitch() == null) {
+            return RgbLigthState.OFF;
+        }
+        final RecurrencePattern recurrence = recurrenceOf(step);
+        final int span = recurrence.effectiveSpan();
+        if (padIndex >= span) {
+            return RgbLigthState.OFF;
+        }
+        final int mask = recurrence.effectiveMask(span);
+        return ((mask >> padIndex) & 0x1) == 1 ? selectedClipColor.getBrightend() : selectedClipColor.getDimmed();
+    }
+
+    private RecurrencePattern recurrenceOf(final MelodicPattern.Step step) {
+        return RecurrencePattern.of(step.recurrenceLength(), step.recurrenceMask());
+    }
+
+    private List<Integer> heldRecurrenceTargets() {
+        final List<Integer> targets = new ArrayList<>();
+        for (final int stepIndex : heldSteps) {
+            if (stepIndex < 0 || stepIndex >= STEP_COUNT) {
+                continue;
+            }
+            final MelodicPattern.Step step = cachedPattern.step(stepIndex);
+            if (step.active() && step.pitch() != null) {
+                targets.add(stepIndex);
+            }
+        }
+        return targets;
+    }
+
+    private void applyHeldRecurrence(final List<Integer> stepIndices,
+                                     final java.util.function.UnaryOperator<RecurrencePattern> updater,
+                                     final String label) {
+        if (!ensureClipAvailable()) {
+            return;
+        }
+        MelodicPattern nextCached = cachedPattern;
+        MelodicPattern nextBase = basePattern;
+        int updatedCount = 0;
+        String summary = null;
+        for (final int stepIndex : stepIndices) {
+            final MelodicPattern.Step step = nextCached.step(stepIndex);
+            if (!step.active() || step.pitch() == null) {
+                continue;
+            }
+            final RecurrencePattern updated = updater.apply(recurrenceOf(step));
+            final MelodicPattern.Step updatedStep = step.withRecurrence(updated.length(), updated.mask());
+            nextCached = nextCached.withStep(updatedStep);
+            nextBase = nextBase.withStep(updatedStep.withIndex(stepIndex));
+            pendingWrittenSteps.put(stepIndex, updatedStep);
+            final NoteStep liveStep = primaryNoteStepAt(stepIndex);
+            if (liveStep != null) {
+                liveStep.setRecurrence(updatedStep.bitwigRecurrenceLength(), updatedStep.bitwigRecurrenceMask());
+            }
+            updatedCount++;
+            summary = updated.summary();
+        }
+        if (updatedCount == 0) {
+            oled.valueInfo(label, "No note");
+            return;
+        }
+        cachedPattern = nextCached;
+        basePattern = nextBase;
+        final String value = updatedCount == 1 ? summary : "%d steps".formatted(updatedCount);
+        oled.valueInfo(label, value);
+        driver.notifyPopup(label, value);
+    }
+
+    private NoteStep primaryNoteStepAt(final int stepIndex) {
+        final Map<Integer, NoteStep> notesAtStep = noteStepsByPosition.get(stepIndex);
+        if (notesAtStep == null || notesAtStep.isEmpty()) {
+            return null;
+        }
+        return notesAtStep.values().stream()
+                .filter(step -> step.state() == NoteStep.State.NoteOn)
+                .min(Comparator.comparingInt(NoteStep::y))
+                .orElse(null);
     }
 
     private RgbLigthState getPitchPoolPadLight(final int padIndex) {
@@ -1789,11 +2055,11 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private EncoderBankLayout createEncoderBankLayout() {
         final Map<EncoderMode, EncoderBank> banks = new EnumMap<>(EncoderMode.class);
         banks.put(EncoderMode.CHANNEL, new EncoderBank(
-                "1: Engine\n2: Density\n3: Motion\n4: Mut Type",
+                "1: Engine\n2: Density\n3: Pool Oct\n4: Mut Type",
                 new EncoderSlotBinding[]{
                         engineSlot(),
-                        valueSlot(this::adjustDensity, () -> "Density"),
-                        valueSlot(this::adjustChannelShape, this::channelShapeLabel),
+                        densitySlot(),
+                        valueSlot(this::adjustPoolOctave, () -> "Pool Oct"),
                         mutationModeSlot()
                 }));
         banks.put(EncoderMode.MIXER, new EncoderBank(
@@ -1805,20 +2071,20 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                         actionSlot("Invert", this::adjustInvertProcess)
                 }));
         banks.put(EncoderMode.USER_1, new EncoderBank(
-                "1: Tension\n2: Pulses\n3: Rotation\n4: Mut %",
+                "1: Motion\n2: Tension\n3: Legato\n4: Span via Row",
                 new EncoderSlotBinding[]{
+                        valueSlot(this::adjustChannelShape, this::channelShapeLabel),
                         valueSlot(this::adjustTension, () -> "Tension"),
-                        valueSlot(this::adjustEuclideanPulses, () -> "Pulses"),
-                        valueSlot(this::adjustEuclideanRotation, () -> "Rotation"),
-                        valueSlot(this::adjustMutateIntensity, () -> "Mut %")
+                        valueSlot(this::adjustLegato, () -> "Legato"),
+                        actionSlot("Span via Row", this::showRecurrenceEditInfo)
                 }));
         banks.put(EncoderMode.USER_2, new EncoderBank(
-                "1: Octave\n2: Gate\n3: Velocity\n4: Artic",
+                "1: Octave\n2: Gate Len\n3: Velocity\n4: Chance",
                 new EncoderSlotBinding[]{
-                        valueSlot(this::adjustSelectedOctave, () -> stepDetail("Oct")),
-                        valueSlot(this::adjustSelectedGate, () -> stepDetail("Gate")),
-                        valueSlot(this::adjustSelectedVelocity, () -> stepDetail("Velocity")),
-                        valueSlot(this::cycleArticulation, () -> stepDetail("Artic"))
+                        stepValueSlot(this::adjustSelectedOctave, () -> stepDetail("Oct")),
+                        stepValueSlot(this::adjustSelectedGate, () -> stepDetail("Gate Len")),
+                        stepValueSlot(this::adjustSelectedVelocity, () -> stepDetail("Velocity")),
+                        stepValueSlot(this::adjustSelectedChance, () -> stepDetail("Chance"))
                 }));
         return new EncoderBankLayout(banks);
     }
@@ -1856,9 +2122,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
                         if (driver.isGlobalAltHeld()) {
-                            oled.valueInfo("Subtype", activeGenerator().currentSubtypeLabel());
+                            oled.valueInfo(view.label, activeGenerator().currentSubtypeLabel());
                         } else {
-                            oled.valueInfo("Engine", generator.label);
+                            oled.valueInfo(view.label, generator.label);
                         }
                     } else {
                         accumulator.reset();
@@ -1909,6 +2175,38 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         };
     }
 
+    private EncoderSlotBinding densitySlot() {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return MixerEncoderProfile.STEP_SIZE;
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                encoder.bindEncoder(layer, inc -> {
+                    if (driver.isGlobalAltHeld()) {
+                        adjustPostDensity(inc);
+                    } else {
+                        adjustDensity(inc);
+                    }
+                });
+                encoder.bindTouched(layer, touched -> {
+                    if (touched) {
+                        if (driver.isGlobalAltHeld()) {
+                            oled.valueInfo("Thin/Fill", "Current phrase");
+                        } else {
+                            oled.valueInfo(view.label, "Density");
+                        }
+                    } else {
+                        oled.clearScreenDelayed();
+                    }
+                });
+            }
+        };
+    }
+
     private String stepDetail(final String label) {
         return "%s S%d".formatted(label, selectedStep + 1);
     }
@@ -1927,7 +2225,30 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 encoder.bindEncoder(layer, adjuster::accept);
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
-                        oled.valueInfo(label.get(), view.label);
+                        oled.valueInfo(view.label, label.get());
+                    } else {
+                        oled.clearScreenDelayed();
+                    }
+                });
+            }
+        };
+    }
+
+    private EncoderSlotBinding stepValueSlot(final java.util.function.IntConsumer adjuster,
+                                             final java.util.function.Supplier<String> label) {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return MixerEncoderProfile.STEP_SIZE;
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                encoder.bindEncoder(layer, adjuster::accept);
+                encoder.bindTouched(layer, touched -> {
+                    if (touched) {
+                        oled.valueInfo("Step", label.get());
                     } else {
                         oled.clearScreenDelayed();
                     }
@@ -1983,7 +2304,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 encoder.bindEncoder(layer, adjuster::accept);
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
-                        oled.valueInfo(label, "Turn");
+                        oled.valueInfo(view.label, label);
                     } else {
                         oled.clearScreenDelayed();
                     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -1017,6 +1017,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (amount == 0) {
             return;
         }
+        if (heldSteps.size() > 1) {
+            applyHeldStepValueEdit(heldEditableTargets(),
+                    step -> step.withPitch(Math.max(0, Math.min(127, step.pitch() + amount * 12))),
+                    "Octave", "%+d oct".formatted(amount));
+            return;
+        }
         final int stepIndex = editingStepIndex();
         final MelodicPattern.Step step = ensureStep(stepIndex);
         final int currentPitch = step.pitch() == null ? phraseContext().baseMidiNote() : step.pitch();
@@ -1029,6 +1035,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (amount == 0) {
             return;
         }
+        if (heldSteps.size() > 1) {
+            applyHeldStepValueEdit(heldEditableTargets(),
+                    step -> step.withGate(step.gate() + amount * 0.05),
+                    "Gate Len", "%+.2f".formatted(amount * 0.05));
+            return;
+        }
         final MelodicPattern.Step step = ensureStep(editingStepIndex());
         applyPattern(cachedPattern.withStep(step.withGate(step.gate() + amount * 0.05)),
                 "Gate Len", "%.2f".formatted(step.gate() + amount * 0.05));
@@ -1038,6 +1050,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (amount == 0) {
             return;
         }
+        if (heldSteps.size() > 1) {
+            applyHeldStepValueEdit(heldEditableTargets(),
+                    step -> step.withVelocity(step.velocity() + amount),
+                    "Velocity", "%+d".formatted(amount));
+            return;
+        }
         final MelodicPattern.Step step = ensureStep(editingStepIndex());
         applyPattern(cachedPattern.withStep(step.withVelocity(step.velocity() + amount)),
                 "Velocity", Integer.toString(step.velocity() + amount));
@@ -1045,6 +1063,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private void adjustSelectedChance(final int amount) {
         if (amount == 0) {
+            return;
+        }
+        if (heldSteps.size() > 1) {
+            applyHeldStepValueEdit(heldEditableTargets(),
+                    step -> step.withChance(step.chance() + amount * 0.05),
+                    "Chance", "%+d%%".formatted(amount * 5));
             return;
         }
         final MelodicPattern.Step step = ensureStep(editingStepIndex());
@@ -1954,6 +1978,20 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         return targets;
     }
 
+    private List<Integer> heldEditableTargets() {
+        final List<Integer> targets = new ArrayList<>();
+        for (final int stepIndex : heldSteps) {
+            if (stepIndex < 0 || stepIndex >= STEP_COUNT) {
+                continue;
+            }
+            final MelodicPattern.Step step = cachedPattern.step(stepIndex);
+            if (step.active() && step.pitch() != null) {
+                targets.add(stepIndex);
+            }
+        }
+        return targets;
+    }
+
     private void applyHeldRecurrence(final List<Integer> stepIndices,
                                      final java.util.function.UnaryOperator<RecurrencePattern> updater,
                                      final String label) {
@@ -1990,6 +2028,39 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         final String value = updatedCount == 1 ? summary : "%d steps".formatted(updatedCount);
         oled.valueInfo(label, value);
         driver.notifyPopup(label, value);
+    }
+
+    private void applyHeldStepValueEdit(final List<Integer> stepIndices,
+                                        final java.util.function.UnaryOperator<MelodicPattern.Step> updater,
+                                        final String label,
+                                        final String value) {
+        if (!ensureClipAvailable()) {
+            return;
+        }
+        if (stepIndices.isEmpty()) {
+            oled.valueInfo(label, "No note");
+            return;
+        }
+        MelodicPattern nextCached = cachedPattern;
+        MelodicPattern nextBase = basePattern;
+        int updatedCount = 0;
+        for (final int stepIndex : stepIndices) {
+            final MelodicPattern.Step step = nextCached.step(stepIndex);
+            if (!step.active() || step.pitch() == null) {
+                continue;
+            }
+            final MelodicPattern.Step updatedStep = updater.apply(step);
+            nextCached = nextCached.withStep(updatedStep);
+            nextBase = nextBase.withStep(updatedStep.withIndex(stepIndex));
+            updatedCount++;
+        }
+        if (updatedCount == 0) {
+            oled.valueInfo(label, "No note");
+            return;
+        }
+        cachedPattern = nextCached;
+        basePattern = nextBase;
+        applyPattern(nextCached, label, updatedCount == 1 ? value : "%s (%d)".formatted(value, updatedCount));
     }
 
     private NoteStep primaryNoteStepAt(final int stepIndex) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -120,6 +120,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private int euclideanRotation = 0;
     private double mutateIntensity = 0.45;
     private long seed;
+    private int poolLayoutRootPitch = -1;
     private View view = View.PROCESS;
     private Generator generator = Generator.ACID;
     private MelodicMutator.Mode mutationMode = MelodicMutator.Mode.PRESERVE_RHYTHM;
@@ -138,10 +139,10 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private enum Generator {
         ACID("Acid"),
-        MOTIF("Motif"),
         CALL_RESPONSE("Call/Resp"),
         ROLLING("Rolling"),
-        OCTAVE("Octave");
+        OCTAVE("Octave"),
+        MOTIF("Motif");
 
         private final String label;
 
@@ -190,6 +191,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         this.encoderBankLayout = createEncoderBankLayout();
         this.encoderLayer = new StepSequencerEncoderHandler(this, driver);
         this.seed = driver.initialMelodicSeed();
+        this.poolLayoutRootPitch = nearestPhraseRootPitch(phraseContext().baseMidiNote());
     }
 
     private void bindPads() {
@@ -1192,6 +1194,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         if (amount == 0) {
             return;
         }
+        poolLayoutRootPitch = shiftedPoolLayoutRootPitch(amount);
         if (allowedPitches.isEmpty()) {
             buildGeneratedPitchPool(seed, false);
         }
@@ -1209,13 +1212,14 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             shifted.add(nearestLayoutPitch(targetPitch, layout));
         }
         if (shifted.equals(allowedPitches)) {
-            oled.valueInfo("Pool Oct", poolOctaveSummary(shifted));
+            oled.valueInfo("Pool Oct", poolOctaveSummary());
             return;
         }
         allowedPitches.clear();
         allowedPitches.addAll(shifted);
         poolUserEdited = true;
-        revoiceCurrentPatternToPool("Pool Oct", poolOctaveSummary(shifted));
+        oled.valueInfo("Pool Oct", poolOctaveSummary());
+        driver.notifyPopup("Pool Oct", poolOctaveSummary());
     }
 
     private void adjustTimeVariance(final int amount) {
@@ -1359,12 +1363,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         return phraseContext().baseMidiNote();
     }
 
-    private String poolOctaveSummary(final Iterable<Integer> pitches) {
-        int lowestPitch = Integer.MAX_VALUE;
-        for (final int pitch : pitches) {
-            lowestPitch = Math.min(lowestPitch, pitch);
-        }
-        return lowestPitch == Integer.MAX_VALUE ? "No pool" : pitchName(lowestPitch);
+    private String poolOctaveSummary() {
+        final int rootPitch = currentPoolLayoutRootPitch();
+        return rootPitch < 0 ? "No pool" : pitchName(rootPitch);
     }
 
     private void seedPitchPoolFromPattern(final MelodicPattern pattern) {
@@ -1636,7 +1637,68 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private List<Integer> pitchPoolLayoutPitches() {
-        return phraseContext().collapsedScaleRange(PITCH_POOL_PAD_COUNT);
+        final MelodicPhraseContext context = phraseContext();
+        final int rootPitch = currentPoolLayoutRootPitch();
+        final List<Integer> notes = new ArrayList<>(PITCH_POOL_PAD_COUNT);
+        int candidate = rootPitch - 1;
+        while (notes.size() < 4 && candidate >= 0) {
+            if (context.scale().isMidiNoteInScale(context.rootNote(), candidate)) {
+                notes.add(0, candidate);
+            }
+            candidate--;
+        }
+        notes.add(rootPitch);
+        candidate = rootPitch + 1;
+        while (notes.size() < PITCH_POOL_PAD_COUNT && candidate <= 127) {
+            if (context.scale().isMidiNoteInScale(context.rootNote(), candidate)) {
+                notes.add(candidate);
+            }
+            candidate++;
+        }
+        candidate = notes.isEmpty() ? rootPitch - 1 : notes.get(0) - 1;
+        while (notes.size() < PITCH_POOL_PAD_COUNT && candidate >= 0) {
+            if (context.scale().isMidiNoteInScale(context.rootNote(), candidate)) {
+                notes.add(0, candidate);
+            }
+            candidate--;
+        }
+        while (notes.size() < PITCH_POOL_PAD_COUNT) {
+            notes.add(notes.isEmpty() ? Math.max(0, Math.min(127, rootPitch)) : notes.get(notes.size() - 1));
+        }
+        return notes;
+    }
+
+    private int currentPoolLayoutRootPitch() {
+        final MelodicPhraseContext context = phraseContext();
+        final int fallback = nearestPhraseRootPitch(context.baseMidiNote());
+        if (poolLayoutRootPitch < 0
+                || Math.floorMod(poolLayoutRootPitch, 12) != context.rootNote()
+                || !context.scale().isRootMidiNote(context.rootNote(), poolLayoutRootPitch)) {
+            poolLayoutRootPitch = fallback;
+        }
+        return poolLayoutRootPitch;
+    }
+
+    private int shiftedPoolLayoutRootPitch(final int octaveDelta) {
+        final int targetPitch = currentPoolLayoutRootPitch() + octaveDelta * 12;
+        return nearestPhraseRootPitch(targetPitch);
+    }
+
+    private int nearestPhraseRootPitch(final int targetPitch) {
+        final MelodicPhraseContext context = phraseContext();
+        int bestPitch = Math.max(0, Math.min(127, targetPitch));
+        int bestDistance = Integer.MAX_VALUE;
+        for (int pitch = 0; pitch <= 127; pitch++) {
+            if (!context.scale().isRootMidiNote(context.rootNote(), pitch)) {
+                continue;
+            }
+            final int distance = Math.abs(pitch - targetPitch);
+            if (distance < bestDistance || (distance == bestDistance && pitch < bestPitch)) {
+                bestPitch = pitch;
+                bestDistance = distance;
+            }
+        }
+        return bestPitch;
     }
 
     private String pitchName(final int midiPitch) {
@@ -1924,8 +1986,8 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
     private MelodicPhraseContext phraseContext() {
         final NoteMode noteMode = driver.getNoteMode();
-        return new MelodicPhraseContext(noteMode.getCurrentScale(), noteMode.getMelodicStepRootNoteClass(),
-                noteMode.getMelodicStepBaseMidiNote());
+        return new MelodicPhraseContext(noteMode.getCurrentScale(), noteMode.getCurrentRootNoteClass(),
+                noteMode.getCurrentBaseMidiNote());
     }
 
     private RgbLigthState getPadLight(final int padIndex) {
@@ -2131,7 +2193,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 new EncoderSlotBinding[]{
                         engineSlot(),
                         densitySlot(),
-                        valueSlot(this::adjustPoolOctave, () -> "Pool Oct"),
+                        poolContextSlot(),
                         mutationModeSlot()
                 }));
         banks.put(EncoderMode.MIXER, new EncoderBank(
@@ -2283,6 +2345,38 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         return "%s S%d".formatted(label, selectedStep + 1);
     }
 
+    private EncoderSlotBinding poolContextSlot() {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return MixerEncoderProfile.STEP_SIZE;
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                encoder.bindEncoder(layer, inc -> {
+                    if (driver.isGlobalAltHeld()) {
+                        adjustGlobalRootKey(inc);
+                    } else {
+                        adjustPoolOctave(inc);
+                    }
+                });
+                encoder.bindTouched(layer, touched -> {
+                    if (touched) {
+                        if (driver.isGlobalAltHeld()) {
+                            oled.valueInfo("Root", NoteAssignHelper.noteName(driver.getSharedRootNote()));
+                        } else {
+                            oled.valueInfo("Pool Oct", poolOctaveSummary());
+                        }
+                    } else {
+                        oled.clearScreenDelayed();
+                    }
+                });
+            }
+        };
+    }
+
     private EncoderSlotBinding valueSlot(final java.util.function.IntConsumer adjuster,
                                          final java.util.function.Supplier<String> label) {
         return new EncoderSlotBinding() {
@@ -2304,6 +2398,24 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 });
             }
         };
+    }
+
+    private void adjustGlobalRootKey(final int amount) {
+        if (amount == 0) {
+            return;
+        }
+        driver.adjustSharedRootNote(amount);
+        final String rootName = NoteAssignHelper.noteName(driver.getSharedRootNote());
+        oled.valueInfo("Root", rootName);
+        driver.notifyPopup("Root", rootName);
+    }
+
+    private static final class NoteAssignHelper {
+        private static final String[] NAMES = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+
+        private static String noteName(final int note) {
+            return NAMES[Math.floorMod(note, 12)];
+        }
     }
 
     private EncoderSlotBinding stepValueSlot(final java.util.function.IntConsumer adjuster,

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -119,7 +119,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private int euclideanPulses = 5;
     private int euclideanRotation = 0;
     private double mutateIntensity = 0.45;
-    private long seed = 1L;
+    private long seed;
     private View view = View.PROCESS;
     private Generator generator = Generator.ACID;
     private MelodicMutator.Mode mutationMode = MelodicMutator.Mode.PRESERVE_RHYTHM;
@@ -189,6 +189,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         bindMainEncoder();
         this.encoderBankLayout = createEncoderBankLayout();
         this.encoderLayer = new StepSequencerEncoderHandler(this, driver);
+        this.seed = driver.initialMelodicSeed();
     }
 
     private void bindPads() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MotifGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MotifGenerator.java
@@ -79,8 +79,8 @@ public final class MotifGenerator implements MelodicGenerator {
             final boolean sectionStart = i % sectionLength == firstActiveOffset(active, i, sectionLength);
             final boolean cadence = i == lastActiveIndex(active, loopSteps);
             final boolean accent = cadence || sectionStart;
-            final boolean slide = shouldSlide(active, degrees, i, loopSteps, parameters.tension(), random);
-            final double gate = gateFor(accent, cadence, slide, parameters.density());
+            final boolean slide = shouldSlide(active, degrees, i, loopSteps, parameters.tension(), parameters.legato(), random);
+            final double gate = gateFor(accent, cadence, slide, parameters.density(), parameters.legato());
             final int velocity = accent ? 112 + random.nextInt(8) : 86 + random.nextInt(18);
             steps.add(new MelodicPattern.Step(i, true, false, pitch, velocity, gate, accent, slide));
         }
@@ -402,25 +402,26 @@ public final class MotifGenerator implements MelodicGenerator {
     }
 
     private boolean shouldSlide(final boolean[] active, final int[] degrees, final int step, final int loopSteps,
-                                final double tension, final Random random) {
+                                final double tension, final double legato, final Random random) {
         if (step >= loopSteps - 1 || !active[step + 1]) {
             return false;
         }
         final int interval = Math.abs(degrees[step + 1] - degrees[step]);
-        return interval == 1 && random.nextDouble() < 0.08 + tension * 0.08;
+        return interval == 1 && random.nextDouble() < 0.04 + tension * 0.06 + legato * 0.18;
     }
 
-    private double gateFor(final boolean accent, final boolean cadence, final boolean slide, final double density) {
+    private double gateFor(final boolean accent, final boolean cadence, final boolean slide,
+                           final double density, final double legato) {
         if (slide) {
-            return 1.02;
+            return 0.96 + legato * 0.20;
         }
         if (cadence) {
-            return 0.95;
+            return 0.90 + legato * 0.10;
         }
         if (accent) {
-            return 0.88;
+            return 0.82 + legato * 0.10;
         }
-        return 0.72 + density * 0.12;
+        return 0.68 + density * 0.12 + legato * 0.10;
     }
 
     private int firstActiveOffset(final boolean[] active, final int step, final int sectionLength) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/RollingBassGenerator.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/RollingBassGenerator.java
@@ -61,8 +61,12 @@ public final class RollingBassGenerator implements MelodicGenerator {
             final int octaveOffset = chooseOctaveOffset(inCell, parameters.octaveActivity(), random);
             final int pitch = context.pitchForDegree(octaveOffset, degree);
             final boolean accent = anchor || inCell == cellLength - 2;
-            final boolean slide = !anchor && inCell == cellLength - 3 && random.nextDouble() < parameters.tension() * 0.10;
-            final double gate = slide ? 1.02 : (inCell % 2 == 0 ? 0.96 : 0.88 + parameters.density() * 0.10);
+            final boolean slide = !anchor && inCell == cellLength - 3
+                    && parameters.legato() > 0.0
+                    && random.nextDouble() < 0.02 + parameters.legato() * 0.20;
+            final double gate = slide
+                    ? 0.96 + parameters.legato() * 0.14
+                    : (inCell % 2 == 0 ? 0.96 : 0.88 + parameters.density() * 0.10);
             final int velocity = accent ? 114 : 86 + (inCell % 2 == 0 ? 10 : 0) + random.nextInt(6);
             steps.add(new MelodicPattern.Step(i, true, false, pitch, velocity, gate, accent, slide));
         }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -95,7 +95,6 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     private static final int MIN_MIDI_VALUE = 0;
     private static final int MAX_MIDI_VALUE = 127;
     private static final int MIN_VELOCITY = 1;
-    private static final int LEGACY_MELODIC_STEP_DEFAULT_BASE = 48;
     private static final int DEFAULT_LIVE_VELOCITY = 100;
     private static final int DEFAULT_OIKORD_STANDARD_VELOCITY = 100;
     private static final int DEFAULT_OIKORD_ACCENTED_VELOCITY = 127;
@@ -176,8 +175,6 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     private final Map<Integer, Map<Integer, NoteStep>> noteStepsByPosition = new HashMap<>();
     private final Map<String, NoteStepMoveSnapshot> pendingMovedNotes = new HashMap<>();
 
-    private int transposeBase = LEGACY_MELODIC_STEP_DEFAULT_BASE;
-    private boolean pitchContextTouched = false;
     private boolean inKey = false;
     private boolean noteStepActive = false;
     private final AccentLatchState oikordAccentState = new AccentLatchState();
@@ -335,45 +332,12 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         bindPads();
         bindButtons();
         bindEncoders();
-        applyDefaultScalePreference();
-        applyDefaultRootKeyPreference();
-        applyDefaultNoteInputOctavePreference();
+        applyDefaultLayoutPreference();
         applyDefaultVelocitySensitivityPreference();
     }
 
-    private void applyDefaultScalePreference() {
-        final String defaultScale = driver.getDefaultScalePreference();
-        switch (defaultScale) {
-            case FireControlPreferences.DEFAULT_SCALE_MINOR -> {
-                driver.setSharedScaleIndex(findScaleIndex("Aeolian (Minor)", 2));
-                inKey = true;
-            }
-            case FireControlPreferences.DEFAULT_SCALE_MAJOR -> {
-                driver.setSharedScaleIndex(findScaleIndex("Ionan (Major)", 1));
-                inKey = true;
-            }
-            default -> {
-                driver.setSharedScaleIndex(PIANO_HIGHLIGHT_INDEX);
-                inKey = false;
-            }
-        }
-    }
-
-    private int findScaleIndex(final String scaleName, final int fallbackIndex) {
-        for (int i = 0; i < scaleLibrary.getMusicalScalesCount(); i++) {
-            if (scaleLibrary.getMusicalScale(i).getName().equals(scaleName)) {
-                return i;
-            }
-        }
-        return fallbackIndex;
-    }
-
-    private void applyDefaultRootKeyPreference() {
-        driver.setSharedRootNote(driver.getDefaultRootKeyPreference());
-    }
-
-    private void applyDefaultNoteInputOctavePreference() {
-        transposeBase = driver.getDefaultNoteInputOctavePreference() * 12 + getRootNote();
+    private void applyDefaultLayoutPreference() {
+        inKey = !FireControlPreferences.DEFAULT_SCALE_PIANO.equals(driver.getDefaultScalePreference());
     }
 
     private void applyDefaultVelocitySensitivityPreference() {
@@ -554,7 +518,11 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         final int steps = liveScaleEncoder.consume(inc);
         if (steps != 0) {
             markEncoderAdjusted(2);
-            adjustScale(steps);
+            if (driver.isGlobalAltHeld()) {
+                adjustTransposeSemitone(steps);
+            } else {
+                adjustScale(steps);
+            }
         }
     }
 
@@ -808,7 +776,9 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     }
 
     private void handleEncoder1Touch(final boolean pressed) {
-        handleResettableTouch(3, pressed, () -> showState("Scale"), liveScaleEncoder::reset);
+        handleResettableTouch(3, pressed,
+                () -> showState(driver.isGlobalAltHeld() ? "Root" : "Scale"),
+                liveScaleEncoder::reset);
     }
 
     private void handleEncoder2Touch(final boolean pressed) {
@@ -2280,15 +2250,8 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     }
 
     public void adjustSharedScaleFromOverview(final int amount) {
-        if (amount == 0) {
-            return;
-        }
         final int minScale = inKey ? 1 : PIANO_HIGHLIGHT_INDEX;
-        final int nextScale = driver.getSharedScaleIndex() + amount;
-        if (nextScale < minScale || nextScale >= scaleLibrary.getMusicalScalesCount()) {
-            return;
-        }
-        driver.setSharedScaleIndex(nextScale);
+        driver.adjustSharedScaleIndex(amount, minScale);
     }
 
     private void adjustOctave(final int amount) {
@@ -2299,8 +2262,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         if (nextOctave == getOctave()) {
             return;
         }
-        pitchContextTouched = true;
-        applyLayoutChange(() -> transposeBase = nextOctave * 12 + getRootNote());
+        applyLayoutChange(() -> driver.setSharedOctave(nextOctave));
         showState("Octave");
     }
 
@@ -2308,12 +2270,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
         if (amount == 0) {
             return;
         }
-        final int currentOctave = getOctave();
-        pitchContextTouched = true;
-        applyLayoutChange(() -> {
-            driver.adjustSharedRootNote(amount);
-            transposeBase = currentOctave * 12 + getRootNote();
-        });
+        applyLayoutChange(() -> driver.adjustSharedRootNote(amount));
         showState("Root");
     }
 
@@ -3041,7 +2998,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     }
 
     private int getOctave() {
-        return transposeBase / 12;
+        return driver.getSharedOctave();
     }
 
     public int getCurrentOctave() {
@@ -3049,15 +3006,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
     }
 
     public int getCurrentBaseMidiNote() {
-        return getOctave() * 12 + getRootNote();
-    }
-
-    public int getMelodicStepRootNoteClass() {
-        return pitchContextTouched ? getRootNote() : Math.floorMod(LEGACY_MELODIC_STEP_DEFAULT_BASE, 12);
-    }
-
-    public int getMelodicStepBaseMidiNote() {
-        return pitchContextTouched ? getCurrentBaseMidiNote() : LEGACY_MELODIC_STEP_DEFAULT_BASE;
+        return driver.getSharedBaseMidiNote();
     }
 
     private NoteGridLayout createLayout() {
@@ -3107,7 +3056,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             }
             return;
         }
-        handlePitchContextButton(true, 1, driver.isGlobalShiftHeld());
+        adjustOctave(1);
     }
 
     private void handlePatternDown(final boolean pressed) {
@@ -3120,7 +3069,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             }
             return;
         }
-        handlePitchContextButton(true, -1, driver.isGlobalShiftHeld());
+        adjustOctave(-1);
     }
 
     private BiColorLightState getPatternUpLight() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteMode.java
@@ -257,7 +257,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private enum OikordInterpretation {
         AS_IS("As Is"),
-        CAST("Cast");
+        IN_SCALE("In Scale");
 
         private final String displayName;
 
@@ -1865,7 +1865,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private void toggleOikordInterpretation() {
         oikordInterpretation = oikordInterpretation == OikordInterpretation.AS_IS
-                ? OikordInterpretation.CAST
+                ? OikordInterpretation.IN_SCALE
                 : OikordInterpretation.AS_IS;
         oled.valueInfo("Chord Step Mode", oikordInterpretation.displayName());
         driver.notifyPopup("Chord Step Mode", oikordInterpretation.displayName());
@@ -1879,9 +1879,19 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             toggleOikordInterpretation();
             return;
         }
-        if (amount < 0 && oikordInterpretation == OikordInterpretation.CAST) {
+        if (amount < 0 && oikordInterpretation == OikordInterpretation.IN_SCALE) {
             toggleOikordInterpretation();
         }
+    }
+
+    private void adjustOikordSharedScale(final int amount) {
+        if (amount == 0) {
+            return;
+        }
+        final int minScale = inKey ? 1 : PIANO_HIGHLIGHT_INDEX;
+        applyLayoutChange(() -> driver.adjustSharedScaleIndex(amount, minScale));
+        oled.valueInfo("Scale", getScaleDisplayName());
+        driver.notifyPopup("Scale", getScaleDisplayName());
     }
 
     private void startAuditionSelectedOikord() {
@@ -2686,7 +2696,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
 
     private String oikordInterpretationSuffix() {
         return "F%d %s K%s O%s".formatted(selectedOikordFamily + 1,
-                oikordInterpretation == OikordInterpretation.AS_IS ? "Raw" : "Cast",
+                oikordInterpretation == OikordInterpretation.AS_IS ? "Raw" : "InKey",
                 NoteGridLayout.noteName(getRootNote()),
                 formatSignedValue(oikordOctaveOffset));
     }
@@ -2728,7 +2738,7 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
             return renderBuilderOikord();
         }
         final OikordBank.Slot slot = currentOikordSlot();
-        if (oikordInterpretation == OikordInterpretation.CAST) {
+        if (oikordInterpretation == OikordInterpretation.IN_SCALE) {
             final int shiftedRoot = getRootNote();
             final int castRoot = Math.floorMod(shiftedRoot, 12);
             final int castOctaveOffset = oikordOctaveOffset;
@@ -3758,11 +3768,27 @@ public class NoteMode extends Layer implements StepSequencerHost, SeqClipRowHost
                 encoder.bindEncoder(layer, inc -> {
                     if (inc != 0) {
                         handler.recordTouchAdjustment(slotIndex, Math.abs(inc));
-                        adjustOikordInterpretation(inc);
+                        if (driver.isGlobalShiftHeld()) {
+                            adjustOikordSharedScale(inc);
+                        } else if (driver.isGlobalAltHeld()) {
+                            adjustOikordRoot(inc);
+                        } else {
+                            adjustOikordInterpretation(inc);
+                        }
                     }
                 });
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
+                        if (driver.isGlobalShiftHeld()) {
+                            handler.beginTouchReset(slotIndex, () -> { });
+                            oled.valueInfo("Scale", getScaleDisplayName());
+                            return;
+                        }
+                        if (driver.isGlobalAltHeld()) {
+                            handler.beginTouchReset(slotIndex, () -> { });
+                            showOikordRootInfo();
+                            return;
+                        }
                         handler.beginTouchReset(slotIndex, () -> {
                             oikordInterpretation = OikordInterpretation.AS_IS;
                             oled.valueInfo("Interpret", oikordInterpretation.displayName());

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -180,9 +180,10 @@ public class PerformClipLauncherMode extends Layer {
 
     private void showOverview() {
         oled.detailInfo("Settings",
-                "1: Root %s\n2: Scale %s".formatted(
+                "1: Root %s\n2: Scale %s\n3: Oct %d".formatted(
                         com.oikoaudio.fire.note.NoteGridLayout.noteName(driver.getSharedRootNote()),
-                        driver.getSharedScaleDisplayName()));
+                        driver.getSharedScaleDisplayName(),
+                        driver.getSharedOctave()));
         oled.clearScreenDelayed();
     }
 
@@ -244,8 +245,13 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
         if (encoderIndex == 1) {
-            driver.getNoteMode().adjustSharedScaleFromOverview(inc);
-            oled.valueInfo("Scale", driver.getNoteMode().getCurrentScaleDisplayName());
+            driver.adjustSharedScaleIndex(inc, -1);
+            oled.valueInfo("Scale", driver.getSharedScaleDisplayName());
+            return;
+        }
+        if (encoderIndex == 2) {
+            driver.adjustSharedOctave(inc);
+            oled.valueInfo("Octave", Integer.toString(driver.getSharedOctave()));
             return;
         }
         showOverview();
@@ -261,7 +267,11 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
         if (encoderIndex == 1) {
-            oled.valueInfo("Scale", driver.getNoteMode().getCurrentScaleDisplayName());
+            oled.valueInfo("Scale", driver.getSharedScaleDisplayName());
+            return;
+        }
+        if (encoderIndex == 2) {
+            oled.valueInfo("Octave", Integer.toString(driver.getSharedOctave()));
             return;
         }
         showOverview();
@@ -524,7 +534,7 @@ public class PerformClipLauncherMode extends Layer {
 
     private String modeInfo(final EncoderMode mode) {
         if (settingsMode) {
-            return "1: Root Key\n2: Scale\n3: Shared Pitch\n4: Shared Pitch";
+            return "1: Root Key\n2: Scale\n3: Octave\n4: Global";
         }
         return switch (mode) {
             case CHANNEL -> "1: Remote 1\n2: Remote 2\n3: Remote 3\n4: Remote 4";

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -611,7 +611,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
     }
 
     private List<NoteStep> getExpressionTargetNotes() {
-        return isPadBeingHeld() ? getOnNotes() : getHeldNotes();
+        return isPadBeingHeld() ? getHeldNotes() : getOnNotes();
     }
 
     private void adjustDefaultVelocity(final int inc) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/RecurrencePattern.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/RecurrencePattern.java
@@ -1,0 +1,83 @@
+package com.oikoaudio.fire.sequence;
+
+public record RecurrencePattern(int length, int mask) {
+    public static final int DEFAULT_BITWIG_LENGTH = 1;
+    public static final int DEFAULT_BITWIG_MASK = 0b1;
+    public static final int EDITOR_DEFAULT_SPAN = 8;
+
+    public RecurrencePattern {
+        if (length <= 1) {
+            length = 0;
+            mask = 0;
+        } else {
+            length = Math.min(8, length);
+            mask &= (1 << length) - 1;
+            if (mask == 0 || mask == ((1 << length) - 1)) {
+                length = 0;
+                mask = 0;
+            }
+        }
+    }
+
+    public static RecurrencePattern of(final int length, final int mask) {
+        return new RecurrencePattern(length, mask);
+    }
+
+    public boolean isDefault() {
+        return length <= 1;
+    }
+
+    public int bitwigLength() {
+        return isDefault() ? DEFAULT_BITWIG_LENGTH : length;
+    }
+
+    public int bitwigMask() {
+        return isDefault() ? DEFAULT_BITWIG_MASK : mask;
+    }
+
+    public int effectiveSpan() {
+        return isDefault() ? EDITOR_DEFAULT_SPAN : length;
+    }
+
+    public int effectiveMask(final int span) {
+        return isDefault() ? ((1 << span) - 1) : (mask & ((1 << span) - 1));
+    }
+
+    public String summary() {
+        if (isDefault()) {
+            return "Off";
+        }
+        final int span = effectiveSpan();
+        final int shownMask = effectiveMask(span);
+        return "%d:%s".formatted(span, Integer.toBinaryString((1 << span) | shownMask).substring(1));
+    }
+
+    public RecurrencePattern toggledAt(final int padIndex) {
+        final int span = effectiveSpan();
+        if (padIndex < 0 || padIndex >= span) {
+            return this;
+        }
+        final int bit = 1 << padIndex;
+        int updatedMask = effectiveMask(span) ^ bit;
+        if ((updatedMask & ((1 << span) - 1)) == 0) {
+            updatedMask = bit;
+        }
+        return of(span, updatedMask);
+    }
+
+    public RecurrencePattern applySpanGesture(final int newSpan) {
+        final int currentSpan = effectiveSpan();
+        if (isDefault()) {
+            return of(newSpan, 0b1);
+        }
+        if (newSpan == currentSpan) {
+            return of(0, 0);
+        }
+        final int currentMask = effectiveMask(currentSpan);
+        final int resizedMask = newSpan < currentSpan
+                ? currentMask & ((1 << newSpan) - 1)
+                : currentMask | (((1 << (newSpan - currentSpan)) - 1) << currentSpan);
+        final int normalizedMask = resizedMask == ((1 << newSpan) - 1) ? 0 : resizedMask;
+        return of(newSpan, normalizedMask);
+    }
+}

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -292,19 +292,34 @@
       </ul>
       <p>Encoder pages:</p>
       <ul>
-        <li><code>Channel</code>: engine, density, engine macro, mutation type</li>
+        <li><code>Channel</code>: primary phrase setup, pool shaping, and mutation controls</li>
         <li><code>Mixer</code>: melodic process transforms</li>
-        <li><code>User 1</code>: reserved for future melodic advanced controls</li>
-        <li><code>User 2</code>: selected or held step octave, gate, velocity, articulation</li>
+        <li><code>User 1</code>: secondary generator-shaping controls</li>
+        <li><code>User 2</code>: selected or held step properties</li>
       </ul>
       <p>Channel page details:</p>
       <ul>
         <li>Encoder 1: <code>Engine</code></li>
         <li><code>ALT + Encoder 1</code>: engine subtype / family when available</li>
         <li>Encoder 2: <code>Density</code></li>
-        <li>Encoder 3: engine-specific macro such as motion, contour, answer, movement, or jump</li>
+        <li><code>ALT + Encoder 2</code>: thin or fill the current phrase without regenerating it</li>
+        <li>Encoder 3: <code>Pool Oct</code> to shift the melodic pitch pool up or down by octaves</li>
         <li>Encoder 4: <code>Mutation Type</code></li>
         <li><code>ALT + Encoder 4</code>: mutation strength</li>
+      </ul>
+      <p><code>User 1</code> is the secondary generator-shaping page:</p>
+      <ul>
+        <li>Encoder 1: engine-specific motion or contour control such as motion, answer, movement, or jump</li>
+        <li>Encoder 2: <code>Tension</code></li>
+        <li>Encoder 3: <code>Legato</code>, which biases slide and gate behavior inside the generator</li>
+        <li>Encoder 4: recurrence span entry; hold it and use the step rows to draw the recurrence mask for the selected step</li>
+      </ul>
+      <p><code>User 2</code> is the per-step property page:</p>
+      <ul>
+        <li>Encoder 1: selected or held step octave offset</li>
+        <li>Encoder 2: selected or held step gate length</li>
+        <li>Encoder 3: selected or held step velocity</li>
+        <li>Encoder 4: selected or held step chance</li>
       </ul>
       <p>Melodic left-side buttons now align with the shared sequencer clip/edit workflow:</p>
       <ul>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -475,7 +475,9 @@
         <li><code>Default Root Key</code></li>
         <li><code>Default Scale</code></li>
         <li><code>Default Note Input Octave</code></li>
+        <li><code>Melodic Seed Mode</code></li>
         <li><code>Default Velocity Sensitivity</code></li>
+        <li><code>Melodic Fixed Seed</code></li>
         <li><code>Pad Brightness</code></li>
         <li><code>Pad Saturation</code></li>
         <li><code>Encoder touch reset</code></li>
@@ -486,6 +488,8 @@
         <li><code>On-screen action notifications</code></li>
       </ul>
       <p><code>Pad Brightness</code> and <code>Pad Saturation</code> interact with the Bitwig track colors used by <code>DRUM</code> and <code>PERFORM</code>, so the same settings can read differently across different project palettes.</p>
+      <p><code>Melodic Seed Mode</code> controls how <code>Melodic Step</code> chooses its initial generator seed when the controller session starts. <code>Random</code> starts each session from a new seed. <code>Fixed</code> starts from the configured <code>Melodic Fixed Seed</code> value, which makes the sequence of generated melodic phrases reproducible across reconnects or reloads. Each <code>Generate</code> press still advances forward from that starting point.</p>
+      <p>The melodic seed controls are grouped into their own <code>Generative control</code> preference section so they stay together in Bitwig's settings UI.</p>
     </section>
 
     <section class="section">

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicEngineTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicEngineTest.java
@@ -19,7 +19,7 @@ class MelodicEngineTest {
     void motifGeneratorIsDeterministicForSeed() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.45, 0.25, 0.1, 5, 0, 23L);
+                new MelodicGenerator.GenerateParameters(16, 0.45, 0.25, 0.1, 0.2, 5, 0, 0.0, 23L);
 
         final MelodicPattern a = new MotifGenerator().generate(context, parameters);
         final MelodicPattern b = new MotifGenerator().generate(context, parameters);
@@ -45,7 +45,7 @@ class MelodicEngineTest {
     void preserveRhythmMutationKeepsActiveMask() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.55, 0.35, 0.2, 5, 0, 9L);
+                new MelodicGenerator.GenerateParameters(16, 0.55, 0.35, 0.2, 0.2, 5, 0, 0.0, 9L);
         final MelodicPattern original = new MotifGenerator().generate(context, parameters);
 
         final MelodicPattern mutated = new MelodicMutator().mutate(original, context,
@@ -58,7 +58,7 @@ class MelodicEngineTest {
     void simplifyAndDensifyMoveDensityInExpectedDirection() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.4, 0.2, 0.1, 5, 0, 12L);
+                new MelodicGenerator.GenerateParameters(16, 0.4, 0.2, 0.1, 0.2, 5, 0, 0.0, 12L);
         final MelodicPattern original = new MotifGenerator().generate(context, parameters);
         final MelodicMutator mutator = new MelodicMutator();
 
@@ -75,7 +75,7 @@ class MelodicEngineTest {
     void preserveRhythmMutationActuallyChangesPitchMaterial() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.55, 0.35, 0.2, 5, 0, 9L);
+                new MelodicGenerator.GenerateParameters(16, 0.55, 0.35, 0.2, 0.2, 5, 0, 0.0, 9L);
         final MelodicPattern original = new MotifGenerator().generate(context, parameters);
 
         final MelodicPattern mutated = new MelodicMutator().mutate(original, context,
@@ -95,7 +95,7 @@ class MelodicEngineTest {
     void rollingGeneratorCreatesDenseConnectedPhrase() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.7, 0.25, 0.15, 6, 0, 31L);
+                new MelodicGenerator.GenerateParameters(16, 0.7, 0.25, 0.15, 0.2, 6, 0, 0.0, 31L);
 
         final MelodicPattern pattern = new RollingBassGenerator().generate(context, parameters);
 
@@ -111,7 +111,7 @@ class MelodicEngineTest {
     void rollingGeneratorUsesAtLeastThreePitches() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.72, 0.35, 1.0, 6, 0, 31L);
+                new MelodicGenerator.GenerateParameters(16, 0.72, 0.35, 1.0, 0.2, 6, 0, 0.0, 31L);
 
         final MelodicPattern pattern = new RollingBassGenerator().generate(context, parameters);
 
@@ -134,7 +134,7 @@ class MelodicEngineTest {
     void acidGeneratorLeavesPhraseSpace() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.45, 0.6, 0.15, 5, 0, 17L);
+                new MelodicGenerator.GenerateParameters(16, 0.45, 0.6, 0.15, 0.2, 5, 0, 0.0, 17L);
 
         final MelodicPattern pattern = new AcidGenerator().generate(context, parameters);
 
@@ -146,7 +146,7 @@ class MelodicEngineTest {
     void acidGeneratorUsesMoreThanOnePitch() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.52, 0.62, 1.0, 5, 0, 17L);
+                new MelodicGenerator.GenerateParameters(16, 0.52, 0.62, 1.0, 0.2, 5, 0, 0.0, 17L);
 
         final MelodicPattern pattern = new AcidGenerator().generate(context, parameters);
 
@@ -157,7 +157,7 @@ class MelodicEngineTest {
     void callResponseGeneratorAnswersTheCall() {
         final MelodicPhraseContext context = context();
         final MelodicGenerator.GenerateParameters parameters =
-                new MelodicGenerator.GenerateParameters(16, 0.5, 0.3, 0.6, 5, 0, 41L);
+                new MelodicGenerator.GenerateParameters(16, 0.5, 0.3, 0.6, 0.2, 5, 0, 0.0, 41L);
 
         final MelodicPattern pattern = new CallResponseGenerator().generate(context, parameters);
 

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicPatternTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/melodic/MelodicPatternTest.java
@@ -1,0 +1,30 @@
+package com.oikoaudio.fire.melodic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MelodicPatternTest {
+
+    @Test
+    void defaultRecurrenceMapsToBitwigSafeValues() {
+        final MelodicPattern.Step step = new MelodicPattern.Step(0, true, false, 48, 96,
+                0.8, false, false);
+
+        assertEquals(0, step.recurrenceLength());
+        assertEquals(0, step.recurrenceMask());
+        assertEquals(1, step.bitwigRecurrenceLength());
+        assertEquals(1, step.bitwigRecurrenceMask());
+    }
+
+    @Test
+    void fullMaskCollapsesBackToDefaultRecurrence() {
+        final MelodicPattern.Step step = new MelodicPattern.Step(0, true, false, 48, 96,
+                0.8, false, false).withRecurrence(4, 0b1111);
+
+        assertEquals(0, step.recurrenceLength());
+        assertEquals(0, step.recurrenceMask());
+        assertEquals(1, step.bitwigRecurrenceLength());
+        assertEquals(1, step.bitwigRecurrenceMask());
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/RecurrencePatternTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/sequence/RecurrencePatternTest.java
@@ -1,0 +1,46 @@
+package com.oikoaudio.fire.sequence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecurrencePatternTest {
+
+    @Test
+    void defaultPatternMapsToSafeBitwigValues() {
+        final RecurrencePattern pattern = RecurrencePattern.of(0, 0);
+
+        assertTrue(pattern.isDefault());
+        assertEquals(1, pattern.bitwigLength());
+        assertEquals(1, pattern.bitwigMask());
+        assertEquals(8, pattern.effectiveSpan());
+        assertEquals(0b11111111, pattern.effectiveMask(8));
+        assertEquals("Off", pattern.summary());
+    }
+
+    @Test
+    void spanGestureEntersRecurrenceFromDefaultState() {
+        final RecurrencePattern pattern = RecurrencePattern.of(0, 0).applySpanGesture(4);
+
+        assertEquals(4, pattern.length());
+        assertEquals(0b0001, pattern.mask());
+        assertEquals("4:0001", pattern.summary());
+    }
+
+    @Test
+    void repeatingCurrentSpanGestureClearsRecurrence() {
+        final RecurrencePattern pattern = RecurrencePattern.of(4, 0b0101).applySpanGesture(4);
+
+        assertTrue(pattern.isDefault());
+        assertEquals("Off", pattern.summary());
+    }
+
+    @Test
+    void togglingMaskNeverLeavesRecurrenceEmpty() {
+        final RecurrencePattern pattern = RecurrencePattern.of(4, 0b0001).toggledAt(0);
+
+        assertEquals(4, pattern.length());
+        assertEquals(0b0001, pattern.mask());
+    }
+}


### PR DESCRIPTION
## Main New Features

- Added melodic recurrence editing, including held-step targeting, top-row recurrence pad editing, recurrence span gestures, recurrence feedback, and supporting tests.
- Introduced a unified shared global pitch context for `Root Key`, `Scale`, and `Octave` across `NOTE`, `Chord Step`, `Melodic Step`, and `SHIFT+PERFORM`.
- Added melodic seed setting support and related preference plumbing.

## Workflow and Behavior Changes

- Reworked `Melodic Step` encoder layout and controls:
  - encoder 3 now controls pitch-pool octave center
  - `Alt+Encoder 3` edits shared root
  - engine macro/tension/legato/recurrence helper moved into a cleaner page layout
- Updated `NOTE` shortcuts to work with the shared pitch context:
  - `Pattern Up/Down` now changes shared octave
  - scale/root shortcuts are exposed more directly on the encoders
- Expanded `SHIFT+PERFORM` settings to edit shared `Root Key`, `Scale`, and `Octave`.
- Updated `Chord Step` interpretation workflow:
  - renamed `Cast` to `In Scale`
  - added shared `Scale` and `Root` shortcuts on the interpretation encoder
  - clarified how shared root/scale affect chord rendering
- Adjusted melodic generation/pattern behavior and related engine/test coverage.
- Updated docs and bundled help to reflect the new shared pitch model, recurrence workflow, melodic controls, and chord interpretation behavior.

## Fixes and Safety Improvements

- Prevented melodic pool octave/root changes from immediately rewriting notes in the selected clip.
- Fixed hold-pad / velocity editing behavior.
- Removed older mode-local/shared-state paths and aligned mode interactions around a single global pitch context.
- Added recurrence infrastructure tests and other regression coverage around melodic pattern behavior.