### PR TITLE
Akai Fire Oikontrol v2.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,32 @@
 
 This document now tracks intentional modifications made to the `bitwig-oikontrol` project.
 
+## 2.5.0 - Harmonic note input, step routing, and control-surface polish
+- Added a harmonic live `NOTE` submode with harmonic lattice layout, multi-note pad output, note-count selection, octave-span control, bass-column/full-field variants, and harmonic gliss support
+- Added live-note pitch-bend with spring-return, and toggle between `5th/8v` and `ScaleDeg` gliss modes
+- Moved `Chord Step` behind `STEP SEQ` so `NOTE` stays focused on live note input; pressing `STEP SEQ` now enters `Melodic Step`, then switches to `Chord Step` on the next press
+- Added `ALT + NOTE` and `SHIFT + Encoder 4` as direct live-layout shortcuts for collapsing note input to scale notes or switching harmonic layout variants
+- Added horizontal `Perform` orientation plus broader encoder-scaling cleanup, melodic step expression-page updates, and Bitwig 6-aligned scale naming/order
+- Updated tests and Fire documentation to match the new harmonic input, step-routing, and live-control workflows
+
+## 2.4.0 - Akai Fire shared pitch context and architecture rework
+- Added a unified shared musical context for `Root Key`, `Scale`, and `Octave` across live `NOTE`, `Chord Step`, `Melodic Step`, and `SHIFT + PERFORM`
+- Added melodic recurrence editing with held-step targeting, top-row recurrence gestures, recurrence feedback, and supporting tests
+- Reworked Fire mode architecture by separating live note play from chord sequencing, extracting dedicated controllers/helpers, and simplifying duplicated framework code
+- Expanded `SHIFT + PERFORM` overview editing for shared pitch controls and refreshed note/chord workflows to use the shared context consistently
+- Updated `Chord Step` interpretation and melodic generator workflows, plus docs and bundled help, to reflect the new shared-pitch model
+
+## 2.3.1 - Akai Fire selected clip sync fix
+- Fixed bidirectional sync of selected clip state so shared clip selection follows the actual Bitwig `isSelected()` state instead of the controller cursor index
+- Updated chord and melodic step refresh paths to trust an already selected clip before falling back to the playing clip
+- Prevented passive refresh from needlessly reselecting clip slots
+
+## 2.3.0 - Akai Fire shared sequencer clip row and step-workflow polish
+- Added a shared sequencer clip row across Drum, Chord Step, and Melodic Step workflows
+- Polished `Melodic Step` generation and editing behavior, including safer held-step and accent interactions
+- Added reusable accent-latch and clip-row helper logic to stabilize sequencer behavior across modes
+- Fixed browser-selection behavior and refreshed documentation for the updated Fire sequencing workflow
+
 ## 2.2.0 - Akai Fire shared pitch and safer performance workflows
 - Added live NOTE `Pitch Gliss` with held-note retuning and a dedicated velocity response model based on `Velocity Sensitivity` and `Default Velocity`
 - Added shared global `Root Key` and `Scale` across live NOTE, Chord Step, and the latched `SHIFT + PERFORM` `Settings` page

--- a/doc/akai-fire-controller-layout.md
+++ b/doc/akai-fire-controller-layout.md
@@ -150,8 +150,9 @@ Drum grid resolution is now adjusted from the `SELECT` encoder when its role is 
 | Pad matrix | `16x4` isomorphic note grid |
 | Pad LEDs | Root, in-scale, and out-of-scale feedback |
 | `NOTE` | Cycle note layout family |
-| `STEP SEQ` | Enter current note-step sub-mode |
-| `SHIFT + STEP SEQ` | Cycle note-step sub-mode and enter it |
+| `ALT + NOTE` | Toggle live-note layout shortcut (`Chromatic` / `In Key`, or harmonic layout variant) |
+| `STEP SEQ` | Enter `Melodic Step`; when already there, press again to switch to `Chord Step` |
+| `SHIFT + STEP SEQ` | Accent mode in `Melodic Step` |
 | `BANK LEFT/RIGHT` | Octave down / up |
 | `PATTERN UP/DOWN` | Octave up / down |
 | `SHIFT + PATTERN UP/DOWN` | Root up / down |
@@ -167,6 +168,7 @@ In live NOTE mode:
 - Encoder 2 is `Pitch Gliss`
 - Encoder 3 adjusts `Velocity Sensitivity`
 - `SHIFT + Encoder 3` adjusts `Default Velocity`
+- `SHIFT + Encoder 4` toggles the local live-note layout
 - Encoder 4 adjusts the shared `Scale`
 - `ALT + Encoder 4` adjusts the shared `Root Key`
 - `PATTERN UP/DOWN` adjusts the shared `Octave`
@@ -180,20 +182,9 @@ In live NOTE mode:
 | `User 1` | Aftertouch | Pressure | Timbre | Pitch expression |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
 
-## Note-Step Sub-Modes
-
-The current note-step sub-modes are:
-
-| Sub-mode | Status | Notes |
-| --- | --- | --- |
-| `Chord Step` | Implemented | Main note-step mode under `NOTE` |
-| `Clip Step Record` | Placeholder | Still deferred |
-
-`Melodic Step` is not a NOTE sub-mode. It is entered directly from `DRUM` via `STEP SEQ`.
-
 ## Chord Step
 
-`Chord Step` repurposes the `NOTE` surface into a chord-and-step editor.
+`Chord Step` is the second `STEP SEQ` surface after `Melodic Step`.
 
 It uses the shared `Root Key`, `Scale`, and `Octave` from live NOTE input and `SHIFT + PERFORM`. Changing pitch context in one of those places updates all of them.
 
@@ -213,8 +204,8 @@ It uses the shared `Root Key`, `Scale`, and `Octave` from live NOTE input and `S
 | Tap lit step | Remove chord from that step |
 | Hold step pad(s) + tap chord pad | Rewrite held steps with that chord |
 | Tap chord pad with no held step | Audition chord, if enabled |
-| `STEP SEQ` | Toggle `As Is` / `In Scale` rendering |
-| `SHIFT + STEP SEQ` | Cycle note-step sub-mode |
+| `STEP SEQ` | Return to `Melodic Step` |
+| `SHIFT + STEP SEQ` | Reserved for melodic-step accent handling |
 | `PATTERN UP/DOWN` | Page the visible chord-step window |
 | `ALT + BANK LEFT/RIGHT` | Halve / double clip length |
 | Hold step(s) + `BANK LEFT/RIGHT` | Experimental micro-timing nudge for held chord material |

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -178,27 +178,24 @@ Quick start:
 Useful live-note controls:
 
 - `PATTERN UP/DOWN`: shared octave
+- `ALT + NOTE`: toggle the local live-note layout shortcut
+- `SHIFT + Encoder 4`: local layout (`Chromatic` / `In Key` in melodic note mode)
 - `Encoder 4`: shared scale
 - `ALT + Encoder 4`: shared root
 - `MUTE_1`: sustain
 - `MUTE_2`: sostenuto
 
-The current note-step sub-modes are:
-
-- `Chord Step`
-- `Clip Step Record` placeholder
-
-`Melodic Step` is a separate top-level mode entered from `STEP SEQ`, not a NOTE sub-mode.
+`Melodic Step` and `Chord Step` now live behind `STEP SEQ` rather than under `NOTE`.
 
 Quick start:
 
 1. Enter `NOTE`.
 2. Play notes directly on the pad grid.
 3. Press `NOTE` again to move between the primary note-family surfaces.
-4. Use `PATTERN UP/DOWN` for shared octave, `Encoder 4` for shared scale, `ALT + Encoder 4` for shared root, and the Channel page for `Pitch Gliss` and live velocity response.
+4. Use `ALT + NOTE` or `SHIFT + Encoder 4` for the local layout, `PATTERN UP/DOWN` for shared octave, `Encoder 4` for shared scale, `ALT + Encoder 4` for shared root, and the Channel page for `Pitch Gliss` and live velocity response.
 
 ### Chord Step workflow
-To get to this mode from the Note live input mode, press the `NOTE` controller button. From any other mode, press the `NOTE` button twice to cycle past the Note input mode.
+Press `STEP SEQ` once to enter `Melodic Step`, then press `STEP SEQ` again to switch to `Chord Step`. Press `NOTE` to return to live note input.
 
 `Chord Step` is the chord-oriented note-step workflow.
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -654,6 +654,21 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (!pressed) {
             return;
         }
+        if (modeState.activeMode() == Mode.NOTE_PLAY && isGlobalAltHeld() && !notePlayMode.isHarmonicNoteSubMode()) {
+            notePlayMode.toggleSurfaceVariant();
+            return;
+        }
+        if (modeState.activeMode() == Mode.NOTE_PLAY && !isGlobalAltHeld()) {
+            if (notePlayMode.isHarmonicNoteSubMode()) {
+                modeState.handleNotePressed(true);
+                switchActiveMode();
+                notifyAction("Mode", "Chord Step");
+            } else {
+                notePlayMode.cycleNoteSubMode();
+                notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
+            }
+            return;
+        }
         switch (modeState.handleNotePressed(isGlobalAltHeld())) {
             case TOGGLE_NOTE_VARIANT -> {
                 notePlayMode.cycleNoteSubMode();
@@ -665,6 +680,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
                 notifyAction("Mode", "Chord Step");
             }
             case SWITCH_TO_NOTE_PLAY -> {
+                notePlayMode.resetNoteSubMode();
                 switchActiveMode();
                 notifyAction("Mode", "Note");
             }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -704,15 +704,18 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         }
         if (modeState.activeMode() == Mode.PERFORM) {
             final boolean leavingSettings = performMode.isSettingsMode();
-            performMode.exitOverview();
             if (leavingSettings) {
-                notifyAction("Mode", "Perform");
+                performMode.exitOverview();
+                notifyAction("Mode", performMode.modeLabel());
+            } else {
+                performMode.toggleOrientation();
+                notifyAction("Mode", performMode.modeLabel());
             }
             return;
         }
         modeState.activatePerform();
         switchActiveMode();
-        notifyAction("Mode", "Perform");
+        notifyAction("Mode", performMode.modeLabel());
     }
 
     private void togglePlay(final boolean pressed) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -654,6 +654,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (!pressed) {
             return;
         }
+        if (modeState.activeMode() == Mode.NOTE_PLAY && isGlobalAltHeld()) {
+            notePlayMode.toggleLiveLayoutShortcut();
+            return;
+        }
         if (modeState.activeMode() == Mode.CHORD_STEP) {
             if (isGlobalAltHeld()) {
                 chordStepMode.toggleSurfaceVariant();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -655,7 +655,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         switch (modeState.handleNotePressed(isGlobalAltHeld())) {
-            case TOGGLE_NOTE_VARIANT -> notePlayMode.toggleSurfaceVariant();
+            case TOGGLE_NOTE_VARIANT -> {
+                notePlayMode.cycleNoteSubMode();
+                notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
+            }
             case TOGGLE_CHORD_VARIANT -> chordStepMode.toggleSurfaceVariant();
             case SWITCH_TO_CHORD_STEP -> {
                 switchActiveMode();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -858,10 +858,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private int resolveDefaultSharedScaleIndex() {
         return switch (getDefaultScalePreference()) {
-            case FireControlPreferences.DEFAULT_SCALE_MAJOR -> findScaleIndex("Ionan (Major)", 1);
-            case FireControlPreferences.DEFAULT_SCALE_MINOR -> findScaleIndex("Aeolian (Minor)", 2);
+            case FireControlPreferences.DEFAULT_SCALE_MAJOR -> findScaleIndex("Major", 1);
+            case FireControlPreferences.DEFAULT_SCALE_MINOR -> findScaleIndex("Minor", 2);
             case FireControlPreferences.DEFAULT_SCALE_HARMONIC_MINOR -> findScaleIndex("Harmonic Minor", 2);
-            case FireControlPreferences.DEFAULT_SCALE_MELODIC_MINOR -> findScaleIndex("Melodic Minor (ascending)", 2);
+            case FireControlPreferences.DEFAULT_SCALE_MELODIC_MINOR -> findScaleIndex("Jazz Minor", 2);
             case FireControlPreferences.DEFAULT_SCALE_MINOR_PENTATONIC -> findScaleIndex("Minor Pentatonic", 2);
             case FireControlPreferences.DEFAULT_SCALE_DORIAN -> findScaleIndex("Dorian", 2);
             case FireControlPreferences.DEFAULT_SCALE_MIXOLYDIAN -> findScaleIndex("Mixolydian", 1);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -654,52 +654,51 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (!pressed) {
             return;
         }
-        if (modeState.activeMode() == Mode.NOTE_PLAY && isGlobalAltHeld() && !notePlayMode.isHarmonicNoteSubMode()) {
-            notePlayMode.toggleSurfaceVariant();
+        if (modeState.activeMode() == Mode.CHORD_STEP) {
+            if (isGlobalAltHeld()) {
+                chordStepMode.toggleSurfaceVariant();
+                return;
+            }
+            modeState.activateNotePlay();
+            switchActiveMode();
+            notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
             return;
         }
-        if (modeState.activeMode() == Mode.NOTE_PLAY && !isGlobalAltHeld()) {
-            if (notePlayMode.isHarmonicNoteSubMode()) {
-                modeState.handleNotePressed(true);
-                switchActiveMode();
-                notifyAction("Mode", "Chord Step");
-            } else {
-                notePlayMode.cycleNoteSubMode();
-                notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
-            }
+        if (modeState.activeMode() != Mode.NOTE_PLAY) {
+            modeState.activateNotePlay();
+            switchActiveMode();
+            notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
             return;
         }
-        switch (modeState.handleNotePressed(isGlobalAltHeld())) {
-            case TOGGLE_NOTE_VARIANT -> {
-                notePlayMode.cycleNoteSubMode();
-                notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
-            }
-            case TOGGLE_CHORD_VARIANT -> chordStepMode.toggleSurfaceVariant();
-            case SWITCH_TO_CHORD_STEP -> {
-                switchActiveMode();
-                notifyAction("Mode", "Chord Step");
-            }
-            case SWITCH_TO_NOTE_PLAY -> {
-                notePlayMode.resetNoteSubMode();
-                switchActiveMode();
-                notifyAction("Mode", "Note");
-            }
-        }
+        notePlayMode.cycleNoteSubMode();
+        notifyAction("Mode", notePlayMode.currentNoteSubModeLabel());
     }
 
     private void handleStepPressed(final boolean pressed) {
-        if (modeState.shouldIgnoreTopLevelStepPress(isGlobalShiftHeld(), isGlobalAltHeld())) {
-            return;
-        }
-        if (modeState.isChordStepActive()) {
-            return;
-        }
         if (modeState.activeMode() == Mode.MELODIC_STEP) {
             if (!pressed && suppressNextMelodicStepRelease) {
                 suppressNextMelodicStepRelease = false;
                 return;
             }
+            if (!isGlobalShiftHeld() && !isGlobalAltHeld()) {
+                if (pressed) {
+                    modeState.activateChordStep();
+                    switchActiveMode();
+                    notifyAction("Mode", "Chord Step");
+                }
+                return;
+            }
             melodicStepMode.handleStepButton(pressed);
+            return;
+        }
+        if (modeState.activeMode() == Mode.CHORD_STEP) {
+            if (!pressed || isGlobalShiftHeld() || isGlobalAltHeld()) {
+                return;
+            }
+            enterMelodicStepMode();
+            return;
+        }
+        if (modeState.shouldIgnoreTopLevelStepPress(isGlobalShiftHeld(), isGlobalAltHeld())) {
             return;
         }
         if (!pressed) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
@@ -9,13 +9,6 @@ public final class TopLevelModeState {
         PERFORM
     }
 
-    public enum NoteButtonResult {
-        TOGGLE_NOTE_VARIANT,
-        TOGGLE_CHORD_VARIANT,
-        SWITCH_TO_NOTE_PLAY,
-        SWITCH_TO_CHORD_STEP
-    }
-
     private Mode activeMode = Mode.NOTE_PLAY;
     private Mode previousNonStepMode = Mode.NOTE_PLAY;
 
@@ -31,23 +24,12 @@ public final class TopLevelModeState {
         activeMode = Mode.PERFORM;
     }
 
-    public NoteButtonResult handleNotePressed(final boolean altHeld) {
-        if (activeMode == Mode.NOTE_PLAY) {
-            if (altHeld) {
-                activeMode = Mode.CHORD_STEP;
-                return NoteButtonResult.SWITCH_TO_CHORD_STEP;
-            }
-            return NoteButtonResult.TOGGLE_NOTE_VARIANT;
-        }
-        if (activeMode == Mode.CHORD_STEP) {
-            if (altHeld) {
-                return NoteButtonResult.TOGGLE_CHORD_VARIANT;
-            }
-            activeMode = Mode.NOTE_PLAY;
-            return NoteButtonResult.SWITCH_TO_NOTE_PLAY;
-        }
+    public void activateNotePlay() {
         activeMode = Mode.NOTE_PLAY;
-        return NoteButtonResult.SWITCH_TO_NOTE_PLAY;
+    }
+
+    public void activateChordStep() {
+        activeMode = Mode.CHORD_STEP;
     }
 
     public boolean shouldIgnoreTopLevelStepPress(final boolean shiftHeld, final boolean altHeld) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
@@ -34,10 +34,10 @@ public final class TopLevelModeState {
     public NoteButtonResult handleNotePressed(final boolean altHeld) {
         if (activeMode == Mode.NOTE_PLAY) {
             if (altHeld) {
-                return NoteButtonResult.TOGGLE_NOTE_VARIANT;
+                activeMode = Mode.CHORD_STEP;
+                return NoteButtonResult.SWITCH_TO_CHORD_STEP;
             }
-            activeMode = Mode.CHORD_STEP;
-            return NoteButtonResult.SWITCH_TO_CHORD_STEP;
+            return NoteButtonResult.TOGGLE_NOTE_VARIANT;
         }
         if (activeMode == Mode.CHORD_STEP) {
             if (altHeld) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/ContinuousEncoderScaler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/ContinuousEncoderScaler.java
@@ -6,7 +6,8 @@ package com.oikoaudio.fire.control;
 public final class ContinuousEncoderScaler {
     public enum Profile {
         STRONG(2, 4),
-        GENTLE(2, 3);
+        GENTLE(2, 3),
+        SOFT(1, 2);
 
         private final int mediumMultiplier;
         private final int fastMultiplier;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/ContinuousEncoderScaler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/ContinuousEncoderScaler.java
@@ -1,0 +1,76 @@
+package com.oikoaudio.fire.control;
+
+/**
+ * Scales rapid continuous encoder turns so slow turns stay precise while fast turns travel further.
+ */
+public final class ContinuousEncoderScaler {
+    public enum Profile {
+        STRONG(2, 4),
+        GENTLE(2, 3);
+
+        private final int mediumMultiplier;
+        private final int fastMultiplier;
+
+        Profile(final int mediumMultiplier, final int fastMultiplier) {
+            this.mediumMultiplier = mediumMultiplier;
+            this.fastMultiplier = fastMultiplier;
+        }
+    }
+
+    private static final long FAST_WINDOW_NS = 45_000_000L;
+    private static final long MEDIUM_WINDOW_NS = 100_000_000L;
+    private static final long STREAK_RESET_NS = 220_000_000L;
+
+    private final Profile profile;
+    private long lastTurnNs = Long.MIN_VALUE;
+    private int lastDirection = 0;
+    private int streak = 0;
+
+    public ContinuousEncoderScaler() {
+        this(Profile.STRONG);
+    }
+
+    public ContinuousEncoderScaler(final Profile profile) {
+        this.profile = profile;
+    }
+
+    public int scale(final int inc, final boolean fine) {
+        if (inc == 0) {
+            return 0;
+        }
+        if (fine) {
+            reset();
+            return inc;
+        }
+
+        final long now = System.nanoTime();
+        final int direction = Integer.signum(inc);
+        final long delta = lastTurnNs == Long.MIN_VALUE ? Long.MAX_VALUE : now - lastTurnNs;
+
+        if (direction != lastDirection || delta > STREAK_RESET_NS) {
+            streak = 1;
+        } else {
+            streak++;
+        }
+
+        lastTurnNs = now;
+        lastDirection = direction;
+
+        final int magnitude = Math.abs(inc);
+        final int multiplier;
+        if (delta <= FAST_WINDOW_NS && streak >= 3) {
+            multiplier = profile.fastMultiplier;
+        } else if (delta <= MEDIUM_WINDOW_NS && streak >= 2) {
+            multiplier = profile.mediumMultiplier;
+        } else {
+            multiplier = 1;
+        }
+        return direction * magnitude * multiplier;
+    }
+
+    public void reset() {
+        lastTurnNs = Long.MIN_VALUE;
+        lastDirection = 0;
+        streak = 0;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/TouchEncoder.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/TouchEncoder.java
@@ -1,5 +1,6 @@
 package com.oikoaudio.fire.control;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
@@ -45,6 +46,35 @@ public class TouchEncoder {
 	public void bindEncoder(final Layer layer, final IntConsumer action) {
 		layer.bind(encoder, createIncrementBinder(action));
 	}
+
+    public void bindContinuousEncoder(final Layer layer, final BooleanSupplier fineSupplier, final IntConsumer action) {
+        bindContinuousEncoder(layer, fineSupplier, ContinuousEncoderScaler.Profile.STRONG, action);
+    }
+
+    public void bindContinuousEncoder(final Layer layer, final BooleanSupplier fineSupplier,
+                                      final ContinuousEncoderScaler.Profile profile,
+                                      final IntConsumer action) {
+        final ContinuousEncoderScaler scaler = new ContinuousEncoderScaler(profile);
+        layer.bind(encoder, createIncrementBinder(inc -> {
+            final int effective = scaler.scale(inc, fineSupplier.getAsBoolean());
+            if (effective != 0) {
+                action.accept(effective);
+            }
+        }));
+    }
+
+    public void bindThresholdedEncoder(final Layer layer, final int normalThreshold, final int fineThreshold,
+                                       final BooleanSupplier fineSupplier, final IntConsumer action) {
+        final EncoderStepAccumulator normalAccumulator = new EncoderStepAccumulator(normalThreshold);
+        final EncoderStepAccumulator fineAccumulator = new EncoderStepAccumulator(fineThreshold);
+        layer.bind(encoder, createIncrementBinder(inc -> {
+            final EncoderStepAccumulator accumulator = fineSupplier.getAsBoolean() ? fineAccumulator : normalAccumulator;
+            final int effective = accumulator.consume(inc);
+            if (effective != 0) {
+                action.accept(effective);
+            }
+        }));
+    }
 
 	public RelativeHardwarControlBindable createIncrementBinder(final IntConsumer consumer) {
 		return host.createRelativeHardwareControlStepTarget(//

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -2177,12 +2177,12 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                         noteAccessSlot(NoteStepAccess.PITCH)
                 }));
         banks.put(EncoderMode.USER_2, new EncoderBank(
-                "1: Octave\n2: Gate Len\n3: Velocity\n4: Chance",
+                "1: Gate Len\n2: Chance\n3: Vel Spread\n4: Repeat",
                 new EncoderSlotBinding[]{
-                        stepValueSlot(this::adjustSelectedOctave, () -> stepDetail("Oct")),
-                        stepValueSlot(this::adjustSelectedGate, () -> stepDetail("Gate Len")),
-                        stepValueSlot(this::adjustSelectedVelocity, () -> stepDetail("Velocity")),
-                        stepValueSlot(this::adjustSelectedChance, () -> stepDetail("Chance"))
+                        noteAccessSlot(NoteStepAccess.DURATION),
+                        noteAccessSlot(NoteStepAccess.CHANCE),
+                        noteAccessSlot(NoteStepAccess.VELOCITY_SPREAD),
+                        noteAccessSlot(NoteStepAccess.REPEATS)
                 }));
         return new EncoderBankLayout(banks);
     }
@@ -2309,10 +2309,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         };
     }
 
-    private String stepDetail(final String label) {
-        return "%s S%d".formatted(label, selectedStep + 1);
-    }
-
     private EncoderSlotBinding poolContextSlot() {
         return new EncoderSlotBinding() {
             @Override
@@ -2387,7 +2383,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private EncoderSlotBinding stepValueSlot(final java.util.function.IntConsumer adjuster,
-                                             final java.util.function.Supplier<String> label) {
+                                             final String label) {
         return new EncoderSlotBinding() {
             @Override
             public double stepSize() {
@@ -2400,7 +2396,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld, adjuster::accept);
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
-                        oled.valueInfo("Step", label.get());
+                        oled.valueInfo(label, "Step %d".formatted(selectedStep + 1));
                     } else {
                         oled.clearScreenDelayed();
                     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -20,6 +20,7 @@ import com.oikoaudio.fire.AkaiFireOikontrolExtension;
 import com.oikoaudio.fire.NoteAssign;
 import com.oikoaudio.fire.control.BiColorButton;
 import com.oikoaudio.fire.control.EncoderStepAccumulator;
+import com.oikoaudio.fire.control.ContinuousEncoderScaler;
 import com.oikoaudio.fire.control.TouchEncoder;
 import com.oikoaudio.fire.display.OledDisplay;
 import com.oikoaudio.fire.lights.BiColorLightState;
@@ -32,6 +33,7 @@ import com.oikoaudio.fire.control.MixerEncoderProfile;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
 import com.oikoaudio.fire.sequence.NoteClipAvailability;
 import com.oikoaudio.fire.sequence.NoteClipCursorRefresher;
+import com.oikoaudio.fire.sequence.NoteStepAccess;
 import com.oikoaudio.fire.sequence.RecurrencePattern;
 import com.oikoaudio.fire.sequence.SelectedClipSlotObserver;
 import com.oikoaudio.fire.sequence.SelectedClipSlotState;
@@ -67,8 +69,8 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     private static final int MAX_CLIP_LENGTH_BEATS = (int) (STEP_COUNT * STEP_LENGTH);
     private static final int DEFAULT_VELOCITY = 96;
     private static final double DEFAULT_GATE = 0.8;
-    private static final int ENGINE_ENCODER_THRESHOLD = 3;
-    private static final int MUTATION_MODE_ENCODER_THRESHOLD = 3;
+    private static final int ENGINE_ENCODER_THRESHOLD = 5;
+    private static final int MUTATION_MODE_ENCODER_THRESHOLD = 5;
     private static final int AUDITION_VELOCITY = 96;
 
     private final AkaiFireOikontrolExtension driver;
@@ -2160,18 +2162,19 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
         banks.put(EncoderMode.MIXER, new EncoderBank(
                 "1: Length\n2: Mirror\n3: Reverse\n4: Invert",
                 new EncoderSlotBinding[]{
-                        actionSlot("Length", this::adjustLengthProcess),
-                        actionSlot("Mirror", this::adjustMirrorProcess),
-                        actionSlot("Reverse", this::adjustReverseProcess),
-                        actionSlot("Invert", this::adjustInvertProcess)
+                        alternateActionSlot("Length", this::adjustLengthProcess, this::channelShapeLabel, this::adjustChannelShape),
+                        alternateActionSlot("Mirror", this::adjustMirrorProcess, () -> "Tension", this::adjustTension),
+                        alternateActionSlot("Reverse", this::adjustReverseProcess, () -> "Legato", this::adjustLegato),
+                        alternateActionSlot("Invert", this::adjustInvertProcess, () -> "Span via Row",
+                                this::showRecurrenceEditInfo)
                 }));
         banks.put(EncoderMode.USER_1, new EncoderBank(
-                "1: Motion\n2: Tension\n3: Legato\n4: Span via Row",
+                "1: Velocity\n2: Pressure\n3: Timbre\n4: Pitch",
                 new EncoderSlotBinding[]{
-                        valueSlot(this::adjustChannelShape, this::channelShapeLabel),
-                        valueSlot(this::adjustTension, () -> "Tension"),
-                        valueSlot(this::adjustLegato, () -> "Legato"),
-                        actionSlot("Span via Row", this::showRecurrenceEditInfo)
+                        noteAccessSlot(NoteStepAccess.VELOCITY),
+                        noteAccessSlot(NoteStepAccess.PRESSURE),
+                        noteAccessSlot(NoteStepAccess.TIMBRE),
+                        noteAccessSlot(NoteStepAccess.PITCH)
                 }));
         banks.put(EncoderMode.USER_2, new EncoderBank(
                 "1: Octave\n2: Gate Len\n3: Velocity\n4: Chance",
@@ -2191,7 +2194,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
     }
 
     private EncoderSlotBinding engineSlot() {
-        final EncoderStepAccumulator accumulator = new EncoderStepAccumulator(ENGINE_ENCODER_THRESHOLD);
         return new EncoderSlotBinding() {
             @Override
             public double stepSize() {
@@ -2201,19 +2203,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             @Override
             public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
                              final int slotIndex) {
-                encoder.bindEncoder(layer, inc -> {
-                    final int steps = accumulator.consume(inc);
-                    if (steps == 0) {
-                        return;
-                    }
-                    if (driver.isGlobalAltHeld()) {
-                        cycleGeneratorSubtype(steps > 0 ? 1 : -1);
-                    } else if (steps > 0) {
-                        cycleGenerator(1);
-                    } else {
-                        cycleGenerator(-1);
-                    }
-                });
+                encoder.bindThresholdedEncoder(layer, ENGINE_ENCODER_THRESHOLD, ENGINE_ENCODER_THRESHOLD * 2,
+                        driver::isGlobalShiftHeld, steps -> {
+                            if (driver.isGlobalAltHeld()) {
+                                cycleGeneratorSubtype(steps > 0 ? 1 : -1);
+                            } else if (steps > 0) {
+                                cycleGenerator(1);
+                            } else {
+                                cycleGenerator(-1);
+                            }
+                        });
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
                         if (driver.isGlobalAltHeld()) {
@@ -2222,7 +2221,6 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                             oled.valueInfo(view.label, generator.label);
                         }
                     } else {
-                        accumulator.reset();
                         oled.clearScreenDelayed();
                     }
                 });
@@ -2232,6 +2230,8 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
 
     private EncoderSlotBinding mutationModeSlot() {
         final EncoderStepAccumulator accumulator = new EncoderStepAccumulator(MUTATION_MODE_ENCODER_THRESHOLD);
+        final EncoderStepAccumulator fineAccumulator = new EncoderStepAccumulator(MUTATION_MODE_ENCODER_THRESHOLD * 2);
+        final ContinuousEncoderScaler altScaler = new ContinuousEncoderScaler();
         return new EncoderSlotBinding() {
             @Override
             public double stepSize() {
@@ -2243,11 +2243,16 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                              final int slotIndex) {
                 encoder.bindEncoder(layer, inc -> {
                     if (driver.isGlobalAltHeld()) {
-                        handler.recordTouchAdjustment(slotIndex, Math.abs(inc));
-                        adjustMutateIntensity(inc);
+                        final int effective = altScaler.scale(inc, driver.isGlobalShiftHeld());
+                        if (effective != 0) {
+                            handler.recordTouchAdjustment(slotIndex, Math.abs(effective));
+                            adjustMutateIntensity(effective);
+                        }
                         return;
                     }
-                    final int steps = accumulator.consume(inc);
+                    final EncoderStepAccumulator activeAccumulator =
+                            driver.isGlobalShiftHeld() ? fineAccumulator : accumulator;
+                    final int steps = activeAccumulator.consume(inc);
                     if (steps > 0) {
                         cycleMutationMode(1);
                     } else if (steps < 0) {
@@ -2263,6 +2268,8 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                         }
                     } else {
                         accumulator.reset();
+                        fineAccumulator.reset();
+                        altScaler.reset();
                         oled.clearScreenDelayed();
                     }
                 });
@@ -2349,7 +2356,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             @Override
             public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
                              final int slotIndex) {
-                encoder.bindEncoder(layer, adjuster::accept);
+                encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld, adjuster::accept);
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
                         oled.valueInfo(view.label, label.get());
@@ -2390,7 +2397,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             @Override
             public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
                              final int slotIndex) {
-                encoder.bindEncoder(layer, adjuster::accept);
+                encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld, adjuster::accept);
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
                         oled.valueInfo("Step", label.get());
@@ -2421,7 +2428,7 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                 parameter.name().markInterested();
                 parameter.displayedValue().markInterested();
                 parameter.value().markInterested();
-                encoder.bindEncoder(layer, inc -> {
+                encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld, inc -> {
                     MixerEncoderProfile.adjustParameter(parameter, driver.isGlobalShiftHeld(), inc);
                     oled.valueInfo(label, parameter.displayedValue().get());
                 });
@@ -2454,6 +2461,56 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
                         oled.clearScreenDelayed();
                     }
                 });
+            }
+        };
+    }
+
+    private EncoderSlotBinding alternateActionSlot(final String primaryLabel, final java.util.function.IntConsumer primaryAdjuster,
+                                                   final java.util.function.Supplier<String> alternateLabel,
+                                                   final java.util.function.IntConsumer alternateAdjuster) {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return MixerEncoderProfile.STEP_SIZE;
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                final ContinuousEncoderScaler altScaler = new ContinuousEncoderScaler();
+                encoder.bindEncoder(layer, inc -> {
+                    if (driver.isGlobalAltHeld()) {
+                        final int effective = altScaler.scale(inc, driver.isGlobalShiftHeld());
+                        if (effective != 0) {
+                            alternateAdjuster.accept(effective);
+                        }
+                    } else {
+                        primaryAdjuster.accept(inc);
+                    }
+                });
+                encoder.bindTouched(layer, touched -> {
+                    if (touched) {
+                        oled.valueInfo(view.label, driver.isGlobalAltHeld() ? alternateLabel.get() : primaryLabel);
+                    } else {
+                        altScaler.reset();
+                        oled.clearScreenDelayed();
+                    }
+                });
+            }
+        };
+    }
+
+    private EncoderSlotBinding noteAccessSlot(final NoteStepAccess access) {
+        return new EncoderSlotBinding() {
+            @Override
+            public double stepSize() {
+                return access.getResolution();
+            }
+
+            @Override
+            public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
+                             final int slotIndex) {
+                handler.bindNoteAccess(layer, encoder, slotIndex, access);
             }
         };
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/HarmonicLatticeLayout.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/HarmonicLatticeLayout.java
@@ -2,39 +2,31 @@ package com.oikoaudio.fire.note;
 
 import com.bitwig.extensions.framework.MusicalScale;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 final class HarmonicLatticeLayout implements LiveNoteLayout {
-    static final int[] GRID_SPANS = {7, 14, 21};
-    static final int MIN_OCTAVE_REACH = 1;
-    static final int MAX_OCTAVE_REACH = 3;
+    static final int[] NOTE_COUNTS = {1, 2, 3};
 
     private static final int PAD_COUNT = 64;
     private static final int PAD_COLUMNS = 16;
     private static final int PAD_ROWS = 4;
     private static final int BASS_COLUMNS = 2;
-    private static final int[] ROW_FINE_PHASES = {0, 2, 4, 6};
 
     private final MusicalScale scale;
     private final int rootNote;
     private final int octave;
-    private final int gridSpan;
-    private final int octaveReach;
+    private final int noteCount;
+    private final int octaveSpan;
     private final boolean bassColumnsEnabled;
     private final int glissSteps;
     private final int scaleDegreeCount;
 
     HarmonicLatticeLayout(final MusicalScale scale, final int rootNote, final int octave,
-                          final int gridSpan, final int octaveReach,
+                          final int noteCount, final int octaveSpan,
                           final boolean bassColumnsEnabled, final int glissSteps) {
         this.scale = scale;
         this.rootNote = rootNote;
         this.octave = octave;
-        this.gridSpan = gridSpan;
-        this.octaveReach = octaveReach;
+        this.noteCount = noteCount;
+        this.octaveSpan = octaveSpan;
         this.bassColumnsEnabled = bassColumnsEnabled;
         this.glissSteps = glissSteps;
         this.scaleDegreeCount = detectScaleDegreeCount(scale, rootNote);
@@ -71,42 +63,33 @@ final class HarmonicLatticeLayout implements LiveNoteLayout {
 
     private int[] bassNotesForPad(final int column, final int rowFromBottom) {
         final int bassIndex = rowFromBottom * BASS_COLUMNS + column;
-        final int bassNote = clampMidi(resolveTertianSeriesMidi(bassIndex, octave));
+        final int bassNote = clampMidi(resolveRegisteredRunMidi(bassIndex, octave));
         return bassNote < 0 ? new int[0] : new int[]{bassNote};
     }
 
     private int[] harmonicNotesForPad(final int harmonicColumn, final int rowFromBottom) {
-        final int anchorSeriesIndex = harmonicColumn + glissSteps;
-        final int rowPhase = ROW_FINE_PHASES[Math.max(0, Math.min(ROW_FINE_PHASES.length - 1, rowFromBottom))];
+        final int startIndex = harmonicColumn - rowFromBottom * 2 + glissSteps;
         final int rowBaseOctave = octave + rowFromBottom;
-        final Set<Integer> candidates = new LinkedHashSet<>();
-        for (int candidateIndex = 0; ; candidateIndex++) {
-            final int fineIndex = rowPhase + candidateIndex * 2;
-            if (fineIndex >= gridSpan) {
-                break;
-            }
-            final int octaveLayer = fineIndex / 7;
-            if (octaveLayer >= octaveReach) {
-                break;
-            }
-            final int midiNote = clampMidi(resolveTertianSeriesMidi(anchorSeriesIndex + candidateIndex,
-                    rowBaseOctave + octaveLayer));
-            if (midiNote >= 0) {
-                candidates.add(midiNote);
+        final int[] notes = new int[noteCount * octaveSpan];
+        int out = 0;
+        for (int octaveOffset = 0; octaveOffset < octaveSpan; octaveOffset++) {
+            for (int i = 0; i < noteCount; i++) {
+                final int baseNote = clampMidi(resolveRegisteredRunMidi(startIndex + i, rowBaseOctave));
+                notes[out++] = baseNote < 0 ? -1 : wrapMidi(baseNote + octaveOffset * 12);
             }
         }
-        return candidates.stream().mapToInt(Integer::intValue).toArray();
+        return notes;
     }
 
-    private int resolveTertianSeriesMidi(final int seriesIndex, final int baseOctave) {
+    private int resolveRegisteredRunMidi(final int seriesIndex, final int baseOctave) {
         if (scaleDegreeCount <= 0) {
             return -1;
         }
-        final int normalizedSeries = Math.max(0, seriesIndex);
-        final int degreeTravel = normalizedSeries * 2;
+        final int degreeTravel = seriesIndex * 2;
         final int octaveFromWrap = Math.floorDiv(degreeTravel, scaleDegreeCount);
         final int degreeIndex = Math.floorMod(degreeTravel, scaleDegreeCount);
-        return scale.computeNote(rootNote, baseOctave + 1 + octaveFromWrap, degreeIndex);
+        final int compactOffset = Math.floorMod(seriesIndex, 2) == 0 ? 0 : -1;
+        return scale.computeNote(rootNote, baseOctave + 1 + octaveFromWrap + compactOffset, degreeIndex);
     }
 
     private static int detectScaleDegreeCount(final MusicalScale scale, final int rootNote) {
@@ -121,5 +104,16 @@ final class HarmonicLatticeLayout implements LiveNoteLayout {
 
     private static int clampMidi(final int midiNote) {
         return midiNote >= 0 && midiNote <= 127 ? midiNote : -1;
+    }
+
+    private static int wrapMidi(final int midiNote) {
+        int wrapped = midiNote;
+        while (wrapped > 127) {
+            wrapped -= 12;
+        }
+        while (wrapped < 0) {
+            wrapped += 12;
+        }
+        return wrapped;
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/HarmonicLatticeLayout.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/HarmonicLatticeLayout.java
@@ -1,0 +1,125 @@
+package com.oikoaudio.fire.note;
+
+import com.bitwig.extensions.framework.MusicalScale;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class HarmonicLatticeLayout implements LiveNoteLayout {
+    static final int[] GRID_SPANS = {7, 14, 21};
+    static final int MIN_OCTAVE_REACH = 1;
+    static final int MAX_OCTAVE_REACH = 3;
+
+    private static final int PAD_COUNT = 64;
+    private static final int PAD_COLUMNS = 16;
+    private static final int PAD_ROWS = 4;
+    private static final int BASS_COLUMNS = 2;
+    private static final int[] ROW_FINE_PHASES = {0, 2, 4, 6};
+
+    private final MusicalScale scale;
+    private final int rootNote;
+    private final int octave;
+    private final int gridSpan;
+    private final int octaveReach;
+    private final boolean bassColumnsEnabled;
+    private final int glissSteps;
+    private final int scaleDegreeCount;
+
+    HarmonicLatticeLayout(final MusicalScale scale, final int rootNote, final int octave,
+                          final int gridSpan, final int octaveReach,
+                          final boolean bassColumnsEnabled, final int glissSteps) {
+        this.scale = scale;
+        this.rootNote = rootNote;
+        this.octave = octave;
+        this.gridSpan = gridSpan;
+        this.octaveReach = octaveReach;
+        this.bassColumnsEnabled = bassColumnsEnabled;
+        this.glissSteps = glissSteps;
+        this.scaleDegreeCount = detectScaleDegreeCount(scale, rootNote);
+    }
+
+    @Override
+    public int[] notesForPad(final int padIndex) {
+        if (padIndex < 0 || padIndex >= PAD_COUNT) {
+            return new int[0];
+        }
+        final int column = padIndex % PAD_COLUMNS;
+        final int rowFromBottom = PAD_ROWS - 1 - (padIndex / PAD_COLUMNS);
+        if (bassColumnsEnabled && column < BASS_COLUMNS) {
+            return bassNotesForPad(column, rowFromBottom);
+        }
+        final int harmonicColumn = bassColumnsEnabled ? column - BASS_COLUMNS : column;
+        return harmonicNotesForPad(harmonicColumn, rowFromBottom);
+    }
+
+    @Override
+    public NoteGridLayout.PadRole roleForPad(final int padIndex) {
+        final int midiNote = primaryNoteForPad(padIndex);
+        if (midiNote < 0) {
+            return NoteGridLayout.PadRole.UNAVAILABLE;
+        }
+        if (scale.isRootMidiNote(rootNote, midiNote)) {
+            return NoteGridLayout.PadRole.ROOT;
+        }
+        if (scale.isMidiNoteInScale(rootNote, midiNote)) {
+            return NoteGridLayout.PadRole.IN_SCALE;
+        }
+        return NoteGridLayout.PadRole.OUT_OF_SCALE;
+    }
+
+    private int[] bassNotesForPad(final int column, final int rowFromBottom) {
+        final int bassIndex = rowFromBottom * BASS_COLUMNS + column;
+        final int bassNote = clampMidi(resolveTertianSeriesMidi(bassIndex, octave));
+        return bassNote < 0 ? new int[0] : new int[]{bassNote};
+    }
+
+    private int[] harmonicNotesForPad(final int harmonicColumn, final int rowFromBottom) {
+        final int anchorSeriesIndex = harmonicColumn + glissSteps;
+        final int rowPhase = ROW_FINE_PHASES[Math.max(0, Math.min(ROW_FINE_PHASES.length - 1, rowFromBottom))];
+        final int rowBaseOctave = octave + rowFromBottom;
+        final Set<Integer> candidates = new LinkedHashSet<>();
+        for (int candidateIndex = 0; ; candidateIndex++) {
+            final int fineIndex = rowPhase + candidateIndex * 2;
+            if (fineIndex >= gridSpan) {
+                break;
+            }
+            final int octaveLayer = fineIndex / 7;
+            if (octaveLayer >= octaveReach) {
+                break;
+            }
+            final int midiNote = clampMidi(resolveTertianSeriesMidi(anchorSeriesIndex + candidateIndex,
+                    rowBaseOctave + octaveLayer));
+            if (midiNote >= 0) {
+                candidates.add(midiNote);
+            }
+        }
+        return candidates.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    private int resolveTertianSeriesMidi(final int seriesIndex, final int baseOctave) {
+        if (scaleDegreeCount <= 0) {
+            return -1;
+        }
+        final int normalizedSeries = Math.max(0, seriesIndex);
+        final int degreeTravel = normalizedSeries * 2;
+        final int octaveFromWrap = Math.floorDiv(degreeTravel, scaleDegreeCount);
+        final int degreeIndex = Math.floorMod(degreeTravel, scaleDegreeCount);
+        return scale.computeNote(rootNote, baseOctave + 1 + octaveFromWrap, degreeIndex);
+    }
+
+    private static int detectScaleDegreeCount(final MusicalScale scale, final int rootNote) {
+        int count = 0;
+        for (int semitone = 0; semitone < 12; semitone++) {
+            if (scale.isMidiNoteInScale(rootNote, rootNote + semitone)) {
+                count++;
+            }
+        }
+        return Math.max(1, count);
+    }
+
+    private static int clampMidi(final int midiNote) {
+        return midiNote >= 0 && midiNote <= 127 ? midiNote : -1;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LiveNoteLayout.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LiveNoteLayout.java
@@ -1,0 +1,12 @@
+package com.oikoaudio.fire.note;
+
+interface LiveNoteLayout {
+    int[] notesForPad(int padIndex);
+
+    NoteGridLayout.PadRole roleForPad(int padIndex);
+
+    default int primaryNoteForPad(final int padIndex) {
+        final int[] notes = notesForPad(padIndex);
+        return notes.length == 0 ? -1 : notes[0];
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteGridLayout.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteGridLayout.java
@@ -2,7 +2,7 @@ package com.oikoaudio.fire.note;
 
 import com.bitwig.extensions.framework.MusicalScale;
 
-public final class NoteGridLayout {
+public final class NoteGridLayout implements LiveNoteLayout {
     public static final int PAD_COUNT = 64;
     public static final int PAD_COLUMNS = 16;
     public static final int PAD_ROWS = 4;
@@ -40,6 +40,12 @@ public final class NoteGridLayout {
         }
         final int note = rootNote + (octave + 1) * 12 + column + rowFromBottom * CHROMATIC_ROW_INTERVAL;
         return note >= 0 && note <= 127 ? note : -1;
+    }
+
+    @Override
+    public int[] notesForPad(final int padIndex) {
+        final int midiNote = noteForPad(padIndex);
+        return midiNote < 0 ? new int[0] : new int[]{midiNote};
     }
 
     public PadRole roleForPad(final int padIndex) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControls.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControls.java
@@ -4,6 +4,7 @@ import com.oikoaudio.fire.lights.BiColorLightState;
 import com.oikoaudio.fire.sequence.EncoderMode;
 
 import java.util.EnumMap;
+import java.util.function.Function;
 
 /**
  * Owns the live encoder-page selection and layer activation used by Note mode's live surface.
@@ -11,18 +12,21 @@ import java.util.EnumMap;
 final class NoteLiveEncoderModeControls {
     private final EnumMap<EncoderMode, LayerHandle> layers = new EnumMap<>(EncoderMode.class);
     private final StepSizeApplier stepSizeApplier;
+    private final Function<EncoderMode, String> modeInfoSupplier;
     private EncoderMode mode = EncoderMode.CHANNEL;
 
     NoteLiveEncoderModeControls(final LayerHandle channelLayer,
                                 final LayerHandle mixerLayer,
                                 final LayerHandle user1Layer,
                                 final LayerHandle user2Layer,
-                                final StepSizeApplier stepSizeApplier) {
+                                final StepSizeApplier stepSizeApplier,
+                                final Function<EncoderMode, String> modeInfoSupplier) {
         layers.put(EncoderMode.CHANNEL, channelLayer);
         layers.put(EncoderMode.MIXER, mixerLayer);
         layers.put(EncoderMode.USER_1, user1Layer);
         layers.put(EncoderMode.USER_2, user2Layer);
         this.stepSizeApplier = stepSizeApplier;
+        this.modeInfoSupplier = modeInfoSupplier;
     }
 
     void resetToChannel() {
@@ -57,7 +61,7 @@ final class NoteLiveEncoderModeControls {
     }
 
     String modeInfo() {
-        return modeInfo(mode);
+        return modeInfoSupplier.apply(mode);
     }
 
     EncoderMode mode() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControls.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControls.java
@@ -66,9 +66,9 @@ final class NoteLiveEncoderModeControls {
 
     static String modeInfo(final EncoderMode mode) {
         return switch (mode) {
-            case CHANNEL -> "1: Mod\n2: Pitch Gliss\n3: Velocity\n4: Scale";
+            case CHANNEL -> "1: Mod\n2: Pitch Bend\n3: Pitch Gliss\n4: Scale";
             case MIXER -> "1: Volume\n2: Pan\n3: Send 1\n4: Send 2";
-            case USER_1 -> "1: Aftertouch\n2: Pressure\n3: Timbre\n4: Pitch Expr";
+            case USER_1 -> "1: Velocity\n2: Aftertouch\n3: Timbre\n4: Pitch Expr";
             case USER_2 -> "1: Remote 1\n2: Remote 2\n3: Remote 3\n4: Remote 4";
         };
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveExpressionControls.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLiveExpressionControls.java
@@ -8,12 +8,14 @@ final class NoteLiveExpressionControls {
     private static final int MAX_MIDI_VALUE = 127;
     private static final int DEFAULT_TIMBRE = 64;
     private static final int DEFAULT_PITCH_EXPRESSION = 64;
+    private static final int DEFAULT_PITCH_BEND = 8192;
 
     private final MidiExpressionOut midiOut;
     private int pressure = MIN_MIDI_VALUE;
     private int timbre = DEFAULT_TIMBRE;
     private int modulation = MIN_MIDI_VALUE;
     private int pitchExpression = DEFAULT_PITCH_EXPRESSION;
+    private int transientPitchBendOffset = 0;
 
     NoteLiveExpressionControls(final MidiExpressionOut midiOut) {
         this.midiOut = midiOut;
@@ -71,7 +73,7 @@ final class NoteLiveExpressionControls {
             return false;
         }
         pitchExpression = next;
-        midiOut.pitchBend(pitchBendValueFor(pitchExpression));
+        emitPitchBend();
         return true;
     }
 
@@ -92,7 +94,12 @@ final class NoteLiveExpressionControls {
 
     void resetPitchExpression() {
         pitchExpression = DEFAULT_PITCH_EXPRESSION;
-        midiOut.pitchBend(pitchBendValueFor(pitchExpression));
+        emitPitchBend();
+    }
+
+    void setTransientPitchBendValue(final int value) {
+        transientPitchBendOffset = pitchBendValueFor(clampMidiValue(value)) - DEFAULT_PITCH_BEND;
+        emitPitchBend();
     }
 
     private static int clampMidiValue(final int value) {
@@ -106,6 +113,14 @@ final class NoteLiveExpressionControls {
         final int rangeAboveCenter = MAX_MIDI_VALUE - DEFAULT_PITCH_EXPRESSION;
         return 8192 + (int) Math.round(((value - DEFAULT_PITCH_EXPRESSION) / (double) rangeAboveCenter)
                 * (16383.0 - 8192.0));
+    }
+
+    private static int clampPitchBend(final int bend) {
+        return Math.max(0, Math.min(16383, bend));
+    }
+
+    private void emitPitchBend() {
+        midiOut.pitchBend(clampPitchBend(pitchBendValueFor(pitchExpression) + transientPitchBendOffset));
     }
 
     interface MidiExpressionOut {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLivePadPerformer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/NoteLivePadPerformer.java
@@ -3,26 +3,26 @@ package com.oikoaudio.fire.note;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.IntBinaryOperator;
-import java.util.function.IntUnaryOperator;
+import java.util.function.BiFunction;
 
 /**
  * Live pad-note performance state for Note mode: held pads, sounding notes, retuning, and note on/off output.
  */
 final class NoteLivePadPerformer {
     private final MidiOut midiOut;
-    private final IntUnaryOperator midiNoteResolver;
-    private final IntBinaryOperator velocityResolver;
+    private final java.util.function.IntFunction<int[]> midiNotesResolver;
+    private final BiFunction<Integer, Integer, Integer> velocityResolver;
     private final Set<Integer> heldPads = new HashSet<>();
     private final Map<Integer, LivePadNote> soundingNotesByPad = new HashMap<>();
 
     NoteLivePadPerformer(final MidiOut midiOut,
-                         final IntUnaryOperator midiNoteResolver,
-                         final IntBinaryOperator velocityResolver) {
+                         final java.util.function.IntFunction<int[]> midiNotesResolver,
+                         final BiFunction<Integer, Integer, Integer> velocityResolver) {
         this.midiOut = midiOut;
-        this.midiNoteResolver = midiNoteResolver;
+        this.midiNotesResolver = midiNotesResolver;
         this.velocityResolver = velocityResolver;
     }
 
@@ -60,13 +60,22 @@ final class NoteLivePadPerformer {
 
     private void noteOn(final int padIndex, final int rawVelocity, final int configuredVelocity) {
         noteOff(padIndex);
-        final int midiNote = midiNoteResolver.applyAsInt(padIndex);
-        if (midiNote < 0) {
+        final int[] midiNotes = midiNotesResolver.apply(padIndex);
+        if (midiNotes == null || midiNotes.length == 0) {
             return;
         }
-        final int appliedVelocity = velocityResolver.applyAsInt(configuredVelocity, rawVelocity);
-        midiOut.noteOn(midiNote, appliedVelocity);
-        soundingNotesByPad.put(padIndex, new LivePadNote(midiNote, appliedVelocity));
+        final int appliedVelocity = velocityResolver.apply(configuredVelocity, rawVelocity);
+        final List<Integer> sounding = new ArrayList<>();
+        for (final int midiNote : midiNotes) {
+            if (midiNote < 0) {
+                continue;
+            }
+            midiOut.noteOn(midiNote, appliedVelocity);
+            sounding.add(midiNote);
+        }
+        if (!sounding.isEmpty()) {
+            soundingNotesByPad.put(padIndex, new LivePadNote(sounding, appliedVelocity));
+        }
     }
 
     private void noteOff(final int padIndex) {
@@ -74,7 +83,9 @@ final class NoteLivePadPerformer {
         if (activeNote == null) {
             return;
         }
-        midiOut.noteOff(activeNote.midiNote());
+        for (final int midiNote : activeNote.midiNotes()) {
+            midiOut.noteOff(midiNote);
+        }
     }
 
     @FunctionalInterface
@@ -85,6 +96,6 @@ final class NoteLivePadPerformer {
         }
     }
 
-    private record LivePadNote(int midiNote, int velocity) {
+    private record LivePadNote(List<Integer> midiNotes, int velocity) {
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -502,7 +502,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         for (int i = 0; i < encoders.length; i++) {
             final int index = i;
             final Parameter parameter = liveRemoteControlsPage.getParameter(index);
-            encoders[i].bindEncoder(liveUser2Layer, inc -> adjustMixerParameter(parameter, parameter.name().get(), inc));
+            encoders[i].bindContinuousEncoder(liveUser2Layer, driver::isGlobalShiftHeld,
+                    com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.STRONG,
+                    inc -> adjustMixerParameter(parameter, parameter.name().get(), inc));
             encoders[i].bindTouched(liveUser2Layer, touched -> {
                 if (touched) {
                     oled.valueInfo(parameter.name().get(), parameter.displayedValue().get());
@@ -533,7 +535,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 case 2 -> "Send 1";
                 default -> "Send 2";
             };
-            encoders[i].bindEncoder(liveMixerLayer, inc -> adjustMixerParameter(parameter, fallbackLabel, inc));
+            encoders[i].bindContinuousEncoder(liveMixerLayer, driver::isGlobalShiftHeld,
+                    com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.STRONG,
+                    inc -> adjustMixerParameter(parameter, fallbackLabel, inc));
             encoders[i].bindTouched(liveMixerLayer, touched -> {
                 if (touched) {
                     oled.valueInfo(parameter.name().get(), parameter.displayedValue().get());
@@ -547,7 +551,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private void bindLiveMidiEncoder(final TouchEncoder encoder, final Layer layer, final String label,
                                      final java.util.function.IntConsumer adjuster,
                                      final java.util.function.IntSupplier valueSupplier) {
-        encoder.bindEncoder(layer, adjuster::accept);
+        encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.GENTLE, adjuster::accept);
         encoder.bindTouched(layer, touched -> liveControls.handleExpressionTouch(touched, label,
                 Integer.toString(valueSupplier.getAsInt())));
     }
@@ -556,7 +561,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                                                final String label, final java.util.function.IntConsumer adjuster,
                                                final java.util.function.Supplier<String> valueSupplier,
                                                final Runnable resetAction) {
-        encoder.bindEncoder(layer, inc -> {
+        encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.GENTLE, inc -> {
             if (inc == 0) {
                 return;
             }
@@ -3253,7 +3259,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 parameter.name().markInterested();
                 parameter.displayedValue().markInterested();
                 parameter.value().markInterested();
-                encoder.bindEncoder(layer, inc -> adjustMixerParameter(parameter, label, inc));
+                encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
+                        com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.STRONG,
+                        inc -> adjustMixerParameter(parameter, label, inc));
                 encoder.bindTouched(layer, touched -> {
                     if (touched) {
                         oled.valueInfo(label, parameter.displayedValue().get());

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -189,11 +189,31 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private final Map<Integer, Map<Integer, NoteStep>> noteStepsByPosition = new HashMap<>();
     private final Map<String, NoteStepMoveSnapshot> pendingMovedNotes = new HashMap<>();
 
+    private enum LiveNoteSubMode {
+        MELODIC("Note"),
+        HARMONIC("Harmonic");
+
+        private final String displayName;
+
+        LiveNoteSubMode(final String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String displayName() {
+            return displayName;
+        }
+
+        public LiveNoteSubMode next() {
+            return values()[(ordinal() + 1) % values().length];
+        }
+    }
+
     private boolean inKey = false;
     private boolean noteStepActive = false;
     private final AccentLatchState oikordAccentState = new AccentLatchState();
     private boolean mainEncoderPressConsumed = false;
     private boolean builderInKey = true;
+    private LiveNoteSubMode liveNoteSubMode = LiveNoteSubMode.MELODIC;
     private NoteStepSubMode currentStepSubMode = NoteStepSubMode.OIKORD_STEP;
     private OikordInterpretation oikordInterpretation = OikordInterpretation.AS_IS;
     private int selectedOikordFamily = 0;
@@ -209,6 +229,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private int playingStep = -1;
     private int pendingBankDir = 0;
     private int livePitchOffsetIndex = DEFAULT_LIVE_PITCH_OFFSET_INDEX;
+    private int harmonicGridSpanIndex = 0;
+    private int harmonicOctaveReach = 1;
+    private boolean harmonicBassColumns = true;
     private int livePitchBend = DEFAULT_LIVE_PITCH_BEND;
     private boolean livePitchBendTouched = false;
     private int livePitchBendReturnGeneration = 0;
@@ -368,8 +391,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                         noteInput.sendRawMidiEvent(Midi.NOTE_OFF, midiNote, 0);
                     }
                 },
-                this::getLivePadMidiNote,
-                this::resolveLivePadVelocity);
+                this::getLivePadMidiNotes,
+                (configuredVelocity, rawVelocity) -> resolveLivePadVelocity(configuredVelocity, rawVelocity));
         this.liveExpressionControls = new NoteLiveExpressionControls(new NoteLiveExpressionControls.MidiExpressionOut() {
             @Override
             public void channelAftertouch(final int value) {
@@ -476,15 +499,58 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     }
 
     private void bindLiveChannelEncoders(final TouchEncoder[] encoders) {
-        bindResettableLiveMidiEncoder(encoders[0], liveChannelLayer, 0, "Mod",
-                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT,
-                this::adjustLiveModulation, () -> Integer.toString(liveExpressionControls.modulation()), this::resetLiveModulation);
+        encoders[0].bindContinuousEncoder(liveChannelLayer, driver::isGlobalShiftHeld,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT, inc -> {
+                    if (inc == 0) {
+                        return;
+                    }
+                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
+                        adjustHarmonicGridSpan(inc);
+                        return;
+                    }
+                    liveControls.markEncoderAdjusted(0);
+                    adjustLiveModulation(inc);
+                });
+        encoders[0].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(0, touched,
+                () -> {
+                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
+                        oled.valueInfo("Width", harmonicGridSpanDisplay());
+                    } else {
+                        oled.valueInfo("Mod", Integer.toString(liveExpressionControls.modulation()));
+                    }
+                },
+                () -> {
+                    if (!isHarmonicLiveMode() || !driver.isGlobalAltHeld()) {
+                        resetLiveModulation();
+                    }
+                }));
 
-        bindLivePitchBendEncoder(encoders[1], liveChannelLayer, 1);
+        encoders[1].bindContinuousEncoder(liveChannelLayer, driver::isGlobalShiftHeld,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT, inc -> {
+                    if (inc == 0) {
+                        return;
+                    }
+                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
+                        adjustHarmonicOctaveReach(inc);
+                        return;
+                    }
+                    liveControls.markEncoderAdjusted(1);
+                    cancelLivePitchBendReturn();
+                    adjustLivePitchBend(inc);
+                });
+        encoders[1].bindTouched(liveChannelLayer, touched -> {
+            if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
+                liveControls.handleResettableTouch(1, touched,
+                        () -> oled.valueInfo("Oct Reach", Integer.toString(harmonicOctaveReach)),
+                        () -> { });
+                return;
+            }
+            handleLivePitchBendTouch(touched);
+        });
 
         encoders[2].bindEncoder(liveChannelLayer, this::adjustLivePitchOffset);
         encoders[2].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(2, touched,
-                () -> oled.valueInfo("Pitch Gliss", formatSignedValue(getLivePitchOffset())),
+                () -> oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay()),
                 livePitchOffsetEncoder::reset));
 
         encoders[3].bindEncoder(liveChannelLayer, this::handleEncoder1);
@@ -701,11 +767,55 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }
         liveControls.markEncoderAdjusted(1);
         retuneLivePads(() -> livePitchOffsetIndex = nextIndex);
-        oled.valueInfo("Pitch Gliss", formatSignedValue(getLivePitchOffset()));
+        oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay());
+    }
+
+    private void adjustHarmonicGridSpan(final int inc) {
+        final int steps = liveVelocityEncoder.consume(inc);
+        if (steps == 0) {
+            return;
+        }
+        final int next = Math.max(0, Math.min(HarmonicLatticeLayout.GRID_SPANS.length - 1, harmonicGridSpanIndex + steps));
+        if (next == harmonicGridSpanIndex) {
+            return;
+        }
+        liveControls.markEncoderAdjusted(0);
+        retuneLivePads(() -> harmonicGridSpanIndex = next);
+        oled.valueInfo("Width", harmonicGridSpanDisplay());
+    }
+
+    private void adjustHarmonicOctaveReach(final int inc) {
+        final int steps = liveOctaveEncoder.consume(inc);
+        if (steps == 0) {
+            return;
+        }
+        final int next = Math.max(HarmonicLatticeLayout.MIN_OCTAVE_REACH,
+                Math.min(HarmonicLatticeLayout.MAX_OCTAVE_REACH, harmonicOctaveReach + steps));
+        if (next == harmonicOctaveReach) {
+            return;
+        }
+        liveControls.markEncoderAdjusted(1);
+        retuneLivePads(() -> harmonicOctaveReach = next);
+        oled.valueInfo("Oct Reach", Integer.toString(harmonicOctaveReach));
+    }
+
+    private String harmonicGridSpanDisplay() {
+        return Integer.toString(HarmonicLatticeLayout.GRID_SPANS[harmonicGridSpanIndex]);
+    }
+
+    private int getHarmonicGlissStepOffset() {
+        return livePitchOffsetIndex - DEFAULT_LIVE_PITCH_OFFSET_INDEX;
     }
 
     private String formatLivePitchExpressionDisplay() {
         return formatSignedValue(liveExpressionControls.pitchExpression() - DEFAULT_LIVE_PITCH_EXPRESSION);
+    }
+
+    private String formatLivePitchOffsetDisplay() {
+        if (isHarmonicLiveMode()) {
+            return formatSignedValue(getHarmonicGlissStepOffset());
+        }
+        return formatSignedValue(getLivePitchOffset());
     }
 
     private void resetLivePressure() {
@@ -2067,7 +2177,36 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 .allMatch(this::isOikordAccented);
     }
 
+    private boolean isHarmonicLiveMode() {
+        return !noteStepActive && surfaceRole == SurfaceRole.NOTE_PLAY && liveNoteSubMode == LiveNoteSubMode.HARMONIC;
+    }
+
+    public String currentNoteSubModeLabel() {
+        return liveNoteSubMode.displayName();
+    }
+
+    public void cycleNoteSubMode() {
+        if (isChordStepSurface()) {
+            toggleSurfaceVariant();
+            return;
+        }
+        final LiveNoteSubMode next = liveNoteSubMode.next();
+        applyLayoutChange(() -> {
+            liveNoteSubMode = next;
+            if (driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX
+                    && (liveNoteSubMode == LiveNoteSubMode.HARMONIC || (liveNoteSubMode == LiveNoteSubMode.MELODIC && inKey))) {
+                driver.setSharedScaleIndex(1);
+            }
+        });
+    }
+
     private void toggleLayout() {
+        if (isHarmonicLiveMode()) {
+            harmonicBassColumns = !harmonicBassColumns;
+            retuneLivePads(() -> { });
+            showState("Layout");
+            return;
+        }
         applyLayoutChange(() -> {
             inKey = !inKey;
             if (inKey && driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX) {
@@ -2079,6 +2218,12 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
 
     private void adjustLayout(final int amount) {
         if (amount == 0) {
+            return;
+        }
+        if (isHarmonicLiveMode()) {
+            if ((amount > 0 && !harmonicBassColumns) || (amount < 0 && harmonicBassColumns)) {
+                toggleLayout();
+            }
             return;
         }
         if (amount > 0 && !inKey) {
@@ -2099,7 +2244,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
             }
             return;
         }
-        toggleLayout();
+        cycleNoteSubMode();
     }
 
     private void toggleBuilderLayout() {
@@ -2123,7 +2268,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         if (amount == 0) {
             return;
         }
-        final int minScale = inKey ? 1 : PIANO_HIGHLIGHT_INDEX;
+        final int minScale = liveScaleMinIndex();
         final int nextScale = driver.getSharedScaleIndex() + amount;
         if (nextScale < minScale || nextScale >= scaleLibrary.getMusicalScalesCount()) {
             return;
@@ -2133,8 +2278,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     }
 
     public void adjustSharedScaleFromOverview(final int amount) {
-        final int minScale = inKey ? 1 : PIANO_HIGHLIGHT_INDEX;
-        driver.adjustSharedScaleIndex(amount, minScale);
+        driver.adjustSharedScaleIndex(amount, liveScaleMinIndex());
     }
 
     private void adjustOctave(final int amount) {
@@ -2267,8 +2411,22 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }, liveVelocity);
     }
 
-    private int getLivePadMidiNote(final int padIndex) {
-        return applyLivePitchOffset(createLayout().noteForPad(padIndex));
+    private int[] getLivePadMidiNotes(final int padIndex) {
+        final int[] layoutNotes = createLayout().notesForPad(padIndex);
+        final int[] shifted = new int[layoutNotes.length];
+        int count = 0;
+        for (final int layoutNote : layoutNotes) {
+            final int shiftedNote = applyLivePitchOffset(layoutNote);
+            if (shiftedNote >= 0) {
+                shifted[count++] = shiftedNote;
+            }
+        }
+        if (count == shifted.length) {
+            return shifted;
+        }
+        final int[] compact = new int[count];
+        System.arraycopy(shifted, 0, compact, 0, count);
+        return compact;
     }
 
     private int resolveLivePadVelocity(final int configuredVelocity, final int rawVelocity) {
@@ -2294,12 +2452,12 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     }
 
     private RgbLigthState getLivePadLight(final int padIndex) {
-        final NoteGridLayout layout = createLayout();
-        final int midiNote = applyLivePitchOffset(layout.noteForPad(padIndex));
+        final LiveNoteLayout layout = createLayout();
+        final int midiNote = applyLivePitchOffset(layout.primaryNoteForPad(padIndex));
         final RgbLigthState base;
         if (midiNote < 0) {
             base = RgbLigthState.OFF;
-        } else if (!inKey && driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX) {
+        } else if (!isHarmonicLiveMode() && !inKey && driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX) {
             if (layout.roleForPad(padIndex) == NoteGridLayout.PadRole.ROOT) {
                 base = ROOT_COLOR;
             } else if (NoteGridLayout.isBlackKey(midiNote)) {
@@ -2458,7 +2616,11 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
             return;
         }
         if ("Layout".equals(focus)) {
-            oled.valueInfo("Layout", inKey ? "In Key" : "Chromatic");
+            if (isHarmonicLiveMode()) {
+                oled.valueInfo("Layout", harmonicBassColumns ? "Bass Columns" : "Full Field");
+            } else {
+                oled.valueInfo("Layout", inKey ? "In Key" : "Chromatic");
+            }
             return;
         }
         if ("Interpretation".equals(focus) && noteStepActive && currentStepSubMode == NoteStepSubMode.OIKORD_STEP) {
@@ -2469,7 +2631,10 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 noteStepActive
                         ? "Step: %s\n%s".formatted(currentStepSubMode.displayName(),
                         currentStepSubMode == NoteStepSubMode.OIKORD_STEP ? currentOikordDisplay() : "Deferred")
-                        : "Scale: %s\n%s".formatted(getScaleDisplayName(), inKey ? "In Key" : "Chromatic"));
+                        : "Scale: %s\n%s".formatted(getScaleDisplayName(),
+                        isHarmonicLiveMode()
+                                ? "Harmonic %s".formatted(harmonicBassColumns ? "Bass" : "Full")
+                                : inKey ? "In Key" : "Chromatic"));
     }
 
     private void showContextInfo() {
@@ -2874,7 +3039,16 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         return driver.getSharedBaseMidiNote();
     }
 
-    private NoteGridLayout createLayout() {
+    private int liveScaleMinIndex() {
+        return isHarmonicLiveMode() || inKey ? 1 : PIANO_HIGHLIGHT_INDEX;
+    }
+
+    private LiveNoteLayout createLayout() {
+        if (isHarmonicLiveMode()) {
+            return new HarmonicLatticeLayout(getScale(), getRootNote(), getOctave(),
+                    HarmonicLatticeLayout.GRID_SPANS[harmonicGridSpanIndex], harmonicOctaveReach,
+                    harmonicBassColumns, getHarmonicGlissStepOffset());
+        }
         return new NoteGridLayout(getScale(), getRootNote(), getOctave(), inKey);
     }
 
@@ -2897,6 +3071,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private int applyLivePitchOffset(final int midiNote) {
         if (midiNote < 0) {
             return -1;
+        }
+        if (isHarmonicLiveMode()) {
+            return midiNote;
         }
         final int shifted = midiNote + getLivePitchOffset();
         return shifted >= 0 && shifted <= 127 ? shifted : -1;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -115,6 +115,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private static final int DEFAULT_LIVE_PITCH_EXPRESSION = 64;
     private static final int LIVE_PITCH_BEND_RETURN_STEP = 6;
     private static final long LIVE_PITCH_BEND_RETURN_DELAY_MS = 15L;
+    private static final long LIVE_PITCH_BEND_INACTIVITY_RETURN_MS = 120L;
     private static final int MIDI_CC_MOD = 1;
     private static final int MIDI_CC_SUSTAIN = 64;
     private static final int MIDI_CC_SOSTENUTO = 66;
@@ -211,6 +212,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private int livePitchBend = DEFAULT_LIVE_PITCH_BEND;
     private boolean livePitchBendTouched = false;
     private int livePitchBendReturnGeneration = 0;
+    private int livePitchBendInactivityGeneration = 0;
     private boolean pendingBankFineMove = false;
     private boolean pendingBankLengthAdjust = false;
     private boolean bankMoveInFlight = false;
@@ -677,6 +679,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         livePitchBend = next;
         liveExpressionControls.setTransientPitchBendValue(livePitchBend);
         oled.valueInfo("Pitch Bend", formatSignedValue(livePitchBend - DEFAULT_LIVE_PITCH_BEND));
+        armLivePitchBendInactivityReturn();
     }
 
     private void adjustLivePitchExpression(final int inc) {
@@ -758,6 +761,17 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
 
     private void cancelLivePitchBendReturn() {
         livePitchBendReturnGeneration++;
+    }
+
+    private void armLivePitchBendInactivityReturn() {
+        final int generation = ++livePitchBendInactivityGeneration;
+        driver.getHost().scheduleTask(() -> {
+            if (generation != livePitchBendInactivityGeneration || livePitchBendTouched
+                    || livePitchBend == DEFAULT_LIVE_PITCH_BEND) {
+                return;
+            }
+            scheduleLivePitchBendReturn();
+        }, LIVE_PITCH_BEND_INACTIVITY_RETURN_MS);
     }
 
     private int getLivePitchOffset() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -489,7 +489,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
 
         encoders[3].bindEncoder(liveChannelLayer, this::handleEncoder1);
         encoders[3].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(3, touched,
-                () -> showState(driver.isGlobalAltHeld() ? "Root" : "Scale"),
+                () -> showState(driver.isGlobalShiftHeld() ? "Layout" : driver.isGlobalAltHeld() ? "Root" : "Scale"),
                 liveScaleEncoder::reset));
     }
 
@@ -628,8 +628,10 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private void handleEncoder1(final int inc) {
         final int steps = liveScaleEncoder.consume(inc);
         if (steps != 0) {
-            liveControls.markEncoderAdjusted(2);
-            if (driver.isGlobalAltHeld()) {
+            liveControls.markEncoderAdjusted(3);
+            if (driver.isGlobalShiftHeld()) {
+                adjustLayout(steps);
+            } else if (driver.isGlobalAltHeld()) {
                 adjustTransposeSemitone(steps);
             } else {
                 adjustScale(steps);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -2344,6 +2344,13 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         cycleNoteSubMode();
     }
 
+    public void toggleLiveLayoutShortcut() {
+        if (isChordStepSurface()) {
+            return;
+        }
+        toggleLayout();
+    }
+
     private void toggleBuilderLayout() {
         builderInKey = !builderInKey;
         if (builderInKey && driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -2728,25 +2728,32 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
             return "Piano";
         }
         return switch (getScale().getName()) {
-            case "Ionan (Major)" -> "Major";
-            case "Aeolian (Minor)" -> "Minor";
+            case "Major" -> "Major";
+            case "Minor" -> "Minor";
             case "Phrygian Dominant" -> "Phryg Dom";
-            case "Double Harmonic" -> "Dbl Harm";
+            case "Double Harmonic Major" -> "DH Maj";
+            case "Double Harmonic Minor" -> "DH Min";
+            case "Harmonic Major" -> "Harm Maj";
             case "Harmonic Minor" -> "Harm Min";
-            case "Melodic Minor (ascending)" -> "Mel Min";
+            case "Jazz Minor" -> "Jazz Min";
+            case "Overtone Scale" -> "Overtone";
             case "Hungarian Minor" -> "Hung Min";
             case "Ukranian Dorian" -> "Ukr Dor";
             case "Super Locrian" -> "Sup Loc";
-            case "Half-Whole Diminished" -> "Half-Whole";
+            case "Half-diminished" -> "Half Dim";
+            case "Diminished WH" -> "Dim WH";
+            case "Diminished HW" -> "Dim HW";
             case "Major Pentatonic" -> "Maj Pent";
             case "Minor Pentatonic" -> "Min Pent";
-            case "Major Blues" -> "Maj Blues";
+            case "Blues Major" -> "Bl Maj";
+            case "Blues Minor" -> "Bl Min";
             case "Whole Tone" -> "Whole";
-            case "Whole Half" -> "WholeHalf";
-            case "BeBop Major" -> "Bebop Maj";
-            case "BeBop Dorian" -> "Bebop Dor";
-            case "BeBop Mixolydian" -> "Bebop Mix";
-            case "BeBop Minor" -> "Bebop Min";
+            case "Major Triad" -> "Maj Tri";
+            case "Minor Triad" -> "Min Tri";
+            case "Bebop Major" -> "Bebop Maj";
+            case "Bebop Dorian" -> "Bebop Dor";
+            case "Bebop Mixolydian" -> "Bebop Mix";
+            case "Bebop Minor" -> "Bebop Min";
             default -> getScale().getName();
         };
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -122,6 +122,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private static final int MIDI_CC_TIMBRE = 74;
     private static final int[] LIVE_PITCH_OFFSETS = {-24, -19, -12, -7, 0, 7, 12, 19, 24};
     private static final int DEFAULT_LIVE_PITCH_OFFSET_INDEX = 4;
+    private static final int MIN_SCALE_DEGREE_GLISS = -14;
+    private static final int MAX_SCALE_DEGREE_GLISS = 14;
     private static final RgbLigthState ROOT_COLOR = new RgbLigthState(120, 64, 0, true);
     private static final RgbLigthState IN_SCALE_COLOR = new RgbLigthState(0, 72, 110, true);
     private static final RgbLigthState PIANO_BLACK_KEY_COLOR = new RgbLigthState(0, 56, 120, true);
@@ -208,6 +210,21 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }
     }
 
+    private enum LivePitchGlissMode {
+        FIFTH_OCTAVE("5th/8v"),
+        SCALE_DEGREE("ScaleDeg");
+
+        private final String displayName;
+
+        LivePitchGlissMode(final String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String displayName() {
+            return displayName;
+        }
+    }
+
     private boolean inKey = false;
     private boolean noteStepActive = false;
     private final AccentLatchState oikordAccentState = new AccentLatchState();
@@ -229,8 +246,10 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private int playingStep = -1;
     private int pendingBankDir = 0;
     private int livePitchOffsetIndex = DEFAULT_LIVE_PITCH_OFFSET_INDEX;
-    private int harmonicGridSpanIndex = 0;
-    private int harmonicOctaveReach = 1;
+    private int liveScaleDegreeGlissOffset = 0;
+    private LivePitchGlissMode livePitchGlissMode = LivePitchGlissMode.FIFTH_OCTAVE;
+    private int harmonicNoteCountIndex = 2;
+    private int harmonicOctaveSpan = 1;
     private boolean harmonicBassColumns = true;
     private int livePitchBend = DEFAULT_LIVE_PITCH_BEND;
     private boolean livePitchBendTouched = false;
@@ -330,7 +349,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 liveEncoderLayer(liveMixerLayer),
                 liveEncoderLayer(liveUser1Layer),
                 liveEncoderLayer(liveUser2Layer),
-                this::applyLiveEncoderStepSizes);
+                this::applyLiveEncoderStepSizes,
+                this::liveEncoderModeInfo);
 
         final ControllerHost host = driver.getHost();
         this.cursorTrack = host.createCursorTrack("NOTE_VIEW", "Note View", 8, CLIP_ROW_PAD_COUNT, true);
@@ -504,54 +524,33 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                     if (inc == 0) {
                         return;
                     }
-                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
-                        adjustHarmonicGridSpan(inc);
-                        return;
-                    }
                     liveControls.markEncoderAdjusted(0);
                     adjustLiveModulation(inc);
                 });
         encoders[0].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(0, touched,
-                () -> {
-                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
-                        oled.valueInfo("Width", harmonicGridSpanDisplay());
-                    } else {
-                        oled.valueInfo("Mod", Integer.toString(liveExpressionControls.modulation()));
-                    }
-                },
-                () -> {
-                    if (!isHarmonicLiveMode() || !driver.isGlobalAltHeld()) {
-                        resetLiveModulation();
-                    }
-                }));
+                () -> oled.valueInfo("Mod", Integer.toString(liveExpressionControls.modulation())),
+                this::resetLiveModulation));
 
         encoders[1].bindContinuousEncoder(liveChannelLayer, driver::isGlobalShiftHeld,
                 com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT, inc -> {
                     if (inc == 0) {
                         return;
                     }
-                    if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
-                        adjustHarmonicOctaveReach(inc);
-                        return;
-                    }
                     liveControls.markEncoderAdjusted(1);
                     cancelLivePitchBendReturn();
                     adjustLivePitchBend(inc);
                 });
-        encoders[1].bindTouched(liveChannelLayer, touched -> {
-            if (isHarmonicLiveMode() && driver.isGlobalAltHeld()) {
-                liveControls.handleResettableTouch(1, touched,
-                        () -> oled.valueInfo("Oct Reach", Integer.toString(harmonicOctaveReach)),
-                        () -> { });
-                return;
-            }
-            handleLivePitchBendTouch(touched);
-        });
+        encoders[1].bindTouched(liveChannelLayer, this::handleLivePitchBendTouch);
 
-        encoders[2].bindEncoder(liveChannelLayer, this::adjustLivePitchOffset);
+        encoders[2].bindEncoder(liveChannelLayer, this::handleLivePitchGlissEncoder);
         encoders[2].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(2, touched,
-                () -> oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay()),
-                livePitchOffsetEncoder::reset));
+                () -> oled.valueInfo(driver.isGlobalAltHeld() ? "Gliss Mode" : "Pitch Gliss",
+                        driver.isGlobalAltHeld() ? livePitchGlissMode.displayName() : formatLivePitchOffsetDisplay()),
+                () -> {
+                    if (!driver.isGlobalAltHeld()) {
+                        livePitchOffsetEncoder.reset();
+                    }
+                }));
 
         encoders[3].bindEncoder(liveChannelLayer, this::handleEncoder1);
         encoders[3].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(3, touched,
@@ -602,6 +601,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
             parameter.value().markInterested();
         }
         for (int i = 0; i < encoders.length; i++) {
+            final int index = i;
             final com.bitwig.extension.controller.api.Parameter parameter = params.get(i);
             final String fallbackLabel = switch (i) {
                 case 0 -> "Volume";
@@ -610,15 +610,47 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 default -> "Send 2";
             };
             encoders[i].bindContinuousEncoder(liveMixerLayer, driver::isGlobalShiftHeld,
-                    com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.STRONG,
-                    inc -> adjustMixerParameter(parameter, fallbackLabel, inc));
+                    com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.STRONG, inc -> {
+                    if (inc == 0) {
+                        return;
+                    }
+                    if (isHarmonicLiveMode()) {
+                            handleHarmonicMixerEncoder(index, inc);
+                            return;
+                    }
+                    adjustMixerParameter(parameter, fallbackLabel, inc);
+                    });
             encoders[i].bindTouched(liveMixerLayer, touched -> {
                 if (touched) {
-                    oled.valueInfo(parameter.name().get(), parameter.displayedValue().get());
+                    if (isHarmonicLiveMode()) {
+                        showHarmonicMixerInfo(index);
+                    } else {
+                        oled.valueInfo(parameter.name().get(), parameter.displayedValue().get());
+                    }
                 } else {
                     oled.clearScreenDelayed();
                 }
             });
+        }
+    }
+
+    private void handleHarmonicMixerEncoder(final int encoderIndex, final int inc) {
+        switch (encoderIndex) {
+            case 0 -> adjustHarmonicNoteCount(inc);
+            case 1 -> adjustHarmonicOctaveSpan(inc);
+            case 2 -> adjustHarmonicBassColumns(inc);
+            case 3 -> adjustLivePitchOffset(inc);
+            default -> { }
+        }
+    }
+
+    private void showHarmonicMixerInfo(final int encoderIndex) {
+        switch (encoderIndex) {
+            case 0 -> oled.valueInfo("Notes", harmonicNoteCountDisplay());
+            case 1 -> oled.valueInfo("Octaves", Integer.toString(harmonicOctaveSpan));
+            case 2 -> oled.valueInfo("Bass Grid", harmonicBassColumns ? "On" : "Off");
+            case 3 -> oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay());
+            default -> oled.clearScreenDelayed();
         }
     }
 
@@ -756,55 +788,102 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }
     }
 
+    private void handleLivePitchGlissEncoder(final int inc) {
+        if (driver.isGlobalAltHeld()) {
+            toggleLivePitchGlissMode(inc);
+            return;
+        }
+        adjustLivePitchOffset(inc);
+    }
+
+    private void toggleLivePitchGlissMode(final int inc) {
+        if (inc == 0) {
+            return;
+        }
+        final LivePitchGlissMode next = inc < 0 ? LivePitchGlissMode.FIFTH_OCTAVE : LivePitchGlissMode.SCALE_DEGREE;
+        if (next == livePitchGlissMode) {
+            oled.valueInfo("Gliss Mode", livePitchGlissMode.displayName());
+            return;
+        }
+        livePitchGlissMode = next;
+        oled.valueInfo("Gliss Mode", livePitchGlissMode.displayName());
+    }
+
     private void adjustLivePitchOffset(final int inc) {
         final int steps = livePitchOffsetEncoder.consume(inc);
         if (steps == 0) {
             return;
         }
-        final int nextIndex = Math.max(0, Math.min(LIVE_PITCH_OFFSETS.length - 1, livePitchOffsetIndex + steps));
-        if (nextIndex == livePitchOffsetIndex) {
+        if (livePitchGlissMode == LivePitchGlissMode.FIFTH_OCTAVE) {
+            final int nextIndex = Math.max(0, Math.min(LIVE_PITCH_OFFSETS.length - 1, livePitchOffsetIndex + steps));
+            if (nextIndex == livePitchOffsetIndex) {
+                return;
+            }
+            liveControls.markEncoderAdjusted(1);
+            retuneLivePads(() -> livePitchOffsetIndex = nextIndex);
+            oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay());
+            return;
+        }
+        final int nextOffset = Math.max(MIN_SCALE_DEGREE_GLISS,
+                Math.min(MAX_SCALE_DEGREE_GLISS, liveScaleDegreeGlissOffset + steps));
+        if (nextOffset == liveScaleDegreeGlissOffset) {
             return;
         }
         liveControls.markEncoderAdjusted(1);
-        retuneLivePads(() -> livePitchOffsetIndex = nextIndex);
+        retuneLivePads(() -> liveScaleDegreeGlissOffset = nextOffset);
         oled.valueInfo("Pitch Gliss", formatLivePitchOffsetDisplay());
     }
 
-    private void adjustHarmonicGridSpan(final int inc) {
+    private void adjustHarmonicNoteCount(final int inc) {
         final int steps = liveVelocityEncoder.consume(inc);
         if (steps == 0) {
             return;
         }
-        final int next = Math.max(0, Math.min(HarmonicLatticeLayout.GRID_SPANS.length - 1, harmonicGridSpanIndex + steps));
-        if (next == harmonicGridSpanIndex) {
+        final int next = Math.max(0, Math.min(HarmonicLatticeLayout.NOTE_COUNTS.length - 1, harmonicNoteCountIndex + steps));
+        if (next == harmonicNoteCountIndex) {
             return;
         }
         liveControls.markEncoderAdjusted(0);
-        retuneLivePads(() -> harmonicGridSpanIndex = next);
-        oled.valueInfo("Width", harmonicGridSpanDisplay());
+        retuneLivePads(() -> harmonicNoteCountIndex = next);
+        oled.valueInfo("Notes", harmonicNoteCountDisplay());
     }
 
-    private void adjustHarmonicOctaveReach(final int inc) {
+    private void adjustHarmonicOctaveSpan(final int inc) {
         final int steps = liveOctaveEncoder.consume(inc);
         if (steps == 0) {
             return;
         }
-        final int next = Math.max(HarmonicLatticeLayout.MIN_OCTAVE_REACH,
-                Math.min(HarmonicLatticeLayout.MAX_OCTAVE_REACH, harmonicOctaveReach + steps));
-        if (next == harmonicOctaveReach) {
+        final int next = Math.max(1, Math.min(3, harmonicOctaveSpan + steps));
+        if (next == harmonicOctaveSpan) {
             return;
         }
         liveControls.markEncoderAdjusted(1);
-        retuneLivePads(() -> harmonicOctaveReach = next);
-        oled.valueInfo("Oct Reach", Integer.toString(harmonicOctaveReach));
+        retuneLivePads(() -> harmonicOctaveSpan = next);
+        oled.valueInfo("Octaves", Integer.toString(harmonicOctaveSpan));
     }
 
-    private String harmonicGridSpanDisplay() {
-        return Integer.toString(HarmonicLatticeLayout.GRID_SPANS[harmonicGridSpanIndex]);
+    private void adjustHarmonicBassColumns(final int inc) {
+        final int steps = liveLayoutEncoder.consume(inc);
+        if (steps == 0) {
+            return;
+        }
+        final boolean next = steps > 0;
+        if (next == harmonicBassColumns) {
+            return;
+        }
+        liveControls.markEncoderAdjusted(2);
+        retuneLivePads(() -> harmonicBassColumns = next);
+        oled.valueInfo("Bass Grid", harmonicBassColumns ? "On" : "Off");
+    }
+
+    private String harmonicNoteCountDisplay() {
+        return Integer.toString(HarmonicLatticeLayout.NOTE_COUNTS[harmonicNoteCountIndex]);
     }
 
     private int getHarmonicGlissStepOffset() {
-        return livePitchOffsetIndex - DEFAULT_LIVE_PITCH_OFFSET_INDEX;
+        return livePitchGlissMode == LivePitchGlissMode.FIFTH_OCTAVE
+                ? livePitchOffsetIndex - DEFAULT_LIVE_PITCH_OFFSET_INDEX
+                : liveScaleDegreeGlissOffset;
     }
 
     private String formatLivePitchExpressionDisplay() {
@@ -812,10 +891,17 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     }
 
     private String formatLivePitchOffsetDisplay() {
-        if (isHarmonicLiveMode()) {
-            return formatSignedValue(getHarmonicGlissStepOffset());
+        final int value = livePitchGlissMode == LivePitchGlissMode.FIFTH_OCTAVE
+                ? (isHarmonicLiveMode() ? getHarmonicGlissStepOffset() : getLivePitchOffset())
+                : liveScaleDegreeGlissOffset;
+        return "%s %s".formatted(livePitchGlissMode.displayName(), formatSignedValue(value));
+    }
+
+    private String liveEncoderModeInfo(final EncoderMode mode) {
+        if (isHarmonicLiveMode() && mode == EncoderMode.MIXER) {
+            return "1: Notes\n2: Octaves\n3: Bass Grid\n4: Pitch Gliss";
         }
-        return formatSignedValue(getLivePitchOffset());
+        return NoteLiveEncoderModeControls.modeInfo(mode);
     }
 
     private void resetLivePressure() {
@@ -2185,6 +2271,10 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         return liveNoteSubMode.displayName();
     }
 
+    public boolean isHarmonicNoteSubMode() {
+        return liveNoteSubMode == LiveNoteSubMode.HARMONIC;
+    }
+
     public void cycleNoteSubMode() {
         if (isChordStepSurface()) {
             toggleSurfaceVariant();
@@ -3046,7 +3136,8 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private LiveNoteLayout createLayout() {
         if (isHarmonicLiveMode()) {
             return new HarmonicLatticeLayout(getScale(), getRootNote(), getOctave(),
-                    HarmonicLatticeLayout.GRID_SPANS[harmonicGridSpanIndex], harmonicOctaveReach,
+                    HarmonicLatticeLayout.NOTE_COUNTS[harmonicNoteCountIndex],
+                    harmonicOctaveSpan,
                     harmonicBassColumns, getHarmonicGlissStepOffset());
         }
         return new NoteGridLayout(getScale(), getRootNote(), getOctave(), inKey);
@@ -3075,8 +3166,35 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         if (isHarmonicLiveMode()) {
             return midiNote;
         }
+        if (livePitchGlissMode == LivePitchGlissMode.SCALE_DEGREE) {
+            return transposeByScaleDegrees(midiNote, liveScaleDegreeGlissOffset);
+        }
         final int shifted = midiNote + getLivePitchOffset();
         return shifted >= 0 && shifted <= 127 ? shifted : -1;
+    }
+
+    private int transposeByScaleDegrees(final int midiNote, final int scaleDegrees) {
+        if (scaleDegrees == 0) {
+            return midiNote;
+        }
+        if (driver.getSharedScaleIndex() == PIANO_HIGHLIGHT_INDEX) {
+            final int shifted = midiNote + scaleDegrees;
+            return shifted >= 0 && shifted <= 127 ? shifted : -1;
+        }
+        int note = midiNote;
+        int remaining = Math.abs(scaleDegrees);
+        final int direction = scaleDegrees > 0 ? 1 : -1;
+        while (remaining > 0) {
+            note += direction;
+            while (note >= 0 && note <= 127 && !getScale().isMidiNoteInScale(getRootNote(), note)) {
+                note += direction;
+            }
+            if (note < 0 || note > 127) {
+                return -1;
+            }
+            remaining--;
+        }
+        return note;
     }
 
     private void clearTranslation() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -96,7 +96,7 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private static final int OIKORD_OCTAVE_ENCODER_THRESHOLD = 6;
     private static final int OIKORD_FAMILY_ENCODER_THRESHOLD = 8;
     private static final int LIVE_VELOCITY_ENCODER_THRESHOLD = 1;
-    private static final int LIVE_PITCH_OFFSET_ENCODER_THRESHOLD = 5;
+    private static final int LIVE_PITCH_OFFSET_ENCODER_THRESHOLD = 6;
     private static final int MIN_OIKORD_ROOT_OFFSET = -24;
     private static final int MAX_OIKORD_ROOT_OFFSET = 24;
     private static final int MIN_OIKORD_OCTAVE_OFFSET = -3;
@@ -111,7 +111,10 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private static final long TOUCH_RESET_RECENT_ADJUSTMENT_SUPPRESS_MS = 300L;
     private static final int TOUCH_RESET_TOLERATED_ADJUSTMENT_UNITS = 2;
     private static final int DEFAULT_TIMBRE = 64;
+    private static final int DEFAULT_LIVE_PITCH_BEND = 64;
     private static final int DEFAULT_LIVE_PITCH_EXPRESSION = 64;
+    private static final int LIVE_PITCH_BEND_RETURN_STEP = 6;
+    private static final long LIVE_PITCH_BEND_RETURN_DELAY_MS = 15L;
     private static final int MIDI_CC_MOD = 1;
     private static final int MIDI_CC_SUSTAIN = 64;
     private static final int MIDI_CC_SOSTENUTO = 66;
@@ -205,6 +208,9 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     private int playingStep = -1;
     private int pendingBankDir = 0;
     private int livePitchOffsetIndex = DEFAULT_LIVE_PITCH_OFFSET_INDEX;
+    private int livePitchBend = DEFAULT_LIVE_PITCH_BEND;
+    private boolean livePitchBendTouched = false;
+    private int livePitchBendReturnGeneration = 0;
     private boolean pendingBankFineMove = false;
     private boolean pendingBankLengthAdjust = false;
     private boolean bankMoveInFlight = false;
@@ -469,17 +475,15 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
 
     private void bindLiveChannelEncoders(final TouchEncoder[] encoders) {
         bindResettableLiveMidiEncoder(encoders[0], liveChannelLayer, 0, "Mod",
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT,
                 this::adjustLiveModulation, () -> Integer.toString(liveExpressionControls.modulation()), this::resetLiveModulation);
 
-        encoders[1].bindEncoder(liveChannelLayer, this::adjustLivePitchOffset);
-        encoders[1].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(1, touched,
+        bindLivePitchBendEncoder(encoders[1], liveChannelLayer, 1);
+
+        encoders[2].bindEncoder(liveChannelLayer, this::adjustLivePitchOffset);
+        encoders[2].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(2, touched,
                 () -> oled.valueInfo("Pitch Gliss", formatSignedValue(getLivePitchOffset())),
                 livePitchOffsetEncoder::reset));
-
-        encoders[2].bindEncoder(liveChannelLayer, this::handleLiveVelocityEncoder);
-        encoders[2].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(2, touched,
-                this::showLiveVelocityInfo,
-                liveVelocityEncoder::reset));
 
         encoders[3].bindEncoder(liveChannelLayer, this::handleEncoder1);
         encoders[3].bindTouched(liveChannelLayer, touched -> liveControls.handleResettableTouch(3, touched,
@@ -488,9 +492,11 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
     }
 
     private void bindLiveExpressionEncoders(final TouchEncoder[] encoders) {
-        bindResettableLiveMidiEncoder(encoders[0], liveUser1Layer, 0, "Aftertouch",
-                this::adjustLivePressure, () -> Integer.toString(liveExpressionControls.pressure()), this::resetLivePressure);
-        bindResettableLiveMidiEncoder(encoders[1], liveUser1Layer, 1, "Pressure",
+        encoders[0].bindEncoder(liveUser1Layer, inc -> handleLiveVelocityEncoder(0, inc));
+        encoders[0].bindTouched(liveUser1Layer, touched -> liveControls.handleResettableTouch(0, touched,
+                this::showLiveVelocityInfo,
+                liveVelocityEncoder::reset));
+        bindResettableLiveMidiEncoder(encoders[1], liveUser1Layer, 1, "Aftertouch",
                 this::adjustLivePressure, () -> Integer.toString(liveExpressionControls.pressure()), this::resetLivePressure);
         bindResettableLiveMidiEncoder(encoders[2], liveUser1Layer, 2, "Timbre",
                 this::adjustLiveTimbre, () -> Integer.toString(liveExpressionControls.timbre()), this::resetLiveTimbre);
@@ -548,21 +554,23 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }
     }
 
-    private void bindLiveMidiEncoder(final TouchEncoder encoder, final Layer layer, final String label,
-                                     final java.util.function.IntConsumer adjuster,
-                                     final java.util.function.IntSupplier valueSupplier) {
-        encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
-                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.GENTLE, adjuster::accept);
-        encoder.bindTouched(layer, touched -> liveControls.handleExpressionTouch(touched, label,
-                Integer.toString(valueSupplier.getAsInt())));
-    }
-
     private void bindResettableLiveMidiEncoder(final TouchEncoder encoder, final Layer layer, final int encoderIndex,
                                                final String label, final java.util.function.IntConsumer adjuster,
                                                final java.util.function.Supplier<String> valueSupplier,
                                                final Runnable resetAction) {
+        bindResettableLiveMidiEncoder(encoder, layer, encoderIndex, label,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.GENTLE,
+                adjuster, valueSupplier, resetAction);
+    }
+
+    private void bindResettableLiveMidiEncoder(final TouchEncoder encoder, final Layer layer, final int encoderIndex,
+                                               final String label,
+                                               final com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile profile,
+                                               final java.util.function.IntConsumer adjuster,
+                                               final java.util.function.Supplier<String> valueSupplier,
+                                               final Runnable resetAction) {
         encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
-                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.GENTLE, inc -> {
+                profile, inc -> {
             if (inc == 0) {
                 return;
             }
@@ -574,12 +582,29 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 resetAction));
     }
 
+    private void bindLivePitchBendEncoder(final TouchEncoder encoder, final Layer layer, final int encoderIndex) {
+        encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld,
+                com.oikoaudio.fire.control.ContinuousEncoderScaler.Profile.SOFT, inc -> {
+                    if (inc == 0) {
+                        return;
+                    }
+                    liveControls.markEncoderAdjusted(encoderIndex);
+                    cancelLivePitchBendReturn();
+                    adjustLivePitchBend(inc);
+                });
+        encoder.bindTouched(layer, this::handleLivePitchBendTouch);
+    }
+
     private void handleLiveVelocityEncoder(final int inc) {
+        handleLiveVelocityEncoder(1, inc);
+    }
+
+    private void handleLiveVelocityEncoder(final int encoderIndex, final int inc) {
         final int steps = liveVelocityEncoder.consume(inc);
         if (steps == 0) {
             return;
         }
-        liveControls.markEncoderAdjusted(1);
+        liveControls.markEncoderAdjusted(encoderIndex);
         if (driver.isGlobalShiftHeld()) {
             final int nextVelocity = Math.max(MIN_VELOCITY, Math.min(MAX_MIDI_VALUE, liveVelocity + steps));
             if (nextVelocity == liveVelocity) {
@@ -644,6 +669,16 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         }
     }
 
+    private void adjustLivePitchBend(final int inc) {
+        final int next = Math.max(MIN_MIDI_VALUE, Math.min(MAX_MIDI_VALUE, livePitchBend + inc));
+        if (next == livePitchBend) {
+            return;
+        }
+        livePitchBend = next;
+        liveExpressionControls.setTransientPitchBendValue(livePitchBend);
+        oled.valueInfo("Pitch Bend", formatSignedValue(livePitchBend - DEFAULT_LIVE_PITCH_BEND));
+    }
+
     private void adjustLivePitchExpression(final int inc) {
         if (liveExpressionControls.adjustPitchExpression(inc)) {
             oled.valueInfo("Pitch Expr", formatLivePitchExpressionDisplay());
@@ -682,6 +717,47 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
 
     private void resetLivePitchExpression() {
         liveExpressionControls.resetPitchExpression();
+    }
+
+    private void handleLivePitchBendTouch(final boolean touched) {
+        livePitchBendTouched = touched;
+        cancelLivePitchBendReturn();
+        if (touched) {
+            oled.valueInfo("Pitch Bend", formatSignedValue(livePitchBend - DEFAULT_LIVE_PITCH_BEND));
+            return;
+        }
+        scheduleLivePitchBendReturn();
+    }
+
+    private void scheduleLivePitchBendReturn() {
+        if (livePitchBend == DEFAULT_LIVE_PITCH_BEND) {
+            oled.clearScreenDelayed();
+            return;
+        }
+        final int generation = ++livePitchBendReturnGeneration;
+        driver.getHost().scheduleTask(() -> continueLivePitchBendReturn(generation), LIVE_PITCH_BEND_RETURN_DELAY_MS);
+    }
+
+    private void continueLivePitchBendReturn(final int generation) {
+        if (generation != livePitchBendReturnGeneration || livePitchBendTouched) {
+            return;
+        }
+        if (livePitchBend < DEFAULT_LIVE_PITCH_BEND) {
+            livePitchBend = Math.min(DEFAULT_LIVE_PITCH_BEND, livePitchBend + LIVE_PITCH_BEND_RETURN_STEP);
+        } else if (livePitchBend > DEFAULT_LIVE_PITCH_BEND) {
+            livePitchBend = Math.max(DEFAULT_LIVE_PITCH_BEND, livePitchBend - LIVE_PITCH_BEND_RETURN_STEP);
+        }
+        liveExpressionControls.setTransientPitchBendValue(livePitchBend);
+        oled.valueInfo("Pitch Bend", formatSignedValue(livePitchBend - DEFAULT_LIVE_PITCH_BEND));
+        if (livePitchBend == DEFAULT_LIVE_PITCH_BEND) {
+            oled.clearScreenDelayed();
+            return;
+        }
+        driver.getHost().scheduleTask(() -> continueLivePitchBendReturn(generation), LIVE_PITCH_BEND_RETURN_DELAY_MS);
+    }
+
+    private void cancelLivePitchBendReturn() {
+        livePitchBendReturnGeneration++;
     }
 
     private int getLivePitchOffset() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -886,14 +886,22 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
                 : liveScaleDegreeGlissOffset;
     }
 
+    static int displayPitchGlissValue(final boolean fifthOctaveMode,
+                                      final int livePitchOffset,
+                                      final int scaleDegreeGlissOffset) {
+        if (!fifthOctaveMode) {
+            return scaleDegreeGlissOffset;
+        }
+        return livePitchOffset;
+    }
+
     private String formatLivePitchExpressionDisplay() {
         return formatSignedValue(liveExpressionControls.pitchExpression() - DEFAULT_LIVE_PITCH_EXPRESSION);
     }
 
     private String formatLivePitchOffsetDisplay() {
-        final int value = livePitchGlissMode == LivePitchGlissMode.FIFTH_OCTAVE
-                ? (isHarmonicLiveMode() ? getHarmonicGlissStepOffset() : getLivePitchOffset())
-                : liveScaleDegreeGlissOffset;
+        final int value = displayPitchGlissValue(livePitchGlissMode == LivePitchGlissMode.FIFTH_OCTAVE,
+                getLivePitchOffset(), liveScaleDegreeGlissOffset);
         return "%s %s".formatted(livePitchGlissMode.displayName(), formatSignedValue(value));
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -2275,6 +2275,13 @@ abstract class PitchedSurfaceLayer extends Layer implements StepSequencerHost, S
         return liveNoteSubMode == LiveNoteSubMode.HARMONIC;
     }
 
+    public void resetNoteSubMode() {
+        if (isChordStepSurface() || liveNoteSubMode == LiveNoteSubMode.MELODIC) {
+            return;
+        }
+        applyLayoutChange(() -> liveNoteSubMode = LiveNoteSubMode.MELODIC);
+    }
+
     public void cycleNoteSubMode() {
         if (isChordStepSurface()) {
             toggleSurfaceVariant();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -32,11 +32,32 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PerformClipLauncherMode extends Layer {
+    private enum Orientation {
+        VERTICAL("PerformV"),
+        HORIZONTAL("PerformH");
+
+        private final String label;
+
+        Orientation(final String label) {
+            this.label = label;
+        }
+
+        Orientation toggle() {
+            return this == VERTICAL ? HORIZONTAL : VERTICAL;
+        }
+
+        String label() {
+            return label;
+        }
+    }
+
     private static final long PARAMETER_RESET_TOUCH_HOLD_MS = 1000;
     private static final long PARAMETER_RESET_RECENT_ADJUSTMENT_SUPPRESS_MS = 300;
     private static final int PARAMETER_RESET_TOLERATED_ADJUSTMENT_UNITS = 2;
-    private static final int TRACKS = 16;
-    private static final int SCENES = 4;
+    private static final int PAD_COLUMNS = 16;
+    private static final int PAD_ROWS = 4;
+    private static final int MAX_TRACKS = 16;
+    private static final int MAX_SCENES = 16;
     private static final double MIN_DUPLICATE_CLIP_LENGTH = 1.0;
     private static final double MAX_DUPLICATE_CLIP_LENGTH = 256.0;
     private static final RgbLigthState SETTINGS_LOGO_ON = new RgbLigthState(127, 20, 0, true);
@@ -65,9 +86,9 @@ public class PerformClipLauncherMode extends Layer {
     private final Layer user2Layer;
     private final Map<EncoderMode, Layer> modeMapping = new HashMap<>();
 
-    private final RgbLigthState[] slotColors = new RgbLigthState[TRACKS * SCENES];
-    private final String[] trackNames = new String[TRACKS];
-    private final String[] sceneNames = new String[SCENES];
+    private final RgbLigthState[] slotColors = new RgbLigthState[MAX_TRACKS * MAX_SCENES];
+    private final String[] trackNames = new String[MAX_TRACKS];
+    private final String[] sceneNames = new String[MAX_SCENES];
     private final BooleanValueObject selectHeld = new BooleanValueObject();
     private final BooleanValueObject copyHeld = new BooleanValueObject();
     private final BooleanValueObject deleteHeld = new BooleanValueObject();
@@ -77,11 +98,12 @@ public class PerformClipLauncherMode extends Layer {
     private Layer currentEncoderLayer;
     private EncoderMode encoderMode = EncoderMode.CHANNEL;
     private int blinkState;
-    private int totalTrackCount = TRACKS;
-    private int totalSceneCount = SCENES;
+    private int totalTrackCount = MAX_TRACKS;
+    private int totalSceneCount = MAX_SCENES;
     private int selectedTrackIndex = -1;
     private int selectedSceneIndex = -1;
     private boolean settingsMode = false;
+    private Orientation orientation = Orientation.VERTICAL;
 
     public PerformClipLauncherMode(final AkaiFireOikontrolExtension driver) {
         super(driver.getLayers(), "PERFORM_CLIP_LAUNCHER");
@@ -89,7 +111,7 @@ public class PerformClipLauncherMode extends Layer {
         this.sharedMusicalContext = driver.getSharedMusicalContext();
         final ControllerHost host = driver.getHost();
         this.oled = driver.getOled();
-        this.trackBank = host.createTrackBank(TRACKS, 0, SCENES);
+        this.trackBank = host.createTrackBank(MAX_TRACKS, 0, MAX_SCENES);
         this.cursorTrack = driver.getViewControl().getCursorTrack();
         this.project = host.getProject();
         this.projectRemoteControls = project.getRootTrackGroup().createCursorRemoteControlsPage(8);
@@ -119,7 +141,7 @@ public class PerformClipLauncherMode extends Layer {
 
     private void initGrid() {
         final RgbButton[] rgbButtons = driver.getRgbButtons();
-        for (int sceneIndex = 0; sceneIndex < SCENES; sceneIndex++) {
+        for (int sceneIndex = 0; sceneIndex < MAX_SCENES; sceneIndex++) {
             final Scene scene = trackBank.sceneBank().getScene(sceneIndex);
             scene.exists().markInterested();
             scene.name().markInterested();
@@ -128,7 +150,7 @@ public class PerformClipLauncherMode extends Layer {
             sceneNames[row] = scene.name().get();
         }
 
-        for (int trackIndex = 0; trackIndex < TRACKS; trackIndex++) {
+        for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
             final Track track = trackBank.getItemAt(trackIndex);
             track.exists().markInterested();
             track.name().markInterested();
@@ -136,8 +158,8 @@ public class PerformClipLauncherMode extends Layer {
             track.name().addValueObserver(name -> trackNames[column] = name);
             trackNames[column] = track.name().get();
 
-            for (int sceneIndex = 0; sceneIndex < SCENES; sceneIndex++) {
-                final int padIndex = toPadIndex(trackIndex, sceneIndex);
+            for (int sceneIndex = 0; sceneIndex < MAX_SCENES; sceneIndex++) {
+                final int slotIndex = toSlotIndex(trackIndex, sceneIndex);
                 final int row = sceneIndex;
                 final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(sceneIndex);
                 slot.exists().markInterested();
@@ -149,17 +171,20 @@ public class PerformClipLauncherMode extends Layer {
                 slot.isRecordingQueued().markInterested();
                 slot.isStopQueued().markInterested();
                 slot.color().markInterested();
-                slot.color().addValueObserver((r, g, b) -> slotColors[padIndex] = ColorLookup.getColor(r, g, b));
+                slot.color().addValueObserver((r, g, b) -> slotColors[slotIndex] = ColorLookup.getColor(r, g, b));
                 slot.isSelected().addValueObserver(selected -> {
                     if (selected) {
                         selectedTrackIndex = trackBank.scrollPosition().get() + column;
                         selectedSceneIndex = trackBank.sceneBank().scrollPosition().get() + row;
                     }
                 });
-                slotColors[padIndex] = ColorLookup.getColor(slot.color().get());
-                rgbButtons[padIndex].bindPressed(this, pressed -> handleSlotPressed(track, slot, column, row, pressed),
-                        () -> getSlotState(slot, padIndex));
+                slotColors[slotIndex] = ColorLookup.getColor(slot.color().get());
             }
+        }
+        for (int padIndex = 0; padIndex < rgbButtons.length; padIndex++) {
+            final int currentPad = padIndex;
+            rgbButtons[padIndex].bindPressed(this, pressed -> handlePadPressed(currentPad, pressed),
+                    () -> getPadState(currentPad));
         }
     }
 
@@ -202,13 +227,23 @@ public class PerformClipLauncherMode extends Layer {
         return settingsMode;
     }
 
+    public void toggleOrientation() {
+        orientation = orientation.toggle();
+        showCurrentModeInfo();
+        oled.clearScreenDelayed();
+    }
+
+    public String modeLabel() {
+        return orientation.label();
+    }
+
     private void bindChannelPage(final Layer layer, final CursorRemoteControlsPage page, final String fallbackPrefix) {
         final TouchEncoder[] encoders = driver.getEncoders();
         for (int i = 0; i < encoders.length; i++) {
             final int index = i;
             final Parameter parameter = page.getParameter(i);
             markParameterInterested(parameter);
-            encoders[i].bindEncoder(layer, inc -> {
+            encoders[i].bindContinuousEncoder(layer, this::isShiftHeld, inc -> {
                 if (settingsMode) {
                     adjustOverviewPitch(index, inc);
                     return;
@@ -231,7 +266,7 @@ public class PerformClipLauncherMode extends Layer {
             final int index = i;
             final Parameter parameter = page.getParameter(i);
             markParameterInterested(parameter);
-            encoders[i].bindEncoder(layer,
+            encoders[i].bindContinuousEncoder(layer, this::isShiftHeld,
                     inc -> adjustParameter(index, parameter, fallbackPrefix + " " + (index + 1), inc));
             encoders[i].bindTouched(layer, touched -> handleParameterTouch(index, parameter,
                     fallbackPrefix + " " + (index + 1), touched));
@@ -294,7 +329,8 @@ public class PerformClipLauncherMode extends Layer {
             final Parameter parameter = parameters[i];
             markParameterInterested(parameter);
             final String label = fallbackLabels[i];
-            encoders[i].bindEncoder(layer, inc -> adjustParameter(index, parameter, label, inc));
+            encoders[i].bindContinuousEncoder(layer, this::isShiftHeld,
+                    inc -> adjustParameter(index, parameter, label, inc));
             encoders[i].bindTouched(layer, touched -> handleParameterTouch(index, parameter, label, touched));
         }
     }
@@ -356,6 +392,19 @@ public class PerformClipLauncherMode extends Layer {
                 oled.clearScreenDelayed();
             }
         }, () -> button.isPressed() ? activeColor : BiColorLightState.OFF);
+    }
+
+    private void handlePadPressed(final int padIndex, final boolean pressed) {
+        final int visibleTrackIndex = visibleTrackIndexForPad(padIndex);
+        final int visibleSceneIndex = visibleSceneIndexForPad(padIndex);
+        if (visibleTrackIndex < 0 || visibleSceneIndex < 0
+                || visibleTrackIndex >= visibleTrackCount()
+                || visibleSceneIndex >= visibleSceneCount()) {
+            return;
+        }
+        final Track track = trackBank.getItemAt(visibleTrackIndex);
+        final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+        handleSlotPressed(track, slot, visibleTrackIndex, visibleSceneIndex, pressed);
     }
 
     private void handleSlotPressed(final Track track, final ClipLauncherSlot slot, final int visibleTrackIndex,
@@ -426,7 +475,8 @@ public class PerformClipLauncherMode extends Layer {
 
         final int visibleTrackIndex = selectedTrackIndex - trackBank.scrollPosition().get();
         final int visibleSceneIndex = selectedSceneIndex - trackBank.sceneBank().scrollPosition().get();
-        if (visibleTrackIndex < 0 || visibleTrackIndex >= TRACKS || visibleSceneIndex < 0 || visibleSceneIndex >= SCENES) {
+        if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
+                || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
             oled.valueInfo("Duplicate Clip", "Selected clip off page");
             return;
         }
@@ -472,7 +522,7 @@ public class PerformClipLauncherMode extends Layer {
         final int next = clamp(current + (direction * increment), 0, maxTrackOffset());
         if (next != current) {
             trackBank.scrollPosition().set(next);
-            oled.valueInfo("Perform Tracks", offsetLabel(next, totalTrackCount, TRACKS));
+            oled.valueInfo("Perform Tracks", offsetLabel(next, totalTrackCount, visibleTrackCount()));
         }
     }
 
@@ -485,7 +535,7 @@ public class PerformClipLauncherMode extends Layer {
         final int next = clamp(current + (direction * increment), 0, maxSceneOffset());
         if (next != current) {
             trackBank.sceneBank().scrollPosition().set(next);
-            oled.valueInfo("Perform Scenes", offsetLabel(next, totalSceneCount, SCENES));
+            oled.valueInfo("Perform Scenes", offsetLabel(next, totalSceneCount, visibleSceneCount()));
         }
     }
 
@@ -630,11 +680,11 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private int trackScrollAmount() {
-        return isShiftHeld() ? 1 : TRACKS;
+        return isShiftHeld() ? 1 : visibleTrackCount();
     }
 
     private int sceneScrollAmount() {
-        return isShiftHeld() ? 1 : SCENES;
+        return isShiftHeld() ? 1 : visibleSceneCount();
     }
 
     private boolean canScrollTracks(final int direction) {
@@ -648,11 +698,11 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private int maxTrackOffset() {
-        return Math.max(0, totalTrackCount - TRACKS);
+        return Math.max(0, totalTrackCount - visibleTrackCount());
     }
 
     private int maxSceneOffset() {
-        return Math.max(0, totalSceneCount - SCENES);
+        return Math.max(0, totalSceneCount - visibleSceneCount());
     }
 
     private boolean isShiftHeld() {
@@ -667,7 +717,8 @@ public class PerformClipLauncherMode extends Layer {
         final int sceneOffset = trackBank.sceneBank().scrollPosition().get();
         final int visibleTrackIndex = selectedTrackIndex - trackOffset;
         final int visibleSceneIndex = selectedSceneIndex - sceneOffset;
-        if (visibleTrackIndex < 0 || visibleTrackIndex >= TRACKS || visibleSceneIndex < 0 || visibleSceneIndex >= SCENES) {
+        if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
+                || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
             return null;
         }
         return trackBank.getItemAt(visibleTrackIndex).clipLauncherSlotBank().getItemAt(visibleSceneIndex);
@@ -690,9 +741,24 @@ public class PerformClipLauncherMode extends Layer {
         currentEncoderLayer.deactivate();
     }
 
-    private RgbLigthState getSlotState(final ClipLauncherSlot slot, final int padIndex) {
+    private RgbLigthState getPadState(final int padIndex) {
         if (settingsMode) {
             return settingsLogoState(padIndex);
+        }
+        final int visibleTrackIndex = visibleTrackIndexForPad(padIndex);
+        final int visibleSceneIndex = visibleSceneIndexForPad(padIndex);
+        if (visibleTrackIndex < 0 || visibleSceneIndex < 0
+                || visibleTrackIndex >= visibleTrackCount()
+                || visibleSceneIndex >= visibleSceneCount()) {
+            return RgbLigthState.OFF;
+        }
+        final ClipLauncherSlot slot = trackBank.getItemAt(visibleTrackIndex).clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+        return getSlotState(slot, visibleTrackIndex, visibleSceneIndex);
+    }
+
+    private RgbLigthState getSlotState(final ClipLauncherSlot slot, final int visibleTrackIndex, final int visibleSceneIndex) {
+        if (settingsMode) {
+            return settingsLogoState(toPadIndex(visibleTrackIndex, visibleSceneIndex));
         }
         if (!slot.exists().get()) {
             return RgbLigthState.OFF;
@@ -701,7 +767,9 @@ public class PerformClipLauncherMode extends Layer {
             return slot.isSelected().get() ? RgbLigthState.GRAY_2 : RgbLigthState.GRAY_1;
         }
 
-        final RgbLigthState baseColor = slotColors[padIndex] == null ? RgbLigthState.WHITE : slotColors[padIndex];
+        final RgbLigthState baseColor = slotColors[toSlotIndex(visibleTrackIndex, visibleSceneIndex)] == null
+                ? RgbLigthState.WHITE
+                : slotColors[toSlotIndex(visibleTrackIndex, visibleSceneIndex)];
         if (slot.isRecording().get()) {
             return blinkFast(baseColor.getBrightest(), baseColor);
         }
@@ -719,9 +787,9 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private RgbLigthState settingsLogoState(final int padIndex) {
-        final int row = padIndex / TRACKS;
-        final int column = padIndex % TRACKS;
-        if (row < 0 || row >= SETTINGS_LOGO.length || column < 0 || column >= TRACKS) {
+        final int row = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        if (row < 0 || row >= SETTINGS_LOGO.length || column < 0 || column >= PAD_COLUMNS) {
             return RgbLigthState.OFF;
         }
         return SETTINGS_LOGO[row][column] ? SETTINGS_LOGO_ON : SETTINGS_LOGO_OFF;
@@ -738,10 +806,10 @@ public class PerformClipLauncherMode extends Layer {
     private String slotLabel(final int absoluteTrackIndex, final int absoluteSceneIndex) {
         final int visibleTrackIndex = absoluteTrackIndex - trackBank.scrollPosition().get();
         final int visibleSceneIndex = absoluteSceneIndex - trackBank.sceneBank().scrollPosition().get();
-        final String trackName = visibleTrackIndex >= 0 && visibleTrackIndex < TRACKS
+        final String trackName = visibleTrackIndex >= 0 && visibleTrackIndex < MAX_TRACKS
                 ? nameOrFallback(trackNames[visibleTrackIndex], "Track " + (absoluteTrackIndex + 1))
                 : "Track " + (absoluteTrackIndex + 1);
-        final String sceneName = visibleSceneIndex >= 0 && visibleSceneIndex < SCENES
+        final String sceneName = visibleSceneIndex >= 0 && visibleSceneIndex < MAX_SCENES
                 ? nameOrFallback(sceneNames[visibleSceneIndex], "Scene " + (absoluteSceneIndex + 1))
                 : "Scene " + (absoluteSceneIndex + 1);
         return trackName + " / " + sceneName;
@@ -772,8 +840,35 @@ public class PerformClipLauncherMode extends Layer {
         return value == null || value.isBlank() ? fallback : value;
     }
 
-    private int toPadIndex(final int trackIndex, final int sceneIndex) {
-        return sceneIndex * TRACKS + trackIndex;
+    private int visibleTrackCount() {
+        return orientation == Orientation.VERTICAL ? PAD_COLUMNS : PAD_ROWS;
+    }
+
+    private int visibleSceneCount() {
+        return orientation == Orientation.VERTICAL ? PAD_ROWS : PAD_COLUMNS;
+    }
+
+    private int visibleTrackIndexForPad(final int padIndex) {
+        final int row = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        return orientation == Orientation.VERTICAL ? column : row;
+    }
+
+    private int visibleSceneIndexForPad(final int padIndex) {
+        final int row = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        return orientation == Orientation.VERTICAL ? row : column;
+    }
+
+    private int toPadIndex(final int visibleTrackIndex, final int visibleSceneIndex) {
+        if (orientation == Orientation.VERTICAL) {
+            return visibleSceneIndex * PAD_COLUMNS + visibleTrackIndex;
+        }
+        return visibleTrackIndex * PAD_COLUMNS + visibleSceneIndex;
+    }
+
+    private int toSlotIndex(final int trackIndex, final int sceneIndex) {
+        return sceneIndex * MAX_TRACKS + trackIndex;
     }
 
     private int clamp(final int value, final int min, final int max) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -1367,7 +1367,7 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
             @Override
             public void bind(final StepSequencerEncoderHandler handler, final Layer layer, final TouchEncoder encoder,
                              final int slotIndex) {
-                encoder.bindEncoder(layer, inc -> {
+                encoder.bindContinuousEncoder(layer, driver::isGlobalShiftHeld, inc -> {
                     if (padHandler.adjustMixerParameter(index, inc)) {
                         padHandler.showMixerDisplay(index, name);
                     } else {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/StepSequencerEncoderHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/StepSequencerEncoderHandler.java
@@ -8,6 +8,7 @@ import com.oikoaudio.fire.AkaiFireOikontrolExtension;
 import com.oikoaudio.fire.NoteAssign;
 import com.oikoaudio.fire.control.BiColorButton;
 import com.oikoaudio.fire.control.EncoderStepAccumulator;
+import com.oikoaudio.fire.control.ContinuousEncoderScaler;
 import com.oikoaudio.fire.control.TouchEncoder;
 import com.oikoaudio.fire.control.TouchResetGesture;
 import com.oikoaudio.fire.display.OledDisplay;
@@ -108,13 +109,16 @@ public class StepSequencerEncoderHandler extends Layer {
         // No alternate page variants in the shared step-page model.
 	}
 
-	public void bindNoteAccess(final Layer layer, final TouchEncoder encoder, final int slotIndex,
+    public void bindNoteAccess(final Layer layer, final TouchEncoder encoder, final int slotIndex,
                                final NoteStepAccess access) {
         final EncoderStepAccumulator accumulator = access.getStepThreshold() > 1
                 ? new EncoderStepAccumulator(access.getStepThreshold())
                 : null;
+        final ContinuousEncoderScaler scaler = accumulator == null ? new ContinuousEncoderScaler() : null;
 		encoder.bindEncoder(layer, inc -> {
-            final int effectiveInc = accumulator != null ? accumulator.consume(inc) : inc;
+            final int effectiveInc = accumulator != null
+                    ? accumulator.consume(inc)
+                    : scaler.scale(inc, driver.isGlobalShiftHeld());
             if (effectiveInc != 0) {
                 recordTouchAdjustment(slotIndex, Math.abs(effectiveInc));
                 handleMod(effectiveInc, access);
@@ -123,6 +127,9 @@ public class StepSequencerEncoderHandler extends Layer {
 		encoder.bindTouched(layer, touched -> {
             if (!touched && accumulator != null) {
                 accumulator.reset();
+            }
+            if (!touched && scaler != null) {
+                scaler.reset();
             }
             handleTouch(slotIndex, touched, access);
         });

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -209,6 +209,12 @@
         <li><code>User 1</code>: step behavior page</li>
         <li><code>User 2</code>: Euclid controls</li>
       </ul>
+      <p>Expression note:</p>
+      <ul>
+        <li>step-expression editing in <code>DRUM</code> writes Bitwig note-expression data into the clip, per drum hit</li>
+        <li><code>Pressure</code> and <code>Timbre</code> here are per-step note-expression values, not a single live channel-wide MIDI stream</li>
+        <li>that is why different drum hits or drum chains can respond differently inside the same clip</li>
+      </ul>
       <p>Preferences that matter:</p>
       <ul>
         <li><code>Drum Mode Pinning</code></li>
@@ -257,6 +263,13 @@
         <li>Press <code>NOTE</code> again to move between the primary note-family surfaces.</li>
         <li>Use <code>PATTERN UP/DOWN</code> for octave, <code>SHIFT + PATTERN UP/DOWN</code> for shared root, and the Channel page for <code>Scale</code>, <code>Pitch Gliss</code>, and live velocity response.</li>
       </ol>
+      <p>Expression behavior in <code>NOTE</code> is split between live input and sequenced note data:</p>
+      <ul>
+        <li>the live <code>User 1</code> page sends channel-wide expressive MIDI for performance input, not per-note expression edits on an existing clip</li>
+        <li>today that page sends <code>Pressure</code> as channel aftertouch, <code>Timbre</code> as CC 74, and <code>Pitch Expr</code> as pitch bend</li>
+        <li>Bitwig can record those live messages into note-expression lanes while recording, but turning those encoders during playback does not inject per-note expression into notes that are already in a clip</li>
+        <li>the duplicated <code>Aftertouch</code> and <code>Pressure</code> controls currently drive the same channel-aftertouch source</li>
+      </ul>
 
       <h3>Melodic Step workflow</h3>
       <p><code>Melodic Step</code> is a generated and editable mono phrase sequencer for basslines, motifs, and melodic hooks.</p>
@@ -294,7 +307,8 @@
       <ul>
         <li><code>Channel</code>: primary phrase setup, pool shaping, and mutation controls</li>
         <li><code>Mixer</code>: melodic process transforms</li>
-        <li><code>User 1</code>: secondary generator-shaping controls</li>
+        <li><code>ALT + Mixer</code>: secondary generator-shaping controls</li>
+        <li><code>User 1</code>: per-note expression for the selected or held melodic note</li>
         <li><code>User 2</code>: selected or held step properties</li>
       </ul>
       <p>Channel page details:</p>
@@ -307,12 +321,19 @@
         <li>Encoder 4: <code>Mutation Type</code></li>
         <li><code>ALT + Encoder 4</code>: mutation strength</li>
       </ul>
-      <p><code>User 1</code> is the secondary generator-shaping page:</p>
+      <p><code>ALT + Mixer</code> exposes the secondary generator-shaping controls:</p>
       <ul>
         <li>Encoder 1: engine-specific motion or contour control such as motion, answer, movement, or jump</li>
         <li>Encoder 2: <code>Tension</code></li>
         <li>Encoder 3: <code>Legato</code>, which biases slide and gate behavior inside the generator</li>
         <li>Encoder 4: recurrence span entry; hold it and use the step rows to draw the recurrence mask for the selected step</li>
+      </ul>
+      <p><code>User 1</code> is the per-note expression page:</p>
+      <ul>
+        <li>Encoder 1: selected or held step velocity</li>
+        <li>Encoder 2: selected or held step pressure</li>
+        <li>Encoder 3: selected or held step timbre</li>
+        <li>Encoder 4: selected or held step pitch expression</li>
       </ul>
       <p><code>User 2</code> is the per-step property page:</p>
       <ul>
@@ -320,6 +341,12 @@
         <li>Encoder 2: selected or held step gate length</li>
         <li>Encoder 3: selected or held step velocity</li>
         <li>Encoder 4: selected or held step chance</li>
+      </ul>
+      <p>Expression note:</p>
+      <ul>
+        <li><code>Melodic Step</code> edits note data inside the clip rather than sending live channel expression</li>
+        <li>when a step or selected note exposes expression properties, those are Bitwig per-note values stored with the sequence</li>
+        <li>this is a different path from live <code>NOTE</code> mode, where the encoders send incoming performance MIDI such as channel aftertouch or CC 74</li>
       </ul>
       <p>Melodic left-side buttons now align with the shared sequencer clip/edit workflow:</p>
       <ul>
@@ -381,6 +408,11 @@
         <li>coarse nudge is intentionally disabled in <code>Chord Step</code></li>
         <li>chord-step micro-timing is currently temperamental and should be treated as experimental</li>
       </ul>
+      <p>Expression note:</p>
+      <ul>
+        <li>like <code>DRUM</code> and <code>Melodic Step</code>, any step-expression editing here is clip note data, not a live channel-wide performance stream</li>
+        <li>that means per-step expression can differ across notes or steps inside the same clip</li>
+      </ul>
 
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the clip-launch and performance surface.</p>
@@ -389,6 +421,7 @@
         <li>pads show clip color and launch state</li>
         <li>empty slots can create a new clip using the current <code>Default Clip Length</code> preference</li>
         <li>quick select, copy, delete, and clip-length gestures live on the <code>MUTE</code> buttons</li>
+        <li>press <code>PERFORM</code> again while already in the mode to toggle between <code>PerformV</code> and <code>PerformH</code></li>
       </ul>
       <p>Important gestures:</p>
       <ul>
@@ -407,6 +440,12 @@
         <li><code>Mixer</code>: volume, pan, send 1, send 2</li>
         <li><code>User 1</code>: track remotes 1-4</li>
         <li><code>User 2</code>: master / cue controls</li>
+      </ul>
+      <p>Orientation note:</p>
+      <ul>
+        <li><code>PerformV</code> is the original view: tracks by column, scenes by row</li>
+        <li><code>PerformH</code> rotates the grid: tracks by row, scenes by column</li>
+        <li>top row in <code>PerformH</code> is the first visible track of the current page</li>
       </ul>
       <p><code>SHIFT + PERFORM</code> opens a latched <code>Settings</code> page. From there, Encoder 1 adjusts the shared <code>Root Key</code>, Encoder 2 adjusts the shared <code>Scale</code>, and the pad grid becomes a non-performance settings display. Press <code>PERFORM</code> again to leave <code>Settings</code>.</p>
 

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -261,14 +261,14 @@
         <li>Enter <code>NOTE</code>.</li>
         <li>Play notes directly on the pad grid.</li>
         <li>Press <code>NOTE</code> again to move between the primary note-family surfaces.</li>
-        <li>Use <code>PATTERN UP/DOWN</code> for octave, <code>SHIFT + PATTERN UP/DOWN</code> for shared root, and the Channel page for <code>Scale</code>, <code>Pitch Gliss</code>, and live velocity response.</li>
+        <li>Use <code>PATTERN UP/DOWN</code> for octave, <code>SHIFT + PATTERN UP/DOWN</code> for shared root, and the Channel page for <code>Mod</code>, <code>Pitch Bend</code>, <code>Pitch Gliss</code>, and <code>Scale</code>.</li>
       </ol>
       <p>Expression behavior in <code>NOTE</code> is split between live input and sequenced note data:</p>
       <ul>
-        <li>the live <code>User 1</code> page sends channel-wide expressive MIDI for performance input, not per-note expression edits on an existing clip</li>
-        <li>today that page sends <code>Pressure</code> as channel aftertouch, <code>Timbre</code> as CC 74, and <code>Pitch Expr</code> as pitch bend</li>
+        <li>the live <code>User 1</code> page now combines live velocity response with channel-wide expressive MIDI controls, not per-note expression edits on an existing clip</li>
+        <li>today that page is <code>Velocity</code>, <code>Aftertouch</code>, <code>Timbre</code>, and <code>Pitch Expr</code></li>
+        <li>the Channel page carries the performance controls <code>Mod</code>, spring-return <code>Pitch Bend</code>, <code>Pitch Gliss</code>, and <code>Scale</code>; <code>Aftertouch</code> sends channel aftertouch, <code>Timbre</code> sends CC 74, and <code>Pitch Expr</code> is the persistent pitch-expression control</li>
         <li>Bitwig can record those live messages into note-expression lanes while recording, but turning those encoders during playback does not inject per-note expression into notes that are already in a clip</li>
-        <li>the duplicated <code>Aftertouch</code> and <code>Pressure</code> controls currently drive the same channel-aftertouch source</li>
       </ul>
 
       <h3>Melodic Step workflow</h3>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -246,22 +246,21 @@
       <p>Useful live-note controls:</p>
       <ul>
         <li><code>PATTERN UP/DOWN</code>: octave</li>
+        <li><code>ALT + NOTE</code>: local layout shortcut</li>
+        <li><code>SHIFT + Encoder 4</code>: local layout</li>
+        <li><code>Encoder 4</code>: shared scale</li>
+        <li><code>ALT + Encoder 4</code>: shared root</li>
         <li><code>SHIFT + PATTERN UP/DOWN</code>: root</li>
         <li><code>MUTE_1</code>: sustain</li>
         <li><code>MUTE_2</code>: sostenuto</li>
       </ul>
-      <p>The current note-step sub-modes are:</p>
-      <ul>
-        <li><code>Melodic Step</code></li>
-        <li><code>Chord Step</code></li>
-        <li><code>Clip Step Record</code> placeholder</li>
-      </ul>
+      <p><code>Melodic Step</code> and <code>Chord Step</code> now live behind <code>STEP SEQ</code> rather than under <code>NOTE</code>.</p>
       <p>Quick start:</p>
       <ol>
         <li>Enter <code>NOTE</code>.</li>
         <li>Play notes directly on the pad grid.</li>
         <li>Press <code>NOTE</code> again to move between the primary note-family surfaces.</li>
-        <li>Use <code>PATTERN UP/DOWN</code> for octave, <code>SHIFT + PATTERN UP/DOWN</code> for shared root, and the Channel page for <code>Mod</code>, <code>Pitch Bend</code>, <code>Pitch Gliss</code>, and <code>Scale</code>.</li>
+        <li>Use <code>ALT + NOTE</code> or <code>SHIFT + Encoder 4</code> for the local layout, <code>PATTERN UP/DOWN</code> for octave, <code>SHIFT + PATTERN UP/DOWN</code> for shared root, and the Channel page for <code>Mod</code>, <code>Pitch Bend</code>, <code>Pitch Gliss</code>, and shared scale/root control.</li>
       </ol>
       <p>Expression behavior in <code>NOTE</code> is split between live input and sequenced note data:</p>
       <ul>
@@ -373,6 +372,7 @@
       </ul>
 
       <h3>Chord Step workflow</h3>
+      <p>Press <code>STEP SEQ</code> once to enter <code>Melodic Step</code>, then press <code>STEP SEQ</code> again to switch to <code>Chord Step</code>. Press <code>NOTE</code> to return to live note input.</p>
       <p><code>Chord Step</code> is the current chord-oriented note-step workflow.</p>
       <ul>
         <li>Row 1: clip row</li>

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
@@ -9,34 +9,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TopLevelModeStateTest {
 
     @Test
-    void noteButtonSwitchesBetweenNotePlayAndChordStep() {
+    void canActivateLiveAndChordNoteModesExplicitly() {
         final TopLevelModeState state = new TopLevelModeState();
 
-        assertEquals(TopLevelModeState.NoteButtonResult.TOGGLE_NOTE_VARIANT, state.handleNotePressed(false));
+        state.activateChordStep();
+        assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
+
+        state.activateNotePlay();
         assertEquals(TopLevelModeState.Mode.NOTE_PLAY, state.activeMode());
-
-        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_CHORD_STEP, state.handleNotePressed(true));
-        assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
-
-        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_NOTE_PLAY, state.handleNotePressed(false));
-        assertEquals(TopLevelModeState.Mode.NOTE_PLAY, state.activeMode());
-    }
-
-    @Test
-    void alternateNoteButtonDoesNotLeaveCurrentNoteSurface() {
-        final TopLevelModeState state = new TopLevelModeState();
-
-        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_CHORD_STEP, state.handleNotePressed(true));
-        assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
-
-        assertEquals(TopLevelModeState.NoteButtonResult.TOGGLE_CHORD_VARIANT, state.handleNotePressed(true));
-        assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
     }
 
     @Test
     void melodicExitReturnsToPreviousNonStepMode() {
         final TopLevelModeState state = new TopLevelModeState();
-        state.handleNotePressed(true);
+        state.activateChordStep();
 
         state.enterMelodicStepMode();
 

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
@@ -12,7 +12,10 @@ class TopLevelModeStateTest {
     void noteButtonSwitchesBetweenNotePlayAndChordStep() {
         final TopLevelModeState state = new TopLevelModeState();
 
-        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_CHORD_STEP, state.handleNotePressed(false));
+        assertEquals(TopLevelModeState.NoteButtonResult.TOGGLE_NOTE_VARIANT, state.handleNotePressed(false));
+        assertEquals(TopLevelModeState.Mode.NOTE_PLAY, state.activeMode());
+
+        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_CHORD_STEP, state.handleNotePressed(true));
         assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
 
         assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_NOTE_PLAY, state.handleNotePressed(false));
@@ -23,10 +26,9 @@ class TopLevelModeStateTest {
     void alternateNoteButtonDoesNotLeaveCurrentNoteSurface() {
         final TopLevelModeState state = new TopLevelModeState();
 
-        assertEquals(TopLevelModeState.NoteButtonResult.TOGGLE_NOTE_VARIANT, state.handleNotePressed(true));
-        assertEquals(TopLevelModeState.Mode.NOTE_PLAY, state.activeMode());
+        assertEquals(TopLevelModeState.NoteButtonResult.SWITCH_TO_CHORD_STEP, state.handleNotePressed(true));
+        assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
 
-        state.handleNotePressed(false);
         assertEquals(TopLevelModeState.NoteButtonResult.TOGGLE_CHORD_VARIANT, state.handleNotePressed(true));
         assertEquals(TopLevelModeState.Mode.CHORD_STEP, state.activeMode());
     }
@@ -34,7 +36,7 @@ class TopLevelModeStateTest {
     @Test
     void melodicExitReturnsToPreviousNonStepMode() {
         final TopLevelModeState state = new TopLevelModeState();
-        state.handleNotePressed(false);
+        state.handleNotePressed(true);
 
         state.enterMelodicStepMode();
 

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/HarmonicLatticeLayoutTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/HarmonicLatticeLayoutTest.java
@@ -1,0 +1,47 @@
+package com.oikoaudio.fire.note;
+
+import com.bitwig.extensions.framework.MusicalScaleLibrary;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HarmonicLatticeLayoutTest {
+
+    @Test
+    void rowsExposeDifferentAnchorNotesForSameHarmonicColumn() {
+        final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
+                MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
+                0,
+                2,
+                7,
+                1,
+                true,
+                0);
+
+        final int topRowPad = 2;
+        final int nextRowPad = 18;
+        final int thirdRowPad = 34;
+        final int bottomRowPad = 50;
+
+        assertNotEquals(layout.primaryNoteForPad(topRowPad), layout.primaryNoteForPad(nextRowPad));
+        assertNotEquals(layout.primaryNoteForPad(nextRowPad), layout.primaryNoteForPad(thirdRowPad));
+        assertNotEquals(layout.primaryNoteForPad(thirdRowPad), layout.primaryNoteForPad(bottomRowPad));
+    }
+
+    @Test
+    void bassColumnsRemainSingleNotesWhileHarmonicPadsProduceCandidateLists() {
+        final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
+                MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
+                0,
+                2,
+                14,
+                2,
+                true,
+                0);
+
+        assertEquals(1, layout.notesForPad(0).length);
+        assertTrue(layout.notesForPad(2).length > 1);
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/HarmonicLatticeLayoutTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/HarmonicLatticeLayoutTest.java
@@ -4,44 +4,81 @@ import com.bitwig.extensions.framework.MusicalScaleLibrary;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 class HarmonicLatticeLayoutTest {
 
     @Test
-    void rowsExposeDifferentAnchorNotesForSameHarmonicColumn() {
+    void cMajorRowsAreShiftedTwoStepsRight() {
         final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
                 MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
                 0,
                 2,
-                7,
+                1,
                 1,
                 true,
                 0);
 
-        final int topRowPad = 2;
-        final int nextRowPad = 18;
-        final int thirdRowPad = 34;
-        final int bottomRowPad = 50;
-
-        assertNotEquals(layout.primaryNoteForPad(topRowPad), layout.primaryNoteForPad(nextRowPad));
-        assertNotEquals(layout.primaryNoteForPad(nextRowPad), layout.primaryNoteForPad(thirdRowPad));
-        assertNotEquals(layout.primaryNoteForPad(thirdRowPad), layout.primaryNoteForPad(bottomRowPad));
+        assertEquals(36, layout.primaryNoteForPad(50)); // bottom row, first harmonic pad = C2
+        assertEquals(48, layout.primaryNoteForPad(36)); // next row, shifted right by 2 => C3 at col 2
+        assertEquals(60, layout.primaryNoteForPad(22)); // next row, shifted right by 4 => C4 at col 4
+        assertEquals(72, layout.primaryNoteForPad(8));  // top row, shifted right by 6 => C5 at col 6
     }
 
     @Test
-    void bassColumnsRemainSingleNotesWhileHarmonicPadsProduceCandidateLists() {
+    void cMajorRootVoicingUsesCompactAlternatingOctaves() {
         final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
                 MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
                 0,
                 2,
-                14,
+                3,
+                1,
+                true,
+                0);
+
+        assertArrayEquals(new int[]{36, 28, 43}, layout.notesForPad(50)); // C2 E1 G2
+        assertArrayEquals(new int[]{48, 40, 55}, layout.notesForPad(36)); // C3 E2 G3
+    }
+
+    @Test
+    void bassColumnsRemainSingleNotes() {
+        final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
+                MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
+                0,
                 2,
+                3,
+                1,
                 true,
                 0);
 
         assertEquals(1, layout.notesForPad(0).length);
-        assertTrue(layout.notesForPad(2).length > 1);
+    }
+
+    @Test
+    void harmonicPadsWrapAtRightEdgeWithoutReducingNoteCount() {
+        final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
+                MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
+                0,
+                2,
+                3,
+                1,
+                true,
+                0);
+
+        assertEquals(3, layout.notesForPad(63).length);
+    }
+
+    @Test
+    void octaveSpanAddsOctavesAboveSelectedRunNotes() {
+        final HarmonicLatticeLayout layout = new HarmonicLatticeLayout(
+                MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)"),
+                0,
+                2,
+                3,
+                2,
+                true,
+                0);
+
+        assertArrayEquals(new int[]{36, 28, 43, 48, 40, 55}, layout.notesForPad(50));
     }
 }

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveControlSurfaceTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveControlSurfaceTest.java
@@ -157,7 +157,8 @@ class NoteLiveControlSurfaceTest {
                 layer(events, EncoderMode.MIXER),
                 layer(events, EncoderMode.USER_1),
                 layer(events, EncoderMode.USER_2),
-                mode -> events.add("step:" + mode));
+                mode -> events.add("step:" + mode),
+                NoteLiveEncoderModeControls::modeInfo);
     }
 
     private static NoteEncoderTouchResetHandler createTouchResetHandler(final List<String> events) {

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControlsTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControlsTest.java
@@ -78,7 +78,8 @@ class NoteLiveEncoderModeControlsTest {
                 layer(events, EncoderMode.MIXER),
                 layer(events, EncoderMode.USER_1),
                 layer(events, EncoderMode.USER_2),
-                mode -> events.add("step:" + mode));
+                mode -> events.add("step:" + mode),
+                NoteLiveEncoderModeControls::modeInfo);
     }
 
     private static NoteLiveEncoderModeControls.LayerHandle layer(final List<String> events, final EncoderMode mode) {

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControlsTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLiveEncoderModeControlsTest.java
@@ -23,7 +23,7 @@ class NoteLiveEncoderModeControlsTest {
 
         assertEquals(EncoderMode.CHANNEL, controls.mode());
         assertEquals(BiColorLightState.MODE_CHANNEL, controls.lightState());
-        assertEquals("1: Mod\n2: Pitch Gliss\n3: Velocity\n4: Scale", controls.modeInfo());
+        assertEquals("1: Mod\n2: Pitch Bend\n3: Pitch Gliss\n4: Scale", controls.modeInfo());
         assertEquals(List.of(
                 "deactivate:CHANNEL",
                 "deactivate:MIXER",

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLivePadPerformerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NoteLivePadPerformerTest.java
@@ -16,7 +16,7 @@ class NoteLivePadPerformerTest {
         final List<String> events = new ArrayList<>();
         final NoteLivePadPerformer performer = new NoteLivePadPerformer(
                 new TestMidiOut(events),
-                pad -> 60 + pad,
+                pad -> new int[]{60 + pad},
                 (configured, raw) -> raw);
 
         performer.handlePadPress(2, true, 99, 100);
@@ -31,7 +31,7 @@ class NoteLivePadPerformerTest {
         final List<String> events = new ArrayList<>();
         final NoteLivePadPerformer performer = new NoteLivePadPerformer(
                 new TestMidiOut(events),
-                pad -> 60 + pad,
+                pad -> new int[]{60 + pad},
                 (configured, raw) -> raw);
 
         performer.handlePadPress(1, true, 80, 100);
@@ -46,7 +46,7 @@ class NoteLivePadPerformerTest {
         final List<String> events = new ArrayList<>();
         final NoteLivePadPerformer performer = new NoteLivePadPerformer(
                 new TestMidiOut(events),
-                pad -> 60 + pad,
+                pad -> new int[]{60 + pad},
                 (configured, raw) -> configured);
 
         performer.handlePadPress(0, true, 90, 100);
@@ -64,7 +64,7 @@ class NoteLivePadPerformerTest {
         final List<String> events = new ArrayList<>();
         final NoteLivePadPerformer performer = new NoteLivePadPerformer(
                 new TestMidiOut(events),
-                pad -> 60 + pad,
+                pad -> new int[]{60 + pad},
                 (configured, raw) -> raw);
 
         performer.handlePadPress(3, true, 70, 100);
@@ -73,6 +73,20 @@ class NoteLivePadPerformerTest {
 
         assertEquals(List.of("on:63:70", "off:63"), events);
         assertFalse(performer.isPadHeld(3));
+    }
+
+    @Test
+    void handlePadPressSupportsMultipleNotesPerPad() {
+        final List<String> events = new ArrayList<>();
+        final NoteLivePadPerformer performer = new NoteLivePadPerformer(
+                new TestMidiOut(events),
+                pad -> new int[]{60 + pad, 64 + pad, 67 + pad},
+                (configured, raw) -> configured);
+
+        performer.handlePadPress(0, true, 99, 100);
+        performer.handlePadPress(0, false, 0, 100);
+
+        assertEquals(List.of("on:60:100", "on:64:100", "on:67:100", "off:60", "off:64", "off:67"), events);
     }
 
     private record TestMidiOut(List<String> events) implements NoteLivePadPerformer.MidiOut {

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NotePlayControllerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NotePlayControllerTest.java
@@ -26,7 +26,8 @@ class NotePlayControllerTest {
                                 layer(events, "mixer"),
                                 layer(events, "user1"),
                                 layer(events, "user2"),
-                                ignored -> {}),
+                                ignored -> {},
+                                NoteLiveEncoderModeControls::modeInfo),
                         new NoteEncoderTouchResetHandler(
                                 new com.oikoaudio.fire.control.TouchResetGesture(4, 0L, 0L, 2),
                                 () -> false,

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NotePlayControllerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/NotePlayControllerTest.java
@@ -46,7 +46,7 @@ class NotePlayControllerTest {
                     public void noteOff(final int midiNote) {
                         events.add("off:" + midiNote);
                     }
-                }, pad -> 60 + pad, (baseVelocity, rawVelocity) -> baseVelocity));
+                }, pad -> new int[]{60 + pad}, (baseVelocity, rawVelocity) -> baseVelocity));
 
         mode.activate();
         mode.handleMute1(true);

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/PitchedSurfaceLayerPitchGlissDisplayTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/note/PitchedSurfaceLayerPitchGlissDisplayTest.java
@@ -1,0 +1,21 @@
+package com.oikoaudio.fire.note;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PitchedSurfaceLayerPitchGlissDisplayTest {
+
+    @Test
+    void fifthOctaveDisplayUsesSemitoneOffsetsInHarmonicMode() {
+        assertEquals(5, PitchedSurfaceLayer.displayPitchGlissValue(true, 5, 0));
+        assertEquals(12, PitchedSurfaceLayer.displayPitchGlissValue(true, 12, 0));
+        assertEquals(19, PitchedSurfaceLayer.displayPitchGlissValue(true, 19, 0));
+        assertEquals(24, PitchedSurfaceLayer.displayPitchGlissValue(true, 24, 0));
+    }
+
+    @Test
+    void scaleDegreeDisplayStillUsesScaleDegreeOffset() {
+        assertEquals(3, PitchedSurfaceLayer.displayPitchGlissValue(false, 19, 3));
+    }
+}

--- a/modules/common/src/main/java/com/bitwig/extensions/framework/MusicalScaleLibrary.java
+++ b/modules/common/src/main/java/com/bitwig/extensions/framework/MusicalScaleLibrary.java
@@ -9,48 +9,63 @@ public final class MusicalScaleLibrary
 {
    private MusicalScaleLibrary()
    {
-      /* Classic */
+      /* Bitwig-aligned core scales */
       addScale(new MusicalScale("Chromatic", new int[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }));
-      addScale(new MusicalScale("Ionan (Major)", new int[]{ 0, 2, 4, 5, 7, 9, 11 }));
+      addScale(new MusicalScale("Major", new int[]{ 0, 2, 4, 5, 7, 9, 11 }));
+      addScale(new MusicalScale("Minor", new int[]{ 0, 2, 3, 5, 7, 8, 10 }));
       addScale(new MusicalScale("Dorian", new int[]{ 0, 2, 3, 5, 7, 9, 10 }));
       addScale(new MusicalScale("Phrygian", new int[]{ 0, 1, 3, 5, 7, 8, 10 }));
       addScale(new MusicalScale("Lydian", new int[]{ 0, 2, 4, 6, 7, 9, 11 }));
       addScale(new MusicalScale("Mixolydian", new int[]{ 0, 2, 4, 5, 7, 9, 10 }));
-      addScale(new MusicalScale("Aeolian (Minor)", new int[]{ 0, 2, 3, 5, 7, 8, 10 }));
       addScale(new MusicalScale("Locrian", new int[]{ 0, 1, 3, 5, 6, 8, 10 }));
-
-      /* 5 keys */
-      addScale(new MusicalScale("Hirajoshi", new int[]{ 0, 2, 3, 7, 8 }));
-      addScale(new MusicalScale("Iwato", new int[]{ 0, 1, 5, 6, 10 })); // related to Hirajoshi (after)
-      addScale(new MusicalScale("Kumoi", new int[]{ 0, 2, 3, 7, 9 }));
-      addScale(new MusicalScale("In Sen", new int[]{ 0, 1, 5, 7, 10 })); // related to Kumoi (after)
-      addScale(new MusicalScale("Yo scale", new int[]{ 0, 2, 5, 7, 9 }));
-      addScale(new MusicalScale("Minor Pentatonic", new int[]{ 0, 3, 5, 7, 10 })); // related to Yo Scale (after)
-      addScale(new MusicalScale("Major Pentatonic", new int[]{ 0, 2, 4, 7, 9 })); // related to Minor Pentatonic (after)
-
-      /* 6 keys */
+      addScale(new MusicalScale("Harmonic Major", new int[]{ 0, 2, 4, 5, 7, 8, 11 }));
+      addScale(new MusicalScale("Harmonic Minor", new int[]{ 0, 2, 3, 5, 7, 8, 11 }));
+      addScale(new MusicalScale("Overtone Scale", new int[]{ 0, 2, 4, 6, 7, 9, 10 }));
+      addScale(new MusicalScale("Jazz Minor", new int[]{ 0, 2, 3, 5, 7, 9, 11 }));
+      addScale(new MusicalScale("Blues Major", new int[]{ 0, 2, 3, 4, 7, 9 }));
+      addScale(new MusicalScale("Blues Minor", new int[]{ 0, 3, 5, 6, 7, 10 }));
+      addScale(new MusicalScale("Double Harmonic Major", new int[]{ 0, 1, 4, 5, 7, 8, 11 }));
+      addScale(new MusicalScale("Double Harmonic Minor", new int[]{ 0, 2, 3, 6, 7, 8, 11 }));
       addScale(new MusicalScale("Whole Tone", new int[]{ 0, 2, 4, 6, 8, 10 }));
-      addScale(new MusicalScale("Blues", new int[]{ 0, 3, 5, 6, 7, 10 }));
-      addScale(new MusicalScale("Major Blues", new int[]{ 0, 2, 3, 4, 7, 9 }));
+      addScale(new MusicalScale("Half-diminished", new int[]{ 0, 2, 3, 5, 6, 8, 10 }));
+      addScale(new MusicalScale("Diminished WH", new int[]{ 0, 2, 3, 5, 6, 8, 9, 11 }));
+      addScale(new MusicalScale("Diminished HW", new int[]{ 0, 1, 3, 4, 6, 7, 9, 10 }));
+      addScale(new MusicalScale("Major Pentatonic", new int[]{ 0, 2, 4, 7, 9 }));
+      addScale(new MusicalScale("Minor Pentatonic", new int[]{ 0, 3, 5, 7, 10 }));
+      addScale(new MusicalScale("Major Triad", new int[]{ 0, 4, 7 }));
+      addScale(new MusicalScale("Minor Triad", new int[]{ 0, 3, 7 }));
 
-      /* scales with augmented second */
+      /* Extras beyond the Bitwig-like core list */
+      addScale(new MusicalScale("Hirajoshi", new int[]{ 0, 2, 3, 7, 8 }));
+      addScale(new MusicalScale("Iwato", new int[]{ 0, 1, 5, 6, 10 }));
+      addScale(new MusicalScale("Kumoi", new int[]{ 0, 2, 3, 7, 9 }));
+      addScale(new MusicalScale("In Sen", new int[]{ 0, 1, 5, 7, 10 }));
+      addScale(new MusicalScale("Yo Scale", new int[]{ 0, 2, 5, 7, 9 }));
       addScale(new MusicalScale("Todi", new int[]{ 0, 1, 3, 5, 6, 7, 11 }));
       addScale(new MusicalScale("Phrygian Dominant", new int[]{ 0, 1, 4, 5, 7, 8, 10 }));
-      addScale(new MusicalScale("Double Harmonic", new int[]{ 0, 1, 4, 5, 7, 8, 11 }));
       addScale(new MusicalScale("Marva", new int[]{ 0, 1, 4, 6, 7, 9, 11 }));
-      addScale(new MusicalScale("Harmonic Minor", new int[]{ 0, 2, 3, 5, 7, 8, 11 }));
-
-      /* Others */
-      addScale(new MusicalScale("Melodic Minor (ascending)", new int[]{ 0, 2, 3, 5, 7, 9, 11 }));
-      addScale(new MusicalScale("Hungarian Minor", new int[]{ 0, 2, 3, 6, 7, 8, 11 }));
       addScale(new MusicalScale("Ukranian Dorian", new int[]{ 0, 2, 3, 6, 7, 9, 10 }));
       addScale(new MusicalScale("Super Locrian", new int[]{ 0, 1, 3, 4, 6, 8, 10 }));
-      addScale(new MusicalScale("Whole Half", new int[]{ 0, 2, 3, 5, 6, 8, 9, 11 }));
-      addScale(new MusicalScale("Half-Whole Diminished", new int[]{ 0, 1, 3, 4, 6, 7, 9, 10 }));
-      addScale(new MusicalScale("BeBop Major", new int[]{ 0, 2, 4, 5, 7, 8, 9, 11 }));
-      addScale(new MusicalScale("BeBop Dorian", new int[]{ 0, 2, 3, 4, 5, 7, 9, 10 }));
-      addScale(new MusicalScale("BeBop Mixolydian", new int[]{ 0, 2, 4, 5, 7, 9, 10, 11 }));
-      addScale(new MusicalScale("BeBop Minor", new int[]{ 0, 2, 3, 5, 7, 8, 10, 11 }));
+      addScale(new MusicalScale("Bebop Major", new int[]{ 0, 2, 4, 5, 7, 8, 9, 11 }));
+      addScale(new MusicalScale("Bebop Dorian", new int[]{ 0, 2, 3, 4, 5, 7, 9, 10 }));
+      addScale(new MusicalScale("Bebop Mixolydian", new int[]{ 0, 2, 4, 5, 7, 9, 10, 11 }));
+      addScale(new MusicalScale("Bebop Minor", new int[]{ 0, 2, 3, 5, 7, 8, 10, 11 }));
+
+      /* Legacy aliases kept for compatibility with older code/tests */
+      addAlias("Ionan (Major)", "Major");
+      addAlias("Aeolian (Minor)", "Minor");
+      addAlias("Melodic Minor (ascending)", "Jazz Minor");
+      addAlias("Double Harmonic", "Double Harmonic Major");
+      addAlias("Blues", "Blues Minor");
+      addAlias("Major Blues", "Blues Major");
+      addAlias("Whole Half", "Diminished WH");
+      addAlias("Half-Whole Diminished", "Diminished HW");
+      addAlias("Yo scale", "Yo Scale");
+      addAlias("BeBop Major", "Bebop Major");
+      addAlias("BeBop Dorian", "Bebop Dorian");
+      addAlias("BeBop Mixolydian", "Bebop Mixolydian");
+      addAlias("BeBop Minor", "Bebop Minor");
+      addAlias("Hungarian Minor", "Double Harmonic Minor");
 
       final int numScales = mMusicalScales.size();
       mScalesName = new String[numScales];
@@ -70,6 +85,14 @@ public final class MusicalScaleLibrary
       musicalScale.setIndexInLibrary(mMusicalScales.size());
       mMusicalScales.add(musicalScale);
       mMusicalScaleHashMap.put(musicalScale.getName(), musicalScale);
+   }
+
+   private void addAlias(final String alias, final String canonicalName)
+   {
+      assert !mMusicalScaleHashMap.containsKey(alias);
+      final MusicalScale canonical = mMusicalScaleHashMap.get(canonicalName);
+      assert canonical != null;
+      mMusicalScaleHashMap.put(alias, canonical);
    }
 
    static public MusicalScaleLibrary getInstance()


### PR DESCRIPTION
feat(akai-fire): add harmonic note input and rework step routing

- add a harmonic live NOTE submode with harmonic lattice layout,
  multi-note pad output, note-count selection, octave-span control,
  bass-column/full-field variants, and harmonic gliss support
- add live pitch-bend with fake  spring-return 
- add pitch gliss toggle between 5th/8v and ScaleDeg modes
- move Chord Step behind STEP SEQ so NOTE stays focused on live note
  input, with STEP entering Melodic Step and a second press switching
  to Chord Step
- add horizontal Perform mode 
- encoder-scaling / encoder-page cleanup across Fire workflows for encoders that are both more responsive and more precise, depending on context
- align scale naming and ordering with Bitwig 6
- update Fire docs, bundled help, tests, and changelog entries