### PR TITLE
Oikontrol Akai Fire v2.8.0 -  Fugue mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 This document now tracks intentional modifications made to the `bitwig-oikontrol` project.
 
+## 2.8.0 - Fugue mode and generative workflow polish
+- Added Akai Fire `Fugue` step mode. It uses MIDI channel 1 as a template melodic line and generates derived new lines to channels 2-4 in the same clip, using Bach-type operations (transpose/reverse/move etc).
+- Swapped Nested Rhythm pattern gestures so `PATTERN DOWN` generates the current nested rhythm and `PATTERN UP` resets hit edits, to better match related gestures in other modes.
+- Updated the user guide and bundled help with notes on the new Fugue workflow.
+
 ## 2.7.0 - Nested Rhythm mode and global control fixes
 - Added a new Akai Fire `Nested Rhythm` drum mode for generating rhythm from nested segment divisions rather than fixed-grid step placement. The mode slices segments into symmetric and asymmetric subdivisions (tuplets and ratches) in a musically interesting way, and adds expression layer profiles for pressure, timbre, velocity, and chance that can be rotated across the generated hits. Rhythmic structures can be changed on the fly, generated hits can be embellished with per-hit edits, and recurrence can be generated or edited using the same gesture as in `Melodic Step`.
 - (improvement) `PERFORM` now exits the `SHIFT + PERFORM` track-action page for easier exit

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set shell := ["bash", "-cu"]
 
-gradle_user_home := env_var_or_default("GRADLE_USER_HOME", "/tmp/gradle-home")
+gradle_user_home := env_var_or_default("GRADLE_USER_HOME", env_var("HOME") + "/.gradle")
 gradle_java_home := env_var_or_default("GRADLE_JAVA_HOME", "")
 java_home_cmd := if gradle_java_home != "" {
     "JAVA_HOME='" + gradle_java_home + "'"

--- a/Justfile
+++ b/Justfile
@@ -1,13 +1,14 @@
 set shell := ["bash", "-cu"]
 
 gradle_user_home := env_var_or_default("GRADLE_USER_HOME", env_var("HOME") + "/.gradle")
+gradle_daemon_flag := env_var_or_default("GRADLE_DAEMON_FLAG", "")
 gradle_java_home := env_var_or_default("GRADLE_JAVA_HOME", "")
 java_home_cmd := if gradle_java_home != "" {
     "JAVA_HOME='" + gradle_java_home + "'"
 } else {
     "JAVA_HOME=\"$(/usr/libexec/java_home -v 21 2>/dev/null || printf '%s' \"${JAVA_HOME:-}\")\""
 }
-gradlew := java_home_cmd + " PATH=\"$JAVA_HOME/bin:$PATH\" ./gradlew --no-daemon"
+gradlew := java_home_cmd + " PATH=\"$JAVA_HOME/bin:$PATH\" ./gradlew " + gradle_daemon_flag
 bitwig_extensions_dir := env_var_or_default("BITWIG_EXTENSIONS_DIR", env_var("HOME") + "/Documents/Bitwig Studio/Extensions")
 
 default:
@@ -31,6 +32,9 @@ fire-test:
 fire-build:
     GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:akai-fire:build
 
+fire-package:
+    GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:akai-fire:jar
+
 fire-extension:
     GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:akai-fire:jar
     @find modules/akai-fire/build/libs -maxdepth 1 -type f -name '*.bwextension' | sort
@@ -41,8 +45,17 @@ fire-install:
     cp "$(find modules/akai-fire/build/libs -maxdepth 1 -type f -name 'OikontrolFire.bwextension' -printf '%T@ %p\n' | sort -n | tail -n 1 | cut -d' ' -f2-)" "{{bitwig_extensions_dir}}/"
     @find "{{bitwig_extensions_dir}}" -maxdepth 1 -type f -name 'OikontrolFire.bwextension' -printf '%T@ %p\n' | sort -n | tail -n 1 | cut -d' ' -f2-
 
+fire-build-install:
+    GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:akai-fire:build
+    mkdir -p "{{bitwig_extensions_dir}}"
+    cp "$(find modules/akai-fire/build/libs -maxdepth 1 -type f -name 'OikontrolFire.bwextension' -printf '%T@ %p\n' | sort -n | tail -n 1 | cut -d' ' -f2-)" "{{bitwig_extensions_dir}}/"
+    @find "{{bitwig_extensions_dir}}" -maxdepth 1 -type f -name 'OikontrolFire.bwextension' -printf '%T@ %p\n' | sort -n | tail -n 1 | cut -d' ' -f2-
+
 launchcontrol-build:
     GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:launchcontrol:build
+
+launchcontrol-package:
+    GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:launchcontrol:jar
 
 launchcontrol-test:
     GRADLE_USER_HOME={{gradle_user_home}} {{gradlew}} :modules:launchcontrol:test

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -113,7 +113,7 @@ The Akai Fire extension is organized around four top-level workflows.
 | --- | --- | --- |
 | `DRUM` | Drum sequencing | XOX-style drum sequencing; press again for `Nested Rhythm` |
 | `NOTE` | Live note input | 16x4 note surface; press again for harmonic note layout |
-| `STEP SEQ` | Step sequencing | Enters `Melodic Step`; press again for `Chord Step` |
+| `STEP` | Step sequencing | Enters `Melodic Step`; press again for `Chord Step`, then `Fugue` |
 | `PERFORM` | Clip launching | 16x4 clip grid and track actions |
 
 Shared pitch context is global across `NOTE`, `Melodic Step`, `Chord Step`, and the settings overlay. `Root Key`, `Scale`, and `Octave` changes in one of those places update the others.
@@ -163,9 +163,9 @@ Tap `SELECT` to swap between `Last Touched Parameter` and the current alternate 
 
 | Control | Action |
 | --- | --- |
-| `STEP SEQ` | Enter `Melodic Step` |
-| `SHIFT + STEP SEQ` | Accent entry and editing |
-| `ALT + STEP SEQ` | Fill |
+| `STEP` | Enter `Melodic Step` |
+| `SHIFT + STEP` | Accent entry and editing |
+| `ALT + STEP` | Fill |
 | `BANK LEFT/RIGHT` | Move or rotate pattern |
 | `SHIFT + BANK LEFT/RIGHT` | Fine nudge |
 | `ALT + BANK LEFT/RIGHT` | Halve / double clip length |
@@ -199,11 +199,11 @@ If the selected clip slot is empty when you enter the mode, Nested Rhythm genera
 
 | Control | Action |
 | --- | --- |
-| `DRUM` while in standard `DRUM` | Enter `Nested Rhythm` |
-| `DRUM` while in `Nested Rhythm` | Return to standard `DRUM` |
-| `STEP SEQ` | Enter `Melodic Step` |
-| `PATTERN UP` | Generate current nested rhythm into the selected clip |
-| `PATTERN DOWN` or `ALT + MUTE_4` | Reset hit edits for the selected clip |
+| `DRUM` while in `XOX Drum mode` | Enter `Nested Rhythm mode` |
+| `DRUM` while in `Nested Rhythm` | Return to `XOX Drum mode` |
+| `STEP` | Enter `Melodic Step mode` |
+| `PATTERN UP` or `ALT + MUTE_4` | Reset hit edits for the selected clip |
+| `PATTERN DOWN` | Generate current nested rhythm into the selected clip |
 | Hold `MUTE_2` + projected rhythm pad | Set last step within the 32-step edit view |
 | Hold projected rhythm pad | Target nearest generated hit |
 | Tap bottom-row hit pad | Toggle that hit |
@@ -331,6 +331,20 @@ Press `STEP SEQ` from `Melodic Step` to enter `Chord Step`. Press `NOTE` to retu
 Chord banks are static libraries of chord formulas and voicing variants. Changing shared `Root Key` or `Scale` does not switch bank, page, or slot; it only changes how the selected slot is rendered. `As Is` transposes the stored chord shape from the current root. `In Scale` rebuilds that slot from the current shared scale and root.
 
 Coarse nudge is intentionally disabled in `Chord Step`; micro-timing is currently temperamental and should be treated as experimental.
+
+### Fugue mode
+
+Press `STEP` from `Chord Step` to enter `Fugue`. `Fugue` treats MIDI channel 1 as the source line and generates related lines on channels 2-4.
+
+| Control | Action |
+| --- | --- |
+| `PATTERN DOWN` | Reread channel 1 from the clip and rebuild derived lines |
+| Encoder turn on a derived-line page | Immediately rebuild that line with the new parameter |
+| Channel 1 pads and encoders | Edit the source/template line |
+
+If you change channel 1 notes or expression directly in Bitwig, press `PATTERN DOWN` to update the generated lines from the current DAW clip state. Fugue deliberately avoids live regeneration during Bitwig note-editor drags, so you can audition an alternate source line in isolation and avoid rewriting derived notes while the DAW is still editing the source event.
+
+For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.
 
 ### PERFORM mode
 

--- a/modules/akai-fire/build.gradle
+++ b/modules/akai-fire/build.gradle
@@ -1,4 +1,4 @@
-version = '2.7.0'
+version = '2.8.0'
 
 jar {
     archiveBaseName.set('OikontrolFire')

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
@@ -25,7 +25,7 @@ public class AkaiFireOikontrolDefinition extends ControllerExtensionDefinition {
 
     @Override
     public String getVersion() {
-        return "2.7.0";
+        return "2.8.0";
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -6,6 +6,7 @@ import com.oikoaudio.fire.control.RgbButton;
 import com.oikoaudio.fire.control.TouchEncoder;
 import com.oikoaudio.fire.chordstep.ChordStepMode;
 import com.oikoaudio.fire.display.OledDisplay;
+import com.oikoaudio.fire.fugue.FugueStepMode;
 import com.oikoaudio.fire.lights.BiColorLightState;
 import com.oikoaudio.fire.lights.RgbLigthState;
 import com.oikoaudio.fire.melodic.MelodicStepMode;
@@ -151,6 +152,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private NotePlayMode notePlayMode;
     private ChordStepMode chordStepMode;
     private MelodicStepMode melodicStepMode;
+    private FugueStepMode fugueStepMode;
     private NestedRhythmMode nestedRhythmMode;
     private PerformClipLauncherMode performMode;
     private NoteRepeatHandler noteRepeatHandler;
@@ -241,6 +243,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         notePlayMode = new NotePlayMode(this, noteRepeatHandler);
         chordStepMode = new ChordStepMode(this, noteRepeatHandler);
         melodicStepMode = new MelodicStepMode(this, noteRepeatHandler);
+        fugueStepMode = new FugueStepMode(this);
         nestedRhythmMode = new NestedRhythmMode(this);
         performMode = new PerformClipLauncherMode(this);
         initGlobalSettingsOverlay();
@@ -264,6 +267,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         notePlayMode.notifyBlink(blinkTicks);
         chordStepMode.notifyBlink(blinkTicks);
         melodicStepMode.notifyBlink(blinkTicks);
+        fugueStepMode.notifyBlink(blinkTicks);
         nestedRhythmMode.notifyBlink(blinkTicks);
         performMode.notifyBlink(blinkTicks);
         host.scheduleTask(this::handlePing, 100);
@@ -607,6 +611,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (modeState.activeMode() == Mode.MELODIC_STEP && melodicStepMode != null) {
             return melodicStepMode.getModeButtonLightState();
         }
+        if (modeState.activeMode() == Mode.FUGUE_STEP && fugueStepMode != null) {
+            return fugueStepMode.getModeButtonLightState();
+        }
         if (modeState.activeMode() == Mode.NESTED_RHYTHM && nestedRhythmMode != null) {
             return nestedRhythmMode.getModeButtonLightState();
         }
@@ -772,6 +779,15 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         if (modeState.activeMode() == Mode.CHORD_STEP) {
+            if (!pressed || isGlobalAltHeld()) {
+                return;
+            }
+            modeState.activateFugueStep();
+            switchActiveMode();
+            notifyAction("Mode", "Fugue");
+            return;
+        }
+        if (modeState.activeMode() == Mode.FUGUE_STEP) {
             if (!pressed || isGlobalAltHeld()) {
                 return;
             }
@@ -1009,6 +1025,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         notePlayMode.deactivate();
         chordStepMode.deactivate();
         melodicStepMode.deactivate();
+        fugueStepMode.deactivate();
         nestedRhythmMode.deactivate();
         performMode.deactivate();
         if (modeState.activeMode() == Mode.DRUM) {
@@ -1027,6 +1044,8 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             chordStepMode.activate();
         } else if (modeState.activeMode() == Mode.MELODIC_STEP) {
             melodicStepMode.activate();
+        } else if (modeState.activeMode() == Mode.FUGUE_STEP) {
+            fugueStepMode.activate();
         } else if (modeState.activeMode() == Mode.NESTED_RHYTHM) {
             nestedRhythmMode.activate();
         } else {
@@ -1170,6 +1189,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         modeState.enterMelodicStepMode();
         switchActiveMode();
         notifyAction("Mode", "Step");
+    }
+
+    public void enterFugueStepMode() {
+        modeState.activateFugueStep();
+        switchActiveMode();
+        notifyAction("Mode", "Fugue");
     }
 
     public void enterNestedRhythmMode() {
@@ -1324,6 +1349,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             case NOTE_PLAY -> "Note";
             case CHORD_STEP -> "Chord Step";
             case MELODIC_STEP -> "Melodic Step";
+            case FUGUE_STEP -> "Fugue";
             case NESTED_RHYTHM -> "Nested Rhythm";
             case PERFORM -> "Perform";
         };
@@ -1395,6 +1421,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         notePlayMode.deactivate();
         chordStepMode.deactivate();
         melodicStepMode.deactivate();
+        fugueStepMode.deactivate();
         nestedRhythmMode.deactivate();
         performMode.deactivate();
         globalSettingsLayer.activate();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/TopLevelModeState.java
@@ -6,6 +6,7 @@ public final class TopLevelModeState {
         NOTE_PLAY,
         CHORD_STEP,
         MELODIC_STEP,
+        FUGUE_STEP,
         NESTED_RHYTHM,
         PERFORM
     }
@@ -33,6 +34,10 @@ public final class TopLevelModeState {
         activeMode = Mode.CHORD_STEP;
     }
 
+    public void activateFugueStep() {
+        activeMode = Mode.FUGUE_STEP;
+    }
+
     public boolean shouldIgnoreTopLevelStepPress(final boolean shiftHeld, final boolean altHeld) {
         return (activeMode == Mode.DRUM || activeMode == Mode.NOTE_PLAY
                 || activeMode == Mode.CHORD_STEP || activeMode == Mode.PERFORM)
@@ -44,7 +49,7 @@ public final class TopLevelModeState {
     }
 
     public void enterMelodicStepMode() {
-        previousNonStepMode = (activeMode == Mode.MELODIC_STEP || activeMode == Mode.NESTED_RHYTHM)
+        previousNonStepMode = isStepFamily(activeMode)
                 ? Mode.NOTE_PLAY
                 : activeMode;
         activeMode = Mode.MELODIC_STEP;
@@ -56,9 +61,13 @@ public final class TopLevelModeState {
     }
 
     public void enterNestedRhythmMode() {
-        previousNonStepMode = (activeMode == Mode.MELODIC_STEP || activeMode == Mode.NESTED_RHYTHM)
+        previousNonStepMode = isStepFamily(activeMode)
                 ? Mode.NOTE_PLAY
                 : activeMode;
         activeMode = Mode.NESTED_RHYTHM;
+    }
+
+    private boolean isStepFamily(final Mode mode) {
+        return mode == Mode.MELODIC_STEP || mode == Mode.FUGUE_STEP || mode == Mode.NESTED_RHYTHM;
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
@@ -32,18 +32,19 @@ public final class FugueClipAdapter {
             if (notesAtStep == null || notesAtStep.isEmpty()) {
                 continue;
             }
-            final List<NoteStep> notes = notesAtStep.values().stream()
-                    .filter(step -> step.state() == NoteStep.State.NoteOn)
-                    .sorted(Comparator.comparingInt(NoteStep::y))
+            final List<ObservedNote> notes = notesAtStep.values().stream()
+                    .map(FugueClipAdapter::snapshot)
+                    .filter(ObservedNote::active)
+                    .sorted(Comparator.comparingInt(ObservedNote::pitch))
                     .toList();
             if (notes.isEmpty()) {
                 continue;
             }
             int tiedSteps = 0;
-            for (final NoteStep note : notes) {
+            for (final ObservedNote note : notes) {
                 final double duration = Math.max(stepLength * 0.25, note.duration());
                 tiedSteps = Math.max(tiedSteps, (int) Math.floor((duration - stepLength * 0.98) / stepLength));
-                steps.get(i).add(new MelodicPattern.Step(i, true, false, note.y(),
+                steps.get(i).add(new MelodicPattern.Step(i, true, false, note.pitch(),
                         (int) Math.round(note.velocity() * 127.0),
                         Math.max(0.1, duration / stepLength), note.chance(), note.velocity() >= 0.87,
                         duration > stepLength * 1.05, note.recurrenceLength(), note.recurrenceMask()));
@@ -70,14 +71,22 @@ public final class FugueClipAdapter {
                 }
                 final double duration = stepLength * Math.max(step.gate(), 0.02);
                 clip.setStep(channel, i, step.pitch(), step.velocity(), duration);
-                applyGeneratedNoteExpression(clip.getStep(channel, i, step.pitch()), step);
+                final NoteStep generatedStep = clip.getStep(channel, i, step.pitch());
+                applyGeneratedNoteExpression(generatedStep, step);
             }
         }
     }
 
     private static void applyGeneratedNoteExpression(final NoteStep noteStep, final MelodicPattern.Step step) {
-        noteStep.setChance(Math.min(0.999, step.chance()));
-        noteStep.setIsChanceEnabled(step.chance() < 0.999);
+        try {
+            if (noteStep == null || noteStep.state() != NoteStep.State.NoteOn) {
+                return;
+            }
+            noteStep.setChance(Math.min(0.999, step.chance()));
+            noteStep.setIsChanceEnabled(step.chance() < 0.999);
+        } catch (final RuntimeException ignored) {
+            // Host-owned note objects can disappear while Bitwig is applying DAW-side note edits.
+        }
     }
 
     public static void duplicateChannelRange(final PinnableCursorClip clip,
@@ -94,11 +103,12 @@ public final class FugueClipAdapter {
             }
             final int targetX = targetStartStep + sourceX - sourceStartStep;
             for (final NoteStep note : stepEntry.getValue().values()) {
-                if (note.state() != NoteStep.State.NoteOn) {
+                final ObservedNote snapshot = snapshot(note);
+                if (!snapshot.active()) {
                     continue;
                 }
-                clip.setStep(channel, targetX, note.y(), (int) Math.round(note.velocity() * 127.0),
-                        note.duration());
+                clip.setStep(channel, targetX, snapshot.pitch(), (int) Math.round(snapshot.velocity() * 127.0),
+                        snapshot.duration());
             }
         }
     }
@@ -108,6 +118,25 @@ public final class FugueClipAdapter {
                                     final int channel) {
         for (int x = 0; x < FuguePattern.MAX_STEPS; x++) {
             clip.clearStepsAtX(channel, x);
+        }
+    }
+
+    private static ObservedNote snapshot(final NoteStep note) {
+        try {
+            if (note == null || note.state() != NoteStep.State.NoteOn) {
+                return ObservedNote.empty();
+            }
+            return new ObservedNote(true, note.y(), note.velocity(), note.chance(), note.duration(),
+                    note.recurrenceLength(), note.recurrenceMask());
+        } catch (final RuntimeException ignored) {
+            return ObservedNote.empty();
+        }
+    }
+
+    private record ObservedNote(boolean active, int pitch, double velocity, double chance, double duration,
+                                int recurrenceLength, int recurrenceMask) {
+        private static ObservedNote empty() {
+            return new ObservedNote(false, 0, 0.0, 1.0, 0.0, 0, 0);
         }
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
@@ -106,12 +106,8 @@ public final class FugueClipAdapter {
     public static void clearChannel(final PinnableCursorClip clip,
                                     final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> observedSteps,
                                     final int channel) {
-        final Map<Integer, Map<Integer, NoteStep>> channelSteps = observedSteps.getOrDefault(channel, Map.of());
-        for (final Map.Entry<Integer, Map<Integer, NoteStep>> stepEntry : channelSteps.entrySet()) {
-            final int x = stepEntry.getKey();
-            for (final Integer pitch : stepEntry.getValue().keySet()) {
-                clip.clearStep(channel, x, pitch);
-            }
+        for (int x = 0; x < FuguePattern.MAX_STEPS; x++) {
+            clip.clearStepsAtX(channel, x);
         }
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
@@ -1,0 +1,111 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extension.controller.api.NoteStep;
+import com.bitwig.extension.controller.api.PinnableCursorClip;
+import com.oikoaudio.fire.melodic.MelodicPattern;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public final class FugueClipAdapter {
+    public static final int SOURCE_CHANNEL = 0;
+    public static final int FIRST_DERIVED_CHANNEL = 1;
+    public static final int LAST_DERIVED_CHANNEL = 3;
+
+    private FugueClipAdapter() {
+    }
+
+    public static FuguePattern sourceFromChannelOne(final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> noteSteps,
+                                                      final int loopSteps,
+                                                      final double stepLength) {
+        return fromChannel(noteSteps, SOURCE_CHANNEL, loopSteps, stepLength);
+    }
+
+    public static FuguePattern fromChannel(final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> noteSteps,
+                                             final int channel,
+                                             final int loopSteps,
+                                             final double stepLength) {
+        final List<List<MelodicPattern.Step>> steps = FuguePattern.emptyPolySteps();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            final Map<Integer, NoteStep> notesAtStep = noteSteps.getOrDefault(channel, Map.of()).get(i);
+            if (notesAtStep == null || notesAtStep.isEmpty()) {
+                continue;
+            }
+            final List<NoteStep> notes = notesAtStep.values().stream()
+                    .filter(step -> step.state() == NoteStep.State.NoteOn)
+                    .sorted(Comparator.comparingInt(NoteStep::y))
+                    .toList();
+            if (notes.isEmpty()) {
+                continue;
+            }
+            int tiedSteps = 0;
+            for (final NoteStep note : notes) {
+                final double duration = Math.max(stepLength * 0.25, note.duration());
+                tiedSteps = Math.max(tiedSteps, (int) Math.floor((duration - stepLength * 0.98) / stepLength));
+                steps.get(i).add(new MelodicPattern.Step(i, true, false, note.y(),
+                        (int) Math.round(note.velocity() * 127.0),
+                        Math.max(0.1, duration / stepLength), note.chance(), note.velocity() >= 0.87,
+                        duration > stepLength * 1.05, note.recurrenceLength(), note.recurrenceMask()));
+            }
+            for (int offset = 1; offset <= tiedSteps && i + offset < FuguePattern.MAX_STEPS; offset++) {
+                if (steps.get(i + offset).isEmpty()) {
+                    steps.get(i + offset).add(MelodicPattern.Step.rest(i + offset).withTieFromPrevious(true));
+                }
+            }
+        }
+        return new FuguePattern(steps, loopSteps, true);
+    }
+
+    public static void writeDerivedLine(final PinnableCursorClip clip,
+                                        final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> observedSteps,
+                                        final int channel,
+                                        final FuguePattern pattern,
+                                        final double stepLength) {
+        clearChannel(clip, observedSteps, channel);
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            for (final MelodicPattern.Step step : pattern.notesAt(i)) {
+                if (!step.active() || step.tieFromPrevious() || step.pitch() == null) {
+                    continue;
+                }
+                final double duration = stepLength * Math.max(step.gate(), 0.02);
+                clip.setStep(channel, i, step.pitch(), step.velocity(), duration);
+            }
+        }
+    }
+
+    public static void duplicateChannelRange(final PinnableCursorClip clip,
+                                             final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> observedSteps,
+                                             final int channel,
+                                             final int sourceStartStep,
+                                             final int sourceStepCount,
+                                             final int targetStartStep) {
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps = observedSteps.getOrDefault(channel, Map.of());
+        for (final Map.Entry<Integer, Map<Integer, NoteStep>> stepEntry : channelSteps.entrySet()) {
+            final int sourceX = stepEntry.getKey();
+            if (sourceX < sourceStartStep || sourceX >= sourceStartStep + sourceStepCount) {
+                continue;
+            }
+            final int targetX = targetStartStep + sourceX - sourceStartStep;
+            for (final NoteStep note : stepEntry.getValue().values()) {
+                if (note.state() != NoteStep.State.NoteOn) {
+                    continue;
+                }
+                clip.setStep(channel, targetX, note.y(), (int) Math.round(note.velocity() * 127.0),
+                        note.duration());
+            }
+        }
+    }
+
+    public static void clearChannel(final PinnableCursorClip clip,
+                                    final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> observedSteps,
+                                    final int channel) {
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps = observedSteps.getOrDefault(channel, Map.of());
+        for (final Map.Entry<Integer, Map<Integer, NoteStep>> stepEntry : channelSteps.entrySet()) {
+            final int x = stepEntry.getKey();
+            for (final Integer pitch : stepEntry.getValue().keySet()) {
+                clip.clearStep(channel, x, pitch);
+            }
+        }
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueClipAdapter.java
@@ -70,8 +70,14 @@ public final class FugueClipAdapter {
                 }
                 final double duration = stepLength * Math.max(step.gate(), 0.02);
                 clip.setStep(channel, i, step.pitch(), step.velocity(), duration);
+                applyGeneratedNoteExpression(clip.getStep(channel, i, step.pitch()), step);
             }
         }
+    }
+
+    private static void applyGeneratedNoteExpression(final NoteStep noteStep, final MelodicPattern.Step step) {
+        noteStep.setChance(Math.min(0.999, step.chance()));
+        noteStep.setIsChanceEnabled(step.chance() < 0.999);
     }
 
     public static void duplicateChannelRange(final PinnableCursorClip clip,

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueDirection.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueDirection.java
@@ -1,0 +1,22 @@
+package com.oikoaudio.fire.fugue;
+
+public enum FugueDirection {
+    FORWARD("Forward"),
+    REVERSE("Reverse"),
+    PING_PONG("PingPong");
+
+    private final String label;
+
+    FugueDirection(final String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public FugueDirection next(final int amount) {
+        final FugueDirection[] values = values();
+        return values[Math.floorMod(ordinal() + amount, values.length)];
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueLineSettings.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueLineSettings.java
@@ -1,0 +1,75 @@
+package com.oikoaudio.fire.fugue;
+
+public record FugueLineSettings(FugueDirection direction, FugueSpeed speed, int startOffset,
+                                int pitchDegreeOffset, int pitchSemitoneOffset,
+                                int velocityOffset, int chancePercent, int gatePercent) {
+    public static FugueLineSettings init() {
+        return new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.NORMAL, 0, 0, 0, 0, 100, 100);
+    }
+
+    public static FugueLineSettings semitone(final FugueDirection direction, final FugueSpeed speed,
+                                             final int startOffset, final int pitchSemitoneOffset) {
+        return new FugueLineSettings(direction, speed, startOffset, 0, pitchSemitoneOffset, 0, 100, 100);
+    }
+
+    public FugueLineSettings(final FugueDirection direction, final FugueSpeed speed,
+                             final int startOffset, final int pitchDegreeOffset) {
+        this(direction, speed, startOffset, pitchDegreeOffset, 0, 0, 100, 100);
+    }
+
+    public FugueLineSettings {
+        direction = direction == null ? FugueDirection.FORWARD : direction;
+        speed = speed == null ? FugueSpeed.NORMAL : speed;
+        startOffset = Math.max(0, Math.min(FuguePattern.MAX_STEPS - 1, startOffset));
+        pitchDegreeOffset = Math.max(-24, Math.min(24, pitchDegreeOffset));
+        pitchSemitoneOffset = Math.max(-48, Math.min(48, pitchSemitoneOffset));
+        velocityOffset = Math.max(-126, Math.min(126, velocityOffset));
+        chancePercent = Math.max(0, Math.min(100, chancePercent));
+        gatePercent = Math.max(10, Math.min(200, gatePercent));
+    }
+
+    public FugueLineSettings withDirection(final FugueDirection value) {
+        return new FugueLineSettings(value, speed, startOffset, pitchDegreeOffset, pitchSemitoneOffset,
+                velocityOffset, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withSpeed(final FugueSpeed value) {
+        return new FugueLineSettings(direction, value, startOffset, pitchDegreeOffset, pitchSemitoneOffset,
+                velocityOffset, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withStartOffset(final int value) {
+        return new FugueLineSettings(direction, speed, value, pitchDegreeOffset, pitchSemitoneOffset,
+                velocityOffset, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withPitchDegreeOffset(final int value) {
+        return new FugueLineSettings(direction, speed, startOffset, value, pitchSemitoneOffset,
+                velocityOffset, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withPitchSemitoneOffset(final int value) {
+        return new FugueLineSettings(direction, speed, startOffset, pitchDegreeOffset, value,
+                velocityOffset, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withVelocityOffset(final int value) {
+        return new FugueLineSettings(direction, speed, startOffset, pitchDegreeOffset, pitchSemitoneOffset,
+                value, chancePercent, gatePercent);
+    }
+
+    public FugueLineSettings withChancePercent(final int value) {
+        return new FugueLineSettings(direction, speed, startOffset, pitchDegreeOffset, pitchSemitoneOffset,
+                velocityOffset, value, gatePercent);
+    }
+
+    public FugueLineSettings withGatePercent(final int value) {
+        return new FugueLineSettings(direction, speed, startOffset, pitchDegreeOffset, pitchSemitoneOffset,
+                velocityOffset, chancePercent, value);
+    }
+
+    public String summary() {
+        return "%s %s st%d deg%+d sem%+d vel%+d ch%d gate%d".formatted(direction.label(), speed.label(), startOffset,
+                pitchDegreeOffset, pitchSemitoneOffset, velocityOffset, chancePercent, gatePercent);
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePattern.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePattern.java
@@ -1,0 +1,76 @@
+package com.oikoaudio.fire.fugue;
+
+import com.oikoaudio.fire.melodic.MelodicPattern;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class FuguePattern {
+    public static final int MAX_STEPS = 256;
+
+    private final List<List<MelodicPattern.Step>> steps;
+    private final int loopSteps;
+
+    public FuguePattern(final List<MelodicPattern.Step> steps, final int loopSteps) {
+        if (steps.size() != MAX_STEPS) {
+            throw new IllegalArgumentException("FuguePattern requires exactly %d steps".formatted(MAX_STEPS));
+        }
+        final List<List<MelodicPattern.Step>> wrapped = new ArrayList<>(MAX_STEPS);
+        for (final MelodicPattern.Step step : steps) {
+            wrapped.add(step.active() ? List.of(step) : List.of());
+        }
+        this.steps = List.copyOf(wrapped);
+        this.loopSteps = Math.max(1, Math.min(MAX_STEPS, loopSteps));
+    }
+
+    public FuguePattern(final List<List<MelodicPattern.Step>> steps, final int loopSteps, final boolean polyphonic) {
+        if (steps.size() != MAX_STEPS) {
+            throw new IllegalArgumentException("FuguePattern requires exactly %d steps".formatted(MAX_STEPS));
+        }
+        final List<List<MelodicPattern.Step>> copy = new ArrayList<>(MAX_STEPS);
+        for (final List<MelodicPattern.Step> step : steps) {
+            copy.add(List.copyOf(step));
+        }
+        this.steps = List.copyOf(copy);
+        this.loopSteps = Math.max(1, Math.min(MAX_STEPS, loopSteps));
+    }
+
+    public static FuguePattern empty(final int loopSteps) {
+        final List<MelodicPattern.Step> steps = new ArrayList<>(MAX_STEPS);
+        for (int i = 0; i < MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        return new FuguePattern(steps, loopSteps);
+    }
+
+    public MelodicPattern.Step step(final int index) {
+        final List<MelodicPattern.Step> notes = steps.get(index);
+        return notes.isEmpty() ? MelodicPattern.Step.rest(index) : notes.get(0);
+    }
+
+    public List<MelodicPattern.Step> notesAt(final int index) {
+        return steps.get(index);
+    }
+
+    public int loopSteps() {
+        return loopSteps;
+    }
+
+    static List<MelodicPattern.Step> emptySteps() {
+        final List<MelodicPattern.Step> steps = new ArrayList<>(Collections.nCopies(MAX_STEPS,
+                MelodicPattern.Step.rest(0)));
+        for (int i = 0; i < MAX_STEPS; i++) {
+            steps.set(i, MelodicPattern.Step.rest(i));
+        }
+        return steps;
+    }
+
+    static List<List<MelodicPattern.Step>> emptyPolySteps() {
+        final List<List<MelodicPattern.Step>> steps = new ArrayList<>(MAX_STEPS);
+        for (int i = 0; i < MAX_STEPS; i++) {
+            steps.add(new ArrayList<>());
+        }
+        return steps;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePattern.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePattern.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 public final class FuguePattern {
-    public static final int MAX_STEPS = 256;
+    public static final int MAX_STEPS = 512;
 
     private final List<List<MelodicPattern.Step>> steps;
     private final int loopSteps;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePitchIntervals.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePitchIntervals.java
@@ -4,7 +4,6 @@ public final class FuguePitchIntervals {
     private static final int MIN_DEGREES = -24;
     private static final int MAX_DEGREES = 24;
     private static final int OCTAVE_DEGREES = 7;
-    private static final int[] NOMINAL_MAJOR_SEMITONES = {0, 2, 4, 5, 7, 9, 11};
 
     private FuguePitchIntervals() {
     }
@@ -18,16 +17,7 @@ public final class FuguePitchIntervals {
     }
 
     public static String label(final int degreeOffset) {
-        final int semitones = nominalSemitoneOffset(degreeOffset);
-        return semitones == 0 ? "0" : "%+d".formatted(semitones);
-    }
-
-    private static int nominalSemitoneOffset(final int degreeOffset) {
-        final int sign = degreeOffset < 0 ? -1 : 1;
-        final int absolute = Math.abs(degreeOffset);
-        final int octaves = absolute / OCTAVE_DEGREES;
-        final int degree = absolute % OCTAVE_DEGREES;
-        return sign * (octaves * 12 + NOMINAL_MAJOR_SEMITONES[degree]);
+        return degreeOffset == 0 ? "0d" : "%+dd".formatted(degreeOffset);
     }
 
     private static int clamp(final int value) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePitchIntervals.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePitchIntervals.java
@@ -1,0 +1,36 @@
+package com.oikoaudio.fire.fugue;
+
+public final class FuguePitchIntervals {
+    private static final int MIN_DEGREES = -24;
+    private static final int MAX_DEGREES = 24;
+    private static final int OCTAVE_DEGREES = 7;
+    private static final int[] NOMINAL_MAJOR_SEMITONES = {0, 2, 4, 5, 7, 9, 11};
+
+    private FuguePitchIntervals() {
+    }
+
+    public static int nextDegreeInterval(final int current, final int amount) {
+        return clamp(current + amount);
+    }
+
+    public static int octaveJump(final int current, final int amount) {
+        return clamp(current + amount * OCTAVE_DEGREES);
+    }
+
+    public static String label(final int degreeOffset) {
+        final int semitones = nominalSemitoneOffset(degreeOffset);
+        return semitones == 0 ? "0" : "%+d".formatted(semitones);
+    }
+
+    private static int nominalSemitoneOffset(final int degreeOffset) {
+        final int sign = degreeOffset < 0 ? -1 : 1;
+        final int absolute = Math.abs(degreeOffset);
+        final int octaves = absolute / OCTAVE_DEGREES;
+        final int degree = absolute % OCTAVE_DEGREES;
+        return sign * (octaves * 12 + NOMINAL_MAJOR_SEMITONES[degree]);
+    }
+
+    private static int clamp(final int value) {
+        return Math.max(MIN_DEGREES, Math.min(MAX_DEGREES, value));
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePreset.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePreset.java
@@ -1,0 +1,32 @@
+package com.oikoaudio.fire.fugue;
+
+public enum FuguePreset {
+    INIT("Init", FugueLineSettings.init()),
+    BASS_AUGMENTED("Bass /8", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 1, -7)),
+    HIGH_HALF("High /2", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_2, 1, 18)),
+    REVERSE_DOUBLE("Rev x2", new FugueLineSettings(FugueDirection.REVERSE, FugueSpeed.TIMES_2, 1, 11)),
+    FIFTH_DOUBLE("5th x2", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 4)),
+    FOURTH_REVERSE("4th Rev", new FugueLineSettings(FugueDirection.REVERSE, FugueSpeed.NORMAL, 0, 3)),
+    OCTAVE_PING("8ve Ping", new FugueLineSettings(FugueDirection.PING_PONG, FugueSpeed.NORMAL, 0, 7));
+
+    private final String label;
+    private final FugueLineSettings settings;
+
+    FuguePreset(final String label, final FugueLineSettings settings) {
+        this.label = label;
+        this.settings = settings;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public FugueLineSettings settings() {
+        return settings;
+    }
+
+    public FuguePreset next(final int amount) {
+        final FuguePreset[] values = values();
+        return values[Math.floorMod(ordinal() + amount, values.length)];
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePreset.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FuguePreset.java
@@ -2,7 +2,10 @@ package com.oikoaudio.fire.fugue;
 
 public enum FuguePreset {
     INIT("Init", FugueLineSettings.init()),
-    BASS_AUGMENTED("Bass /8", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 1, -7)),
+    BASS_OCTAVE("Bass /8", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 0, -7)),
+    THIRD_TRIPLET("3rd 2trp", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2_TRIPLET, 0, 2)),
+    TENTH_DOUBLE("10th x2", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 9)),
+    BASS_AUGMENTED("BassOld", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 1, -7)),
     HIGH_HALF("High /2", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_2, 1, 18)),
     REVERSE_DOUBLE("Rev x2", new FugueLineSettings(FugueDirection.REVERSE, FugueSpeed.TIMES_2, 1, 11)),
     FIFTH_DOUBLE("5th x2", new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 4)),

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueSpeed.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueSpeed.java
@@ -38,6 +38,10 @@ public enum FugueSpeed {
         return numerator > denominator;
     }
 
+    boolean isSlowDown() {
+        return denominator > numerator;
+    }
+
     int transformedLoopSteps(final int sourceLoopSteps) {
         return Math.max(1, (int) Math.ceil(sourceLoopSteps * (double) denominator / numerator));
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueSpeed.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueSpeed.java
@@ -1,0 +1,53 @@
+package com.oikoaudio.fire.fugue;
+
+public enum FugueSpeed {
+    DIVIDE_8("/8", 8, 1),
+    DIVIDE_4("/4", 4, 1),
+    DIVIDE_3("/3", 3, 1),
+    DIVIDE_2("/2", 2, 1),
+    DIVIDE_1_5("/1.5", 3, 2),
+    NORMAL("1", 1, 1),
+    TIMES_2_DOTTED("2 dt", 3, 4),
+    TIMES_TRIPLET("1 trp", 2, 3),
+    TIMES_2("2", 1, 2),
+    TIMES_2_TRIPLET("2 trp", 1, 3),
+    TIMES_3_DOTTED("3 dt", 2, 9),
+    TIMES_4("4", 1, 4),
+    TIMES_6("6", 1, 6),
+    TIMES_8("8", 1, 8);
+
+    private final String label;
+    private final int denominator;
+    private final int numerator;
+
+    FugueSpeed(final String label, final int denominator, final int numerator) {
+        this.label = label;
+        this.denominator = denominator;
+        this.numerator = numerator;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    int scaleStart(final int sourceStep) {
+        return Math.floorDiv(sourceStep * denominator, numerator);
+    }
+
+    boolean isSpeedUp() {
+        return numerator > denominator;
+    }
+
+    int transformedLoopSteps(final int sourceLoopSteps) {
+        return Math.max(1, (int) Math.ceil(sourceLoopSteps * (double) denominator / numerator));
+    }
+
+    double scaleGate(final double gate) {
+        return gate * denominator / numerator;
+    }
+
+    public FugueSpeed next(final int amount) {
+        final FugueSpeed[] values = values();
+        return values[Math.max(0, Math.min(values.length - 1, ordinal() + amount))];
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -17,6 +17,7 @@ import com.oikoaudio.fire.note.NoteGridLayout;
 import com.oikoaudio.fire.sequence.EncoderMode;
 import com.oikoaudio.fire.utils.PatternButtons;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,6 +67,7 @@ public final class FugueStepMode extends Layer {
     private int sourceRebuildToken = 0;
     private boolean mainEncoderPressConsumed = false;
     private boolean active = false;
+    private TemplatePadEdit templatePadEdit = null;
 
     public FugueStepMode(final AkaiFireOikontrolExtension driver) {
         super(driver.getLayers(), "FUGUE_STEP_MODE");
@@ -164,16 +166,40 @@ public final class FugueStepMode extends Layer {
     private void bindEncoders() {
         final TouchEncoder[] encoders = driver.getEncoders();
         encoders[0].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
-                driver::isGlobalShiftHeld, this::adjustDirectionOrPreset);
+                driver::isGlobalShiftHeld, inc -> {
+                    if (templatePadEdit != null) {
+                        adjustTemplatePadVelocity(inc);
+                    } else {
+                        adjustDirectionOrPreset(inc);
+                    }
+                });
         encoders[0].bindTouched(this, touched -> showEncoderTouchValue(0, touched));
         encoders[1].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
-                driver::isGlobalShiftHeld, inc -> adjustSpeed(activeLineIndex(), inc));
+                driver::isGlobalShiftHeld, inc -> {
+                    if (templatePadEdit != null) {
+                        adjustTemplatePadChance(inc);
+                    } else {
+                        adjustSpeed(activeLineIndex(), inc);
+                    }
+                });
         encoders[1].bindTouched(this, touched -> showEncoderTouchValue(1, touched));
         encoders[2].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
-                driver::isGlobalShiftHeld, inc -> adjustStartOffset(activeLineIndex(), inc));
+                driver::isGlobalShiftHeld, inc -> {
+                    if (templatePadEdit != null) {
+                        adjustTemplatePadGate(inc);
+                    } else {
+                        adjustStartOffset(activeLineIndex(), inc);
+                    }
+                });
         encoders[2].bindTouched(this, touched -> showEncoderTouchValue(2, touched));
         encoders[3].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
-                driver::isGlobalShiftHeld, this::adjustPitch);
+                driver::isGlobalShiftHeld, inc -> {
+                    if (templatePadEdit != null) {
+                        transposeTemplatePadEdit(inc);
+                    } else {
+                        adjustPitch(inc);
+                    }
+                });
         encoders[3].bindTouched(this, touched -> showEncoderTouchValue(3, touched));
     }
 
@@ -189,6 +215,10 @@ public final class FugueStepMode extends Layer {
             return;
         }
         if (inc == 0) {
+            return;
+        }
+        if (templatePadEdit != null) {
+            transposeTemplatePadEdit(inc);
             return;
         }
         driver.markMainEncoderTurned();
@@ -212,6 +242,14 @@ public final class FugueStepMode extends Layer {
     private void handleMainEncoderPress(final boolean pressed) {
         if (driver.isPopupBrowserActive()) {
             driver.routeBrowserMainEncoderPress(pressed);
+            return;
+        }
+        if (templatePadEdit != null) {
+            if (pressed) {
+                oled.valueInfo("Template Pitch", currentTemplatePadEditLabel());
+            } else {
+                oled.clearScreenDelayed();
+            }
             return;
         }
         driver.setMainEncoderPressed(pressed);
@@ -269,11 +307,25 @@ public final class FugueStepMode extends Layer {
             oled.clearScreenDelayed();
             return;
         }
+        if (templatePadEdit != null) {
+            showTemplatePadEditEncoderValue(encoderIndex);
+            return;
+        }
         if (activeLineIndex() == FugueClipAdapter.SOURCE_CHANNEL) {
             showTemplateEncoderValue(encoderIndex);
             return;
         }
         showDerivedLineEncoderValue(activeLineIndex(), encoderIndex);
+    }
+
+    private void showTemplatePadEditEncoderValue(final int encoderIndex) {
+        switch (encoderIndex) {
+            case 0 -> oled.valueInfo("Template Velocity", Integer.toString(templatePadVelocity()));
+            case 1 -> oled.valueInfo("Template Chance", "%d%%".formatted((int) Math.round(templatePadChance() * 100.0)));
+            case 2 -> oled.valueInfo("Template Gate", "%.2f".formatted(templatePadDuration()));
+            case 3 -> oled.valueInfo("Template Pitch", currentTemplatePadEditLabel());
+            default -> { }
+        }
     }
 
     private void showTemplateEncoderValue(final int encoderIndex) {
@@ -330,18 +382,175 @@ public final class FugueStepMode extends Layer {
     }
 
     private void handlePadPress(final int padIndex, final boolean pressed) {
+        final int line = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            handleTemplatePadPress(column, pressed);
+            return;
+        }
         if (!pressed) {
             return;
         }
-        final int line = padIndex / PAD_COLUMNS;
-        final int column = padIndex % PAD_COLUMNS;
         selectLine(line);
-        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
-            setClipPlayStart(bucketStart(column));
+        setStartOffset(line, bucketStart(column));
+    }
+
+    private void handleTemplatePadPress(final int column, final boolean pressed) {
+        if (pressed) {
+            selectLine(FugueClipAdapter.SOURCE_CHANNEL);
+            templatePadEdit = createTemplatePadEdit(column);
+            oled.valueInfo("Template", currentTemplatePadEditLabel());
+            return;
+        }
+        if (templatePadEdit == null || templatePadEdit.column != column) {
+            return;
+        }
+        finishTemplatePadEdit();
+    }
+
+    private TemplatePadEdit createTemplatePadEdit(final int column) {
+        final int start = bucketStart(column);
+        final int end = bucketEnd(column);
+        return findTemplateNoteInRange(start, end)
+                .map(note -> new TemplatePadEdit(column, start, note.x(), note.y(), true, false,
+                        (int) Math.round(note.velocity() * 127.0), note.chance(), note.duration()))
+                .orElseGet(() -> new TemplatePadEdit(column, start, start, defaultTemplatePitch(), false, false,
+                        96, 1.0, STEP_LENGTH * 2));
+    }
+
+    private java.util.Optional<NoteStep> findTemplateNoteInRange(final int start, final int end) {
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps =
+                noteStepsByChannel.getOrDefault(FugueClipAdapter.SOURCE_CHANNEL, Map.of());
+        return channelSteps.entrySet().stream()
+                .filter(entry -> entry.getKey() >= start && entry.getKey() < end)
+                .flatMap(entry -> entry.getValue().values().stream())
+                .filter(note -> note.state() == NoteStep.State.NoteOn)
+                .min(Comparator.comparingInt(NoteStep::y).thenComparingInt(NoteStep::x));
+    }
+
+    private int defaultTemplatePitch() {
+        return driver.getSharedMusicalScale().computeNote(driver.getSharedRootNote(), driver.getSharedOctave() + 1, 0);
+    }
+
+    private void finishTemplatePadEdit() {
+        final TemplatePadEdit edit = templatePadEdit;
+        templatePadEdit = null;
+        if (!edit.changed && edit.existed) {
+            cursorClip.clearStep(FugueClipAdapter.SOURCE_CHANNEL, edit.step, edit.pitch);
+            removeCachedSourceNote(edit.step, edit.pitch);
+            scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
+            oled.valueInfo("Template", "Removed");
             oled.clearScreenDelayed();
             return;
         }
-        setStartOffset(line, bucketStart(column));
+        if (!edit.changed) {
+            setClipPlayStart(edit.step);
+            oled.clearScreenDelayed();
+            return;
+        }
+        regenerateAllEnabledDerivedLinesSilently();
+        oled.clearScreenDelayed();
+    }
+
+    private void transposeTemplatePadEdit(final int inc) {
+        if (templatePadEdit == null) {
+            return;
+        }
+        final TemplatePadEdit edit = templatePadEdit;
+        final int nextPitch = ScaleAwareTransposer.transposeByScaleDegrees(edit.pitch, inc,
+                driver.getSharedMusicalScale(), driver.getSharedRootNote());
+        if (nextPitch == edit.pitch && edit.existed) {
+            return;
+        }
+        if (edit.existed) {
+            cursorClip.clearStep(FugueClipAdapter.SOURCE_CHANNEL, edit.step, edit.pitch);
+            removeCachedSourceNote(edit.step, edit.pitch);
+        }
+        writeTemplatePadEditNote(edit.withPitch(nextPitch).withChanged(true));
+        oled.valueInfo("Template Pitch", currentTemplatePadEditLabel());
+    }
+
+    private void adjustTemplatePadVelocity(final int inc) {
+        if (templatePadEdit == null) {
+            return;
+        }
+        writeTemplatePadEditNote(templatePadEdit.withVelocity(templatePadVelocity() + inc * 4).withChanged(true));
+        oled.valueInfo("Template Velocity", Integer.toString(templatePadVelocity()));
+    }
+
+    private void adjustTemplatePadChance(final int inc) {
+        if (templatePadEdit == null) {
+            return;
+        }
+        writeTemplatePadEditNote(templatePadEdit.withChance(templatePadChance() + inc * 0.05).withChanged(true));
+        oled.valueInfo("Template Chance", "%d%%".formatted((int) Math.round(templatePadChance() * 100.0)));
+    }
+
+    private void adjustTemplatePadGate(final int inc) {
+        if (templatePadEdit == null) {
+            return;
+        }
+        writeTemplatePadEditNote(templatePadEdit.withDuration(templatePadDuration() + inc * STEP_LENGTH).withChanged(true));
+        oled.valueInfo("Template Gate", "%.2f".formatted(templatePadDuration()));
+    }
+
+    private void writeTemplatePadEditNote(final TemplatePadEdit nextEdit) {
+        if (templatePadEdit != null && templatePadEdit.existed) {
+            cursorClip.clearStep(FugueClipAdapter.SOURCE_CHANNEL, templatePadEdit.step, templatePadEdit.pitch);
+            removeCachedSourceNote(templatePadEdit.step, templatePadEdit.pitch);
+        }
+        cursorClip.setStep(FugueClipAdapter.SOURCE_CHANNEL, nextEdit.step, nextEdit.pitch,
+                nextEdit.velocity, nextEdit.duration);
+        final NoteStep note = cursorClip.getStep(FugueClipAdapter.SOURCE_CHANNEL, nextEdit.step, nextEdit.pitch);
+        note.setChance(Math.min(0.999, nextEdit.chance));
+        note.setIsChanceEnabled(nextEdit.chance < 0.999);
+        cacheSourceNote(note);
+        templatePadEdit = nextEdit.withExisted(true);
+    }
+
+    private int templatePadVelocity() {
+        return templatePadEdit == null ? 96 : templatePadEdit.velocity;
+    }
+
+    private double templatePadChance() {
+        return templatePadEdit == null ? 1.0 : templatePadEdit.chance;
+    }
+
+    private double templatePadDuration() {
+        return templatePadEdit == null ? STEP_LENGTH * 2 : templatePadEdit.duration;
+    }
+
+    private String currentTemplatePadEditLabel() {
+        if (templatePadEdit == null) {
+            return "";
+        }
+        return "%s%d".formatted(NoteGridLayout.noteName(templatePadEdit.pitch), templatePadEdit.pitch / 12 - 1);
+    }
+
+    private void cacheSourceNote(final NoteStep note) {
+        if (note.state() != NoteStep.State.NoteOn) {
+            return;
+        }
+        noteStepsByChannel.computeIfAbsent(FugueClipAdapter.SOURCE_CHANNEL, ignored -> new HashMap<>())
+                .computeIfAbsent(note.x(), ignored -> new HashMap<>())
+                .put(note.y(), note);
+    }
+
+    private void removeCachedSourceNote(final int step, final int pitch) {
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps = noteStepsByChannel.get(FugueClipAdapter.SOURCE_CHANNEL);
+        if (channelSteps == null) {
+            return;
+        }
+        final Map<Integer, NoteStep> notesAtStep = channelSteps.get(step);
+        if (notesAtStep != null) {
+            notesAtStep.remove(pitch);
+            if (notesAtStep.isEmpty()) {
+                channelSteps.remove(step);
+            }
+        }
+        if (channelSteps.isEmpty()) {
+            noteStepsByChannel.remove(FugueClipAdapter.SOURCE_CHANNEL);
+        }
     }
 
     private RgbLigthState getPadLight(final int padIndex) {
@@ -888,5 +1097,35 @@ public final class FugueStepMode extends Layer {
 
     private String lineLabel(final int line) {
         return "Line " + (line + 1);
+    }
+
+    private record TemplatePadEdit(int column, int bucketStart, int step, int pitch, boolean existed, boolean changed,
+                                   int velocity, double chance, double duration) {
+        TemplatePadEdit withPitch(final int value) {
+            return new TemplatePadEdit(column, bucketStart, step, value, existed, changed, velocity, chance, duration);
+        }
+
+        TemplatePadEdit withVelocity(final int value) {
+            return new TemplatePadEdit(column, bucketStart, step, pitch, existed, changed,
+                    Math.max(1, Math.min(127, value)), chance, duration);
+        }
+
+        TemplatePadEdit withChance(final double value) {
+            return new TemplatePadEdit(column, bucketStart, step, pitch, existed, changed, velocity,
+                    Math.max(0.0, Math.min(1.0, value)), duration);
+        }
+
+        TemplatePadEdit withDuration(final double value) {
+            return new TemplatePadEdit(column, bucketStart, step, pitch, existed, changed, velocity, chance,
+                    Math.max(STEP_LENGTH * 0.02, value));
+        }
+
+        TemplatePadEdit withExisted(final boolean value) {
+            return new TemplatePadEdit(column, bucketStart, step, pitch, value, changed, velocity, chance, duration);
+        }
+
+        TemplatePadEdit withChanged(final boolean value) {
+            return new TemplatePadEdit(column, bucketStart, step, pitch, existed, value, velocity, chance, duration);
+        }
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -29,8 +29,11 @@ public final class FugueStepMode extends Layer {
     private static final int ENCODER_THRESHOLD = 5;
     private static final int ENCODER_FINE_THRESHOLD = 10;
     private static final int SOURCE_CHANGE_REBUILD_DELAY_MS = 20;
+    private static final int SOURCE_EDIT_REBUILD_DELAY_MS = 250;
+    private static final int BAR_STEPS = 32;
     private static final int MAX_LOOP_STEPS = STEP_COUNT;
     private static final int MIN_LOOP_STEPS = 1;
+    private static final int[] CLIP_LENGTH_STEPS = {8, 16, 32, 64, 96, 128, 160, 192, 224, 256};
     private static final RgbLigthState[] LINE_COLORS = {
             new RgbLigthState(112, 0, 0, true),
             new RgbLigthState(112, 44, 0, true),
@@ -61,6 +64,8 @@ public final class FugueStepMode extends Layer {
     private int loopSteps = DEFAULT_LOOP_STEPS;
     private int playingStep = -1;
     private int sourceRebuildToken = 0;
+    private boolean mainEncoderPressConsumed = false;
+    private boolean active = false;
 
     public FugueStepMode(final AkaiFireOikontrolExtension driver) {
         super(driver.getLayers(), "FUGUE_STEP_MODE");
@@ -77,6 +82,7 @@ public final class FugueStepMode extends Layer {
         this.cursorClip.scrollToKey(0);
         this.cursorClip.scrollToStep(0);
         this.cursorClip.getLoopLength().markInterested();
+        this.cursorClip.getPlayStart().markInterested();
         this.cursorClip.getLoopLength().addValueObserver(length ->
                 loopSteps = Math.max(1, Math.min(STEP_COUNT, (int) Math.round(length / STEP_LENGTH))));
         this.cursorClip.addNoteStepObserver(this::handleNoteStepObject);
@@ -85,6 +91,7 @@ public final class FugueStepMode extends Layer {
         bindPads();
         bindButtons();
         bindEncoders();
+        bindMainEncoder();
     }
 
     public BiColorLightState getModeButtonLightState() {
@@ -96,6 +103,8 @@ public final class FugueStepMode extends Layer {
 
     @Override
     protected void onActivate() {
+        active = true;
+        refreshSourceCacheFromClip();
         patternButtons.setUpCallback(pressed -> {
             if (pressed) {
                 cyclePreset(activeLineIndex(), 1);
@@ -112,6 +121,8 @@ public final class FugueStepMode extends Layer {
 
     @Override
     protected void onDeactivate() {
+        active = false;
+        sourceRebuildToken++;
         patternButtons.setUpCallback(pressed -> { }, () -> BiColorLightState.OFF);
         patternButtons.setDownCallback(pressed -> { }, () -> BiColorLightState.OFF);
     }
@@ -166,6 +177,93 @@ public final class FugueStepMode extends Layer {
         encoders[3].bindTouched(this, touched -> showEncoderTouchValue(3, touched));
     }
 
+    private void bindMainEncoder() {
+        final TouchEncoder mainEncoder = driver.getMainEncoder();
+        mainEncoder.bindEncoder(this, this::handleMainEncoder);
+        mainEncoder.bindTouched(this, this::handleMainEncoderPress);
+    }
+
+    private void handleMainEncoder(final int inc) {
+        if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoder(inc);
+            return;
+        }
+        if (inc == 0) {
+            return;
+        }
+        driver.markMainEncoderTurned();
+        final boolean fine = driver.isGlobalShiftHeld();
+        final String mainEncoderRole = driver.getMainEncoderRolePreference();
+        if (AkaiFireOikontrolExtension.MAIN_ENCODER_TEMPO_ROLE.equals(mainEncoderRole)) {
+            driver.adjustTempo(inc, fine);
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_SHUFFLE_ROLE.equals(mainEncoderRole)) {
+            driver.adjustGrooveShuffleAmount(inc, fine);
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_TRACK_SELECT_ROLE.equals(mainEncoderRole)) {
+            driver.adjustSelectedTrack(inc, driver.isMainEncoderPressed());
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_NOTE_REPEAT_ROLE.equals(mainEncoderRole)) {
+            oled.valueInfo("Note Repeat", "Fugue only");
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_DRUM_GRID_ROLE.equals(mainEncoderRole)) {
+            oled.valueInfo("Drum Grid", "Drum only");
+        } else {
+            driver.adjustMainCursorParameter(inc, fine);
+        }
+    }
+
+    private void handleMainEncoderPress(final boolean pressed) {
+        if (driver.isPopupBrowserActive()) {
+            driver.routeBrowserMainEncoderPress(pressed);
+            return;
+        }
+        driver.setMainEncoderPressed(pressed);
+        if (pressed && driver.isGlobalShiftHeld()) {
+            mainEncoderPressConsumed = true;
+            driver.cycleMainEncoderRolePreference();
+            return;
+        }
+        if (!pressed && mainEncoderPressConsumed) {
+            mainEncoderPressConsumed = false;
+            return;
+        }
+        final String mainEncoderRole = driver.getMainEncoderRolePreference();
+        if (!pressed && !driver.wasMainEncoderTurnedWhilePressed()) {
+            driver.toggleMainEncoderRolePreference();
+            return;
+        }
+        if (AkaiFireOikontrolExtension.MAIN_ENCODER_TEMPO_ROLE.equals(mainEncoderRole)) {
+            if (pressed) {
+                driver.showTempoInfo();
+            } else {
+                oled.clearScreenDelayed();
+            }
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_SHUFFLE_ROLE.equals(mainEncoderRole)) {
+            if (pressed) {
+                driver.showGrooveShuffleInfo();
+            } else {
+                oled.clearScreenDelayed();
+            }
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_TRACK_SELECT_ROLE.equals(mainEncoderRole)) {
+            if (pressed) {
+                driver.showSelectedTrackInfo(false);
+            } else {
+                oled.clearScreenDelayed();
+            }
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_NOTE_REPEAT_ROLE.equals(mainEncoderRole)) {
+            if (pressed) {
+                oled.valueInfo("Note Repeat", "Fugue only");
+            } else {
+                oled.clearScreenDelayed();
+            }
+        } else if (AkaiFireOikontrolExtension.MAIN_ENCODER_DRUM_GRID_ROLE.equals(mainEncoderRole)) {
+            if (pressed) {
+                oled.valueInfo("Drum Grid", "Drum only");
+            } else {
+                oled.clearScreenDelayed();
+            }
+        } else if (pressed) {
+            driver.showMainCursorParameterInfo();
+        }
+    }
+
     private void showEncoderTouchValue(final int encoderIndex, final boolean touched) {
         if (!touched) {
             oled.clearScreenDelayed();
@@ -179,11 +277,22 @@ public final class FugueStepMode extends Layer {
     }
 
     private void showTemplateEncoderValue(final int encoderIndex) {
+        if (driver.isGlobalAltHeld()) {
+            final FugueLineSettings settings = lineSettings[FugueClipAdapter.SOURCE_CHANNEL];
+            switch (encoderIndex) {
+                case 0 -> oled.valueInfo("Line 1 Velocity", "%+d".formatted(settings.velocityOffset()));
+                case 1 -> oled.valueInfo("Line 1 Chance", settings.chancePercent() + "%");
+                case 2 -> oled.valueInfo("Line 1 Gate", settings.gatePercent() + "%");
+                case 3 -> oled.valueInfo("Play Start", formatPlayStart(cursorClip.getPlayStart().get()));
+                default -> { }
+            }
+            return;
+        }
         switch (encoderIndex) {
             case 0 -> oled.valueInfo("Template Root", NoteGridLayout.noteName(driver.getSharedRootNote()));
             case 1 -> oled.valueInfo("Template Scale", driver.getSharedScaleDisplayName());
-            case 2 -> oled.valueInfo("Template Octave", Integer.toString(driver.getSharedOctave()));
-            case 3 -> oled.valueInfo("Template Notes", Integer.toString(sourceStepCount()));
+            case 2 -> oled.valueInfo("Clip Length", formatSteps(currentLoopSteps()));
+            case 3 -> oled.valueInfo("Play Start", formatPlayStart(cursorClip.getPlayStart().get()));
             default -> { }
         }
     }
@@ -380,6 +489,11 @@ public final class FugueStepMode extends Layer {
 
     private void adjustDirectionOrPreset(final int inc) {
         if (activeLineIndex() == FugueClipAdapter.SOURCE_CHANNEL) {
+            if (driver.isGlobalAltHeld()) {
+                adjustVelocityOffset(FugueClipAdapter.SOURCE_CHANNEL, inc);
+                applySourceVelocityDelta(inc * 4);
+                return;
+            }
             adjustTemplateRoot(inc);
             return;
         }
@@ -398,6 +512,11 @@ public final class FugueStepMode extends Layer {
 
     private void adjustSpeed(final int line, final int inc) {
         if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            if (driver.isGlobalAltHeld()) {
+                adjustChance(FugueClipAdapter.SOURCE_CHANNEL, inc);
+                applySourceChancePercent();
+                return;
+            }
             adjustTemplateScale(inc);
             return;
         }
@@ -411,7 +530,13 @@ public final class FugueStepMode extends Layer {
 
     private void adjustStartOffset(final int line, final int inc) {
         if (line == FugueClipAdapter.SOURCE_CHANNEL) {
-            adjustTemplateOctave(inc);
+            if (driver.isGlobalAltHeld()) {
+                final int previousGatePercent = lineSettings[FugueClipAdapter.SOURCE_CHANNEL].gatePercent();
+                adjustGate(FugueClipAdapter.SOURCE_CHANNEL, inc);
+                applySourceGateScale(previousGatePercent);
+                return;
+            }
+            adjustTemplateClipLength(inc);
             return;
         }
         if (driver.isGlobalAltHeld()) {
@@ -430,7 +555,7 @@ public final class FugueStepMode extends Layer {
     private void adjustPitch(final int inc) {
         final int line = activeLineIndex();
         if (line == FugueClipAdapter.SOURCE_CHANNEL) {
-            showTemplateInfo();
+            adjustTemplatePlayStart(inc);
             return;
         }
         if (driver.isGlobalAltHeld()) {
@@ -472,6 +597,38 @@ public final class FugueStepMode extends Layer {
         afterLineSettingsChanged(line, "Gate", lineSettings[line].gatePercent() + "%");
     }
 
+    private void applySourceVelocityDelta(final int delta) {
+        forEachSourceNote(note -> note.setVelocity(Math.max(1.0, Math.min(127.0,
+                Math.round(note.velocity() * 127.0) + delta)) / 127.0));
+    }
+
+    private void applySourceChancePercent() {
+        final double chance = Math.min(0.999,
+                lineSettings[FugueClipAdapter.SOURCE_CHANNEL].chancePercent() / 100.0);
+        forEachSourceNote(note -> {
+            note.setChance(chance);
+            note.setIsChanceEnabled(chance < 0.999);
+        });
+    }
+
+    private void applySourceGateScale(final int previousGatePercent) {
+        final int nextGatePercent = lineSettings[FugueClipAdapter.SOURCE_CHANNEL].gatePercent();
+        final double factor = nextGatePercent / (double) Math.max(1, previousGatePercent);
+        forEachSourceNote(note -> note.setDuration(Math.max(STEP_LENGTH * 0.02, note.duration() * factor)));
+    }
+
+    private void forEachSourceNote(final java.util.function.Consumer<NoteStep> action) {
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps =
+                noteStepsByChannel.getOrDefault(FugueClipAdapter.SOURCE_CHANNEL, Map.of());
+        for (final Map<Integer, NoteStep> notesAtStep : channelSteps.values()) {
+            for (final NoteStep note : notesAtStep.values()) {
+                if (note.state() == NoteStep.State.NoteOn) {
+                    action.accept(note);
+                }
+            }
+        }
+    }
+
     private void cyclePreset(final int line, final int inc) {
         if (line == FugueClipAdapter.SOURCE_CHANNEL) {
             showTemplateInfo();
@@ -504,19 +661,51 @@ public final class FugueStepMode extends Layer {
         regenerateAllEnabledDerivedLinesSilently();
     }
 
-    private void adjustTemplateOctave(final int inc) {
-        driver.adjustSharedOctave(inc);
-        oled.valueInfo("Template Octave", Integer.toString(driver.getSharedOctave()));
-        oled.clearScreenDelayed();
-        regenerateAllEnabledDerivedLinesSilently();
+    private void adjustTemplateClipLength(final int inc) {
+        final int currentLoopSteps = currentLoopSteps();
+        final int nextLoopSteps = nextClipLengthSteps(currentLoopSteps, inc);
+        if (nextLoopSteps == currentLoopSteps) {
+            oled.valueInfo("Clip Length", nextLoopSteps == MAX_LOOP_STEPS ? "Max" : "Min");
+            oled.clearScreenDelayed();
+            return;
+        }
+        cursorClip.getLoopLength().set(nextLoopSteps * STEP_LENGTH);
+        loopSteps = nextLoopSteps;
+        hostRebuildAfterClipLengthChange("Clip Length", formatSteps(nextLoopSteps));
+    }
+
+    private int nextClipLengthSteps(final int currentLoopSteps, final int inc) {
+        if (inc == 0) {
+            return currentLoopSteps;
+        }
+        if (inc > 0) {
+            for (final int candidate : CLIP_LENGTH_STEPS) {
+                if (candidate > currentLoopSteps) {
+                    return candidate;
+                }
+            }
+            return CLIP_LENGTH_STEPS[CLIP_LENGTH_STEPS.length - 1];
+        }
+        for (int i = CLIP_LENGTH_STEPS.length - 1; i >= 0; i--) {
+            final int candidate = CLIP_LENGTH_STEPS[i];
+            if (candidate < currentLoopSteps) {
+                return candidate;
+            }
+        }
+        return CLIP_LENGTH_STEPS[0];
+    }
+
+    private void adjustTemplatePlayStart(final int inc) {
+        final int currentStart = (int) Math.round(cursorClip.getPlayStart().get() / STEP_LENGTH);
+        setClipPlayStart(Math.max(0, Math.min(loopSteps - 1, currentStart + inc)));
     }
 
     private void showTemplateInfo() {
         oled.detailInfo("Template",
-                "Root %s\nScale %s\nOct %d\nNotes %d".formatted(
+                "Root %s\nScale %s\nLen %s\nNotes %d".formatted(
                         NoteGridLayout.noteName(driver.getSharedRootNote()),
                         driver.getSharedScaleDisplayName(),
-                        driver.getSharedOctave(),
+                        formatSteps(currentLoopSteps()),
                         sourceStepCount()));
         oled.clearScreenDelayed();
     }
@@ -624,6 +813,9 @@ public final class FugueStepMode extends Layer {
     }
 
     private void handleNoteStepObject(final NoteStep noteStep) {
+        if (!active) {
+            return;
+        }
         final int channel = noteStep.channel();
         final int x = noteStep.x();
         final int y = noteStep.y();
@@ -639,23 +831,40 @@ public final class FugueStepMode extends Layer {
                 noteStepsByChannel.remove(channel);
             }
             if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
-                scheduleSourceRebuild();
+                scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
             }
             return;
         }
         notesAtStep.put(y, noteStep);
         if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
-            scheduleSourceRebuild();
+            scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
         }
     }
 
-    private void scheduleSourceRebuild() {
+    private void refreshSourceCacheFromClip() {
+        noteStepsByChannel.clear();
+        final Map<Integer, Map<Integer, NoteStep>> sourceSteps =
+                noteStepsByChannel.computeIfAbsent(FugueClipAdapter.SOURCE_CHANNEL, ignored -> new HashMap<>());
+        for (int x = 0; x < FuguePattern.MAX_STEPS; x++) {
+            for (int y = 0; y < 128; y++) {
+                final NoteStep step = cursorClip.getStep(FugueClipAdapter.SOURCE_CHANNEL, x, y);
+                if (step.state() == NoteStep.State.NoteOn) {
+                    sourceSteps.computeIfAbsent(x, ignored -> new HashMap<>()).put(y, step);
+                }
+            }
+        }
+        if (sourceSteps.isEmpty()) {
+            noteStepsByChannel.remove(FugueClipAdapter.SOURCE_CHANNEL);
+        }
+    }
+
+    private void scheduleSourceRebuild(final int delayMs) {
         final int token = ++sourceRebuildToken;
         driver.getHost().scheduleTask(() -> {
             if (token == sourceRebuildToken) {
                 regenerateAllEnabledDerivedLinesSilently();
             }
-        }, SOURCE_CHANGE_REBUILD_DELAY_MS);
+        }, delayMs);
     }
 
     private void handlePlayingStep(final int clipPlayingStep) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -444,7 +444,9 @@ public final class FugueStepMode extends Layer {
             return;
         }
         if (!edit.changed) {
-            setClipPlayStart(edit.step);
+            writeTemplatePadEditNote(edit.withChanged(true));
+            regenerateAllEnabledDerivedLinesSilently();
+            oled.valueInfo("Template", "Added " + currentTemplatePadEditLabel());
             oled.clearScreenDelayed();
             return;
         }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -1,0 +1,599 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extension.controller.api.ControllerHost;
+import com.bitwig.extension.controller.api.CursorTrack;
+import com.bitwig.extension.controller.api.NoteStep;
+import com.bitwig.extension.controller.api.PinnableCursorClip;
+import com.bitwig.extensions.framework.Layer;
+import com.oikoaudio.fire.AkaiFireOikontrolExtension;
+import com.oikoaudio.fire.NoteAssign;
+import com.oikoaudio.fire.control.TouchEncoder;
+import com.oikoaudio.fire.display.OledDisplay;
+import com.oikoaudio.fire.lights.BiColorLightState;
+import com.oikoaudio.fire.lights.RgbLigthState;
+import com.oikoaudio.fire.melodic.MelodicPattern;
+import com.oikoaudio.fire.melodic.MelodicRenderer;
+import com.oikoaudio.fire.note.NoteGridLayout;
+import com.oikoaudio.fire.sequence.EncoderMode;
+import com.oikoaudio.fire.utils.PatternButtons;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FugueStepMode extends Layer {
+    private static final int STEP_COUNT = FuguePattern.MAX_STEPS;
+    private static final int DEFAULT_LOOP_STEPS = 32;
+    private static final double STEP_LENGTH = 0.125;
+    private static final int LINE_COUNT = 4;
+    private static final int PAD_COLUMNS = 16;
+    private static final int ENCODER_THRESHOLD = 5;
+    private static final int ENCODER_FINE_THRESHOLD = 10;
+    private static final int SOURCE_CHANGE_REBUILD_DELAY_MS = 20;
+    private static final int MAX_LOOP_STEPS = STEP_COUNT;
+    private static final int MIN_LOOP_STEPS = 1;
+    private static final RgbLigthState[] LINE_COLORS = {
+            new RgbLigthState(112, 0, 0, true),
+            new RgbLigthState(112, 44, 0, true),
+            new RgbLigthState(104, 88, 0, true),
+            new RgbLigthState(0, 88, 32, true)
+    };
+
+    private final AkaiFireOikontrolExtension driver;
+    private final OledDisplay oled;
+    private final PatternButtons patternButtons;
+    private final PinnableCursorClip cursorClip;
+    private final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> noteStepsByChannel = new HashMap<>();
+    private final FugueLineSettings[] lineSettings = {
+            FugueLineSettings.init(),
+            FuguePreset.BASS_AUGMENTED.settings(),
+            FuguePreset.HIGH_HALF.settings(),
+            FuguePreset.REVERSE_DOUBLE.settings()
+    };
+    private final FuguePreset[] linePresets = {
+            FuguePreset.INIT,
+            FuguePreset.BASS_AUGMENTED,
+            FuguePreset.HIGH_HALF,
+            FuguePreset.REVERSE_DOUBLE
+    };
+    private final boolean[] lineEnabled = {true, true, true, true};
+
+    private EncoderMode activeEncoderMode = EncoderMode.CHANNEL;
+    private int loopSteps = DEFAULT_LOOP_STEPS;
+    private int playingStep = -1;
+    private int sourceRebuildToken = 0;
+
+    public FugueStepMode(final AkaiFireOikontrolExtension driver) {
+        super(driver.getLayers(), "FUGUE_STEP_MODE");
+        this.driver = driver;
+        this.oled = driver.getOled();
+        this.patternButtons = driver.getPatternButtons();
+
+        final ControllerHost host = driver.getHost();
+        final CursorTrack cursorTrack = host.createCursorTrack("FUGUE_STEP", "Fugue Step", 8, 16, true);
+        cursorTrack.name().markInterested();
+        cursorTrack.canHoldNoteData().markInterested();
+        this.cursorClip = cursorTrack.createLauncherCursorClip("FUGUE_STEP_CLIP", "FUGUE_STEP_CLIP", STEP_COUNT, 128);
+        this.cursorClip.setStepSize(STEP_LENGTH);
+        this.cursorClip.scrollToKey(0);
+        this.cursorClip.scrollToStep(0);
+        this.cursorClip.getLoopLength().markInterested();
+        this.cursorClip.getLoopLength().addValueObserver(length ->
+                loopSteps = Math.max(1, Math.min(STEP_COUNT, (int) Math.round(length / STEP_LENGTH))));
+        this.cursorClip.addNoteStepObserver(this::handleNoteStepObject);
+        this.cursorClip.playingStep().addValueObserver(this::handlePlayingStep);
+
+        bindPads();
+        bindButtons();
+        bindEncoders();
+    }
+
+    public BiColorLightState getModeButtonLightState() {
+        return driver.isGlobalAltHeld() ? driver.getStepFillLightState() : BiColorLightState.RED_FULL;
+    }
+
+    public void notifyBlink(final int blinkTicks) {
+    }
+
+    @Override
+    protected void onActivate() {
+        patternButtons.setUpCallback(pressed -> {
+            if (pressed) {
+                cyclePreset(activeLineIndex(), 1);
+            }
+        }, () -> BiColorLightState.GREEN_HALF);
+        patternButtons.setDownCallback(pressed -> {
+            if (pressed) {
+                regenerateAllDerivedLines();
+            }
+        }, () -> BiColorLightState.AMBER_HALF);
+        oled.valueInfo("Fugue", "Line " + (activeLineIndex() + 1));
+        oled.clearScreenDelayed();
+    }
+
+    @Override
+    protected void onDeactivate() {
+        patternButtons.setUpCallback(pressed -> { }, () -> BiColorLightState.OFF);
+        patternButtons.setDownCallback(pressed -> { }, () -> BiColorLightState.OFF);
+    }
+
+    private void bindPads() {
+        final var pads = driver.getRgbButtons();
+        for (int index = 0; index < pads.length; index++) {
+            final int padIndex = index;
+            pads[index].bindPressed(this, pressed -> handlePadPress(padIndex, pressed), () -> getPadLight(padIndex));
+        }
+    }
+
+    private void bindButtons() {
+        driver.getButton(NoteAssign.KNOB_MODE).bindPressed(this, this::handleEncoderModeButton, this::encoderModeLight);
+        driver.getButton(NoteAssign.BANK_L).bindPressed(this, pressed -> {
+            if (pressed) {
+                if (driver.isGlobalAltHeld()) {
+                    halveClipLength();
+                } else {
+                    adjustStartOffset(activeLineIndex(), -1);
+                }
+            }
+        }, () -> BiColorLightState.HALF);
+        driver.getButton(NoteAssign.BANK_R).bindPressed(this, pressed -> {
+            if (pressed) {
+                if (driver.isGlobalAltHeld()) {
+                    doubleClipLength();
+                } else {
+                    adjustStartOffset(activeLineIndex(), 1);
+                }
+            }
+        }, () -> BiColorLightState.HALF);
+        driver.getButton(NoteAssign.MUTE_1).bindPressed(this, pressed -> toggleLineEnabled(0, pressed), () -> lineLight(0));
+        driver.getButton(NoteAssign.MUTE_2).bindPressed(this, pressed -> toggleLineEnabled(1, pressed), () -> lineLight(1));
+        driver.getButton(NoteAssign.MUTE_3).bindPressed(this, pressed -> toggleLineEnabled(2, pressed), () -> lineLight(2));
+        driver.getButton(NoteAssign.MUTE_4).bindPressed(this, pressed -> toggleLineEnabled(3, pressed), () -> lineLight(3));
+    }
+
+    private void bindEncoders() {
+        final TouchEncoder[] encoders = driver.getEncoders();
+        encoders[0].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
+                driver::isGlobalShiftHeld, this::adjustDirectionOrPreset);
+        encoders[1].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
+                driver::isGlobalShiftHeld, inc -> adjustSpeed(activeLineIndex(), inc));
+        encoders[2].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
+                driver::isGlobalShiftHeld, inc -> adjustStartOffset(activeLineIndex(), inc));
+        encoders[3].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
+                driver::isGlobalShiftHeld, this::adjustPitch);
+    }
+
+    private void handlePadPress(final int padIndex, final boolean pressed) {
+        if (!pressed) {
+            return;
+        }
+        final int line = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        selectLine(line);
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            setClipPlayStart(bucketStart(column));
+            oled.clearScreenDelayed();
+            return;
+        }
+        setStartOffset(line, bucketStart(column));
+    }
+
+    private RgbLigthState getPadLight(final int padIndex) {
+        final int line = padIndex / PAD_COLUMNS;
+        final int column = padIndex % PAD_COLUMNS;
+        if (line < 0 || line >= LINE_COUNT) {
+            return RgbLigthState.OFF;
+        }
+        final FuguePattern pattern = linePattern(line);
+        final boolean inLoop = column < activeBucketCount();
+        final boolean playing = playingBucket() == column;
+        final RgbLigthState color = line == activeLineIndex() ? LINE_COLORS[line].getBrightend() : LINE_COLORS[line];
+        final RgbLigthState rendered = MelodicRenderer.stepLight(bucketStep(pattern, column), false, inLoop, playing,
+                column, color);
+        return lineEnabled[line] ? rendered : rendered.getVeryDimmed();
+    }
+
+    private MelodicPattern.Step bucketStep(final FuguePattern pattern, final int column) {
+        if (column >= activeBucketCount()) {
+            return MelodicPattern.Step.rest(column);
+        }
+        final int start = bucketStart(column);
+        final int end = bucketEnd(column);
+        for (int step = start; step < end; step++) {
+            final MelodicPattern.Step candidate = pattern.step(step);
+            if (candidate.active() && !candidate.tieFromPrevious()) {
+                return candidate.withIndex(column);
+            }
+        }
+        return MelodicPattern.Step.rest(column);
+    }
+
+    private int activeBucketCount() {
+        return Math.max(1, Math.min(PAD_COLUMNS, loopSteps));
+    }
+
+    private int bucketStart(final int column) {
+        return column * loopSteps / PAD_COLUMNS;
+    }
+
+    private int bucketEnd(final int column) {
+        return Math.max(bucketStart(column) + 1, (column + 1) * loopSteps / PAD_COLUMNS);
+    }
+
+    private int playingBucket() {
+        if (playingStep < 0 || playingStep >= loopSteps) {
+            return -1;
+        }
+        return Math.max(0, Math.min(PAD_COLUMNS - 1, playingStep * PAD_COLUMNS / loopSteps));
+    }
+
+    private void setClipPlayStart(final int startStep) {
+        final double playStart = Math.max(0.0, Math.min((loopSteps - 1) * STEP_LENGTH, startStep * STEP_LENGTH));
+        cursorClip.getPlayStart().set(playStart);
+        oled.valueInfo("Play Start", formatPlayStart(playStart));
+    }
+
+    private String formatPlayStart(final double beatTime) {
+        final int stepIndex = (int) Math.round(beatTime / STEP_LENGTH);
+        final int quarterNote = (int) Math.floor(beatTime);
+        final int bar = quarterNote / 4;
+        final int beat = quarterNote % 4;
+        final int sixteenth = stepIndex % 4;
+        return "%d.%d.%d".formatted(bar + 1, beat + 1, sixteenth + 1);
+    }
+
+    private FuguePattern linePattern(final int line) {
+        if (line == 0) {
+            return sourcePattern();
+        }
+        if (!lineEnabled[line]) {
+            return FuguePattern.empty(loopSteps);
+        }
+        return MelodicLineTransformer.transform(sourcePattern(), lineSettings[line],
+                driver.getSharedMusicalScale(), driver.getSharedRootNote());
+    }
+
+    private FuguePattern sourcePattern() {
+        return FugueClipAdapter.sourceFromChannelOne(noteStepsByChannel, loopSteps, STEP_LENGTH);
+    }
+
+    private void handleEncoderModeButton(final boolean pressed) {
+        if (!pressed) {
+            oled.clearScreenDelayed();
+            return;
+        }
+        selectEncoderMode(nextEncoderMode(activeEncoderMode));
+    }
+
+    private void selectEncoderMode(final EncoderMode mode) {
+        activeEncoderMode = mode;
+        oled.detailInfo("Fugue Line", lineLabel(activeLineIndex()));
+        oled.clearScreenDelayed();
+    }
+
+    private void selectLine(final int line) {
+        selectEncoderMode(switch (Math.max(0, Math.min(LINE_COUNT - 1, line))) {
+            case 1 -> EncoderMode.MIXER;
+            case 2 -> EncoderMode.USER_1;
+            case 3 -> EncoderMode.USER_2;
+            default -> EncoderMode.CHANNEL;
+        });
+    }
+
+    private int activeLineIndex() {
+        return switch (activeEncoderMode) {
+            case CHANNEL -> 0;
+            case MIXER -> 1;
+            case USER_1 -> 2;
+            case USER_2 -> 3;
+        };
+    }
+
+    private EncoderMode nextEncoderMode(final EncoderMode mode) {
+        return switch (mode) {
+            case CHANNEL -> EncoderMode.MIXER;
+            case MIXER -> EncoderMode.USER_1;
+            case USER_1 -> EncoderMode.USER_2;
+            case USER_2 -> EncoderMode.CHANNEL;
+        };
+    }
+
+    private BiColorLightState encoderModeLight() {
+        return activeEncoderMode.getState();
+    }
+
+    private BiColorLightState lineLight(final int line) {
+        if (line == activeLineIndex()) {
+            return lineEnabled[line] ? BiColorLightState.GREEN_FULL : BiColorLightState.RED_FULL;
+        }
+        return lineEnabled[line] ? BiColorLightState.GREEN_HALF : BiColorLightState.RED_HALF;
+    }
+
+    private void toggleLineEnabled(final int line, final boolean pressed) {
+        if (!pressed) {
+            return;
+        }
+        lineEnabled[line] = !lineEnabled[line];
+        if (line > 0) {
+            regenerateLine(line);
+        }
+        oled.valueInfo(lineLabel(line), lineEnabled[line] ? "On" : "Muted");
+        oled.clearScreenDelayed();
+    }
+
+    private void adjustDirectionOrPreset(final int inc) {
+        if (activeLineIndex() == FugueClipAdapter.SOURCE_CHANNEL) {
+            adjustTemplateRoot(inc);
+            return;
+        }
+        if (driver.isGlobalAltHeld()) {
+            adjustVelocityOffset(activeLineIndex(), inc);
+            return;
+        }
+        if (driver.isGlobalShiftHeld()) {
+            cyclePreset(activeLineIndex(), inc);
+            return;
+        }
+        final int line = activeLineIndex();
+        lineSettings[line] = lineSettings[line].withDirection(lineSettings[line].direction().next(inc));
+        afterLineSettingsChanged(line, "Direction", lineSettings[line].direction().label());
+    }
+
+    private void adjustSpeed(final int line, final int inc) {
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            adjustTemplateScale(inc);
+            return;
+        }
+        if (driver.isGlobalAltHeld()) {
+            adjustChance(line, inc);
+            return;
+        }
+        lineSettings[line] = lineSettings[line].withSpeed(lineSettings[line].speed().next(inc));
+        afterLineSettingsChanged(line, "Tempo", lineSettings[line].speed().label());
+    }
+
+    private void adjustStartOffset(final int line, final int inc) {
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            adjustTemplateOctave(inc);
+            return;
+        }
+        if (driver.isGlobalAltHeld()) {
+            adjustGate(line, inc);
+            return;
+        }
+        lineSettings[line] = lineSettings[line].withStartOffset(lineSettings[line].startOffset() + inc);
+        afterLineSettingsChanged(line, "Start", Integer.toString(lineSettings[line].startOffset() + 1));
+    }
+
+    private void setStartOffset(final int line, final int startOffset) {
+        lineSettings[line] = lineSettings[line].withStartOffset(startOffset);
+        afterLineSettingsChanged(line, "Start", Integer.toString(lineSettings[line].startOffset() + 1));
+    }
+
+    private void adjustPitch(final int inc) {
+        final int line = activeLineIndex();
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            showTemplateInfo();
+            return;
+        }
+        if (driver.isGlobalAltHeld()) {
+            adjustPitchOctaveJump(line, inc);
+            return;
+        }
+        adjustPitchDegreeOffset(line, inc);
+    }
+
+    private void adjustPitchDegreeOffset(final int line, final int inc) {
+        final int nextInterval = FuguePitchIntervals.nextDegreeInterval(lineSettings[line].pitchDegreeOffset(), inc);
+        lineSettings[line] = lineSettings[line].withPitchDegreeOffset(nextInterval);
+        afterLineSettingsChanged(line, "Interval", FuguePitchIntervals.label(nextInterval));
+    }
+
+    private void adjustPitchSemitoneOffset(final int line, final int inc) {
+        lineSettings[line] = lineSettings[line].withPitchSemitoneOffset(lineSettings[line].pitchSemitoneOffset() + inc);
+        afterLineSettingsChanged(line, "Semitone", "%+d".formatted(lineSettings[line].pitchSemitoneOffset()));
+    }
+
+    private void adjustPitchOctaveJump(final int line, final int inc) {
+        final int nextInterval = FuguePitchIntervals.octaveJump(lineSettings[line].pitchDegreeOffset(), inc);
+        lineSettings[line] = lineSettings[line].withPitchDegreeOffset(nextInterval);
+        afterLineSettingsChanged(line, "Interval", FuguePitchIntervals.label(nextInterval));
+    }
+
+    private void adjustVelocityOffset(final int line, final int inc) {
+        lineSettings[line] = lineSettings[line].withVelocityOffset(lineSettings[line].velocityOffset() + inc * 4);
+        afterLineSettingsChanged(line, "Velocity", "%+d".formatted(lineSettings[line].velocityOffset()));
+    }
+
+    private void adjustChance(final int line, final int inc) {
+        lineSettings[line] = lineSettings[line].withChancePercent(lineSettings[line].chancePercent() + inc * 5);
+        afterLineSettingsChanged(line, "Chance", lineSettings[line].chancePercent() + "%");
+    }
+
+    private void adjustGate(final int line, final int inc) {
+        lineSettings[line] = lineSettings[line].withGatePercent(lineSettings[line].gatePercent() + inc * 5);
+        afterLineSettingsChanged(line, "Gate", lineSettings[line].gatePercent() + "%");
+    }
+
+    private void cyclePreset(final int line, final int inc) {
+        if (line == FugueClipAdapter.SOURCE_CHANNEL) {
+            showTemplateInfo();
+            return;
+        }
+        linePresets[line] = linePresets[line].next(inc);
+        lineSettings[line] = linePresets[line].settings();
+        afterLineSettingsChanged(line, "Preset", linePresets[line].label());
+    }
+
+    private void afterLineSettingsChanged(final int line, final String title, final String value) {
+        if (line > 0) {
+            regenerateLine(line);
+        }
+        oled.valueInfo(lineLabel(line) + " " + title, value);
+        oled.clearScreenDelayed();
+    }
+
+    private void adjustTemplateRoot(final int inc) {
+        driver.adjustSharedRootNote(inc);
+        oled.valueInfo("Template Root", NoteGridLayout.noteName(driver.getSharedRootNote()));
+        oled.clearScreenDelayed();
+        regenerateAllEnabledDerivedLinesSilently();
+    }
+
+    private void adjustTemplateScale(final int inc) {
+        driver.adjustSharedScaleIndex(inc, -1);
+        oled.valueInfo("Template Scale", driver.getSharedScaleDisplayName());
+        oled.clearScreenDelayed();
+        regenerateAllEnabledDerivedLinesSilently();
+    }
+
+    private void adjustTemplateOctave(final int inc) {
+        driver.adjustSharedOctave(inc);
+        oled.valueInfo("Template Octave", Integer.toString(driver.getSharedOctave()));
+        oled.clearScreenDelayed();
+        regenerateAllEnabledDerivedLinesSilently();
+    }
+
+    private void showTemplateInfo() {
+        oled.detailInfo("Template",
+                "Root %s\nScale %s\nOct %d\nNotes %d".formatted(
+                        NoteGridLayout.noteName(driver.getSharedRootNote()),
+                        driver.getSharedScaleDisplayName(),
+                        driver.getSharedOctave(),
+                        sourceStepCount()));
+        oled.clearScreenDelayed();
+    }
+
+    private void regenerateAllEnabledDerivedLinesSilently() {
+        for (int line = FugueClipAdapter.FIRST_DERIVED_CHANNEL; line <= FugueClipAdapter.LAST_DERIVED_CHANNEL; line++) {
+            if (lineEnabled[line]) {
+                regenerateLine(line);
+            }
+        }
+    }
+
+    private int sourceStepCount() {
+        final FuguePattern source = sourcePattern();
+        int count = 0;
+        for (int i = 0; i < source.loopSteps(); i++) {
+            for (final MelodicPattern.Step step : source.notesAt(i)) {
+                if (step.active() && !step.tieFromPrevious()) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private void regenerateAllDerivedLines() {
+        for (int line = FugueClipAdapter.FIRST_DERIVED_CHANNEL; line <= FugueClipAdapter.LAST_DERIVED_CHANNEL; line++) {
+            regenerateLine(line);
+        }
+        oled.valueInfo("Fugue", "Rebuilt lines");
+        oled.clearScreenDelayed();
+    }
+
+    private void doubleClipLength() {
+        final int currentLoopSteps = currentLoopSteps();
+        if (currentLoopSteps >= MAX_LOOP_STEPS) {
+            oled.valueInfo("Clip Length", "Max");
+            oled.clearScreenDelayed();
+            return;
+        }
+        final int newLoopSteps = Math.min(MAX_LOOP_STEPS, currentLoopSteps * 2);
+        cursorClip.getLoopLength().set(newLoopSteps * STEP_LENGTH);
+        FugueClipAdapter.duplicateChannelRange(cursorClip, noteStepsByChannel, FugueClipAdapter.SOURCE_CHANNEL,
+                0, currentLoopSteps, currentLoopSteps);
+        loopSteps = newLoopSteps;
+        hostRebuildAfterClipLengthChange("Length", formatSteps(newLoopSteps));
+    }
+
+    private void halveClipLength() {
+        final int currentLoopSteps = currentLoopSteps();
+        if (currentLoopSteps <= MIN_LOOP_STEPS) {
+            oled.valueInfo("Clip Length", "Min");
+            oled.clearScreenDelayed();
+            return;
+        }
+        final int newLoopSteps = Math.max(MIN_LOOP_STEPS, currentLoopSteps / 2);
+        cursorClip.getLoopLength().set(newLoopSteps * STEP_LENGTH);
+        loopSteps = newLoopSteps;
+        hostRebuildAfterClipLengthChange("Length", formatSteps(newLoopSteps));
+    }
+
+    private void hostRebuildAfterClipLengthChange(final String title, final String value) {
+        driver.getHost().scheduleTask(this::regenerateAllEnabledDerivedLinesSilently, SOURCE_CHANGE_REBUILD_DELAY_MS);
+        oled.valueInfo(title, value);
+        oled.clearScreenDelayed();
+    }
+
+    private int currentLoopSteps() {
+        return Math.max(MIN_LOOP_STEPS, Math.min(MAX_LOOP_STEPS,
+                (int) Math.round(cursorClip.getLoopLength().get() / STEP_LENGTH)));
+    }
+
+    private String formatSteps(final int steps) {
+        final double beats = steps * STEP_LENGTH;
+        final double bars = beats / 4.0;
+        if (Math.rint(bars) == bars) {
+            return "%d Bars".formatted((int) bars);
+        }
+        return "%d Steps".formatted(steps);
+    }
+
+    private void regenerateLine(final int line) {
+        if (line <= FugueClipAdapter.SOURCE_CHANNEL || line >= LINE_COUNT) {
+            return;
+        }
+        if (!lineEnabled[line]) {
+            FugueClipAdapter.clearChannel(cursorClip, noteStepsByChannel, line);
+            return;
+        }
+        final FuguePattern source = sourcePattern();
+        final FuguePattern transformed = MelodicLineTransformer.transform(source, lineSettings[line],
+                driver.getSharedMusicalScale(), driver.getSharedRootNote());
+        FugueClipAdapter.writeDerivedLine(cursorClip, noteStepsByChannel, line, transformed, STEP_LENGTH);
+    }
+
+    private void handleNoteStepObject(final NoteStep noteStep) {
+        final int channel = noteStep.channel();
+        final int x = noteStep.x();
+        final int y = noteStep.y();
+        final Map<Integer, Map<Integer, NoteStep>> channelSteps =
+                noteStepsByChannel.computeIfAbsent(channel, ignored -> new HashMap<>());
+        final Map<Integer, NoteStep> notesAtStep = channelSteps.computeIfAbsent(x, ignored -> new HashMap<>());
+        if (noteStep.state() == NoteStep.State.Empty) {
+            notesAtStep.remove(y);
+            if (notesAtStep.isEmpty()) {
+                channelSteps.remove(x);
+            }
+            if (channelSteps.isEmpty()) {
+                noteStepsByChannel.remove(channel);
+            }
+            if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
+                scheduleSourceRebuild();
+            }
+            return;
+        }
+        notesAtStep.put(y, noteStep);
+        if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
+            scheduleSourceRebuild();
+        }
+    }
+
+    private void scheduleSourceRebuild() {
+        final int token = ++sourceRebuildToken;
+        driver.getHost().scheduleTask(() -> {
+            if (token == sourceRebuildToken) {
+                regenerateAllEnabledDerivedLinesSilently();
+            }
+        }, SOURCE_CHANGE_REBUILD_DELAY_MS);
+    }
+
+    private void handlePlayingStep(final int clipPlayingStep) {
+        this.playingStep = clipPlayingStep >= 0 && clipPlayingStep < STEP_COUNT ? clipPlayingStep : -1;
+    }
+
+    private String lineLabel(final int line) {
+        return "Line " + (line + 1);
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -30,7 +30,6 @@ public final class FugueStepMode extends Layer {
     private static final int ENCODER_THRESHOLD = 5;
     private static final int ENCODER_FINE_THRESHOLD = 10;
     private static final int SOURCE_CHANGE_REBUILD_DELAY_MS = 20;
-    private static final int SOURCE_EDIT_REBUILD_DELAY_MS = 250;
     private static final int BAR_STEPS = 32;
     private static final int MAX_LOOP_STEPS = STEP_COUNT;
     private static final int MIN_LOOP_STEPS = 1;
@@ -67,7 +66,6 @@ public final class FugueStepMode extends Layer {
     private EncoderMode activeEncoderMode = EncoderMode.CHANNEL;
     private int loopSteps = DEFAULT_LOOP_STEPS;
     private int playingStep = -1;
-    private int sourceRebuildToken = 0;
     private boolean mainEncoderPressConsumed = false;
     private boolean active = false;
     private TemplatePadEdit templatePadEdit = null;
@@ -127,7 +125,6 @@ public final class FugueStepMode extends Layer {
     @Override
     protected void onDeactivate() {
         active = false;
-        sourceRebuildToken++;
         patternButtons.setUpCallback(pressed -> { }, () -> BiColorLightState.OFF);
         patternButtons.setDownCallback(pressed -> { }, () -> BiColorLightState.OFF);
     }
@@ -441,7 +438,7 @@ public final class FugueStepMode extends Layer {
         if (!edit.changed && edit.existed) {
             cursorClip.clearStep(FugueClipAdapter.SOURCE_CHANNEL, edit.step, edit.pitch);
             removeCachedSourceNote(edit.step, edit.pitch);
-            scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
+            regenerateAllEnabledDerivedLinesSilently();
             oled.valueInfo("Template", "Removed");
             oled.clearScreenDelayed();
             return;
@@ -925,6 +922,7 @@ public final class FugueStepMode extends Layer {
     }
 
     private void showTemplateInfo() {
+        refreshSourceCacheFromClip();
         oled.detailInfo("Template",
                 "Root %s\nScale %s\nLen %s\nNotes %d".formatted(
                         NoteGridLayout.noteName(driver.getSharedRootNote()),
@@ -959,6 +957,7 @@ public final class FugueStepMode extends Layer {
     }
 
     private void regenerateAllDerivedLines() {
+        refreshSourceCacheFromClip();
         if (!hasSourceNotes()) {
             oled.valueInfo("Fugue", "No Ch1 notes");
             oled.clearScreenDelayed();
@@ -1000,7 +999,10 @@ public final class FugueStepMode extends Layer {
     }
 
     private void hostRebuildAfterClipLengthChange(final String title, final String value) {
-        driver.getHost().scheduleTask(this::regenerateAllEnabledDerivedLinesSilently, SOURCE_CHANGE_REBUILD_DELAY_MS);
+        driver.getHost().scheduleTask(() -> {
+            refreshSourceCacheFromClip();
+            regenerateAllEnabledDerivedLinesSilently();
+        }, SOURCE_CHANGE_REBUILD_DELAY_MS);
         oled.valueInfo(title, value);
         oled.clearScreenDelayed();
     }
@@ -1054,15 +1056,9 @@ public final class FugueStepMode extends Layer {
             if (channelSteps.isEmpty()) {
                 noteStepsByChannel.remove(channel);
             }
-            if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
-                scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
-            }
             return;
         }
         notesAtStep.put(y, noteStep);
-        if (channel == FugueClipAdapter.SOURCE_CHANNEL) {
-            scheduleSourceRebuild(SOURCE_EDIT_REBUILD_DELAY_MS);
-        }
     }
 
     private void refreshSourceCacheFromClip() {
@@ -1080,15 +1076,6 @@ public final class FugueStepMode extends Layer {
         if (sourceSteps.isEmpty()) {
             noteStepsByChannel.remove(FugueClipAdapter.SOURCE_CHANNEL);
         }
-    }
-
-    private void scheduleSourceRebuild(final int delayMs) {
-        final int token = ++sourceRebuildToken;
-        driver.getHost().scheduleTask(() -> {
-            if (token == sourceRebuildToken) {
-                regenerateAllEnabledDerivedLinesSilently();
-            }
-        }, delayMs);
     }
 
     private void handlePlayingStep(final int clipPlayingStep) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -154,12 +154,70 @@ public final class FugueStepMode extends Layer {
         final TouchEncoder[] encoders = driver.getEncoders();
         encoders[0].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
                 driver::isGlobalShiftHeld, this::adjustDirectionOrPreset);
+        encoders[0].bindTouched(this, touched -> showEncoderTouchValue(0, touched));
         encoders[1].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
                 driver::isGlobalShiftHeld, inc -> adjustSpeed(activeLineIndex(), inc));
+        encoders[1].bindTouched(this, touched -> showEncoderTouchValue(1, touched));
         encoders[2].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
                 driver::isGlobalShiftHeld, inc -> adjustStartOffset(activeLineIndex(), inc));
+        encoders[2].bindTouched(this, touched -> showEncoderTouchValue(2, touched));
         encoders[3].bindThresholdedEncoder(this, ENCODER_THRESHOLD, ENCODER_FINE_THRESHOLD,
                 driver::isGlobalShiftHeld, this::adjustPitch);
+        encoders[3].bindTouched(this, touched -> showEncoderTouchValue(3, touched));
+    }
+
+    private void showEncoderTouchValue(final int encoderIndex, final boolean touched) {
+        if (!touched) {
+            oled.clearScreenDelayed();
+            return;
+        }
+        if (activeLineIndex() == FugueClipAdapter.SOURCE_CHANNEL) {
+            showTemplateEncoderValue(encoderIndex);
+            return;
+        }
+        showDerivedLineEncoderValue(activeLineIndex(), encoderIndex);
+    }
+
+    private void showTemplateEncoderValue(final int encoderIndex) {
+        switch (encoderIndex) {
+            case 0 -> oled.valueInfo("Template Root", NoteGridLayout.noteName(driver.getSharedRootNote()));
+            case 1 -> oled.valueInfo("Template Scale", driver.getSharedScaleDisplayName());
+            case 2 -> oled.valueInfo("Template Octave", Integer.toString(driver.getSharedOctave()));
+            case 3 -> oled.valueInfo("Template Notes", Integer.toString(sourceStepCount()));
+            default -> { }
+        }
+    }
+
+    private void showDerivedLineEncoderValue(final int line, final int encoderIndex) {
+        final FugueLineSettings settings = lineSettings[line];
+        switch (encoderIndex) {
+            case 0 -> {
+                if (driver.isGlobalAltHeld()) {
+                    oled.valueInfo(lineLabel(line) + " Velocity", "%+d".formatted(settings.velocityOffset()));
+                } else if (driver.isGlobalShiftHeld()) {
+                    oled.valueInfo(lineLabel(line) + " Preset", linePresets[line].label());
+                } else {
+                    oled.valueInfo(lineLabel(line) + " Direction", settings.direction().label());
+                }
+            }
+            case 1 -> {
+                if (driver.isGlobalAltHeld()) {
+                    oled.valueInfo(lineLabel(line) + " Chance", settings.chancePercent() + "%");
+                } else {
+                    oled.valueInfo(lineLabel(line) + " Tempo", settings.speed().label());
+                }
+            }
+            case 2 -> {
+                if (driver.isGlobalAltHeld()) {
+                    oled.valueInfo(lineLabel(line) + " Gate", settings.gatePercent() + "%");
+                } else {
+                    oled.valueInfo(lineLabel(line) + " Start", Integer.toString(settings.startOffset() + 1));
+                }
+            }
+            case 3 -> oled.valueInfo(lineLabel(line) + " Interval",
+                    FuguePitchIntervals.label(settings.pitchDegreeOffset()));
+            default -> { }
+        }
     }
 
     private void handlePadPress(final int padIndex, final boolean pressed) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -34,7 +34,10 @@ public final class FugueStepMode extends Layer {
     private static final int BAR_STEPS = 32;
     private static final int MAX_LOOP_STEPS = STEP_COUNT;
     private static final int MIN_LOOP_STEPS = 1;
-    private static final int[] CLIP_LENGTH_STEPS = {8, 16, 32, 64, 96, 128, 160, 192, 224, 256};
+    private static final int[] CLIP_LENGTH_STEPS = {
+            8, 16, 32, 64, 96, 128, 160, 192, 224, 256,
+            288, 320, 352, 384, 416, 448, 480, 512
+    };
     private static final RgbLigthState[] LINE_COLORS = {
             new RgbLigthState(112, 0, 0, true),
             new RgbLigthState(112, 44, 0, true),
@@ -117,7 +120,7 @@ public final class FugueStepMode extends Layer {
                 regenerateAllDerivedLines();
             }
         }, () -> BiColorLightState.AMBER_HALF);
-        oled.valueInfo("Fugue", "Line " + (activeLineIndex() + 1));
+        showEncoderModeInfo();
         oled.clearScreenDelayed();
     }
 
@@ -335,7 +338,7 @@ public final class FugueStepMode extends Layer {
                 case 0 -> oled.valueInfo("Line 1 Velocity", "%+d".formatted(settings.velocityOffset()));
                 case 1 -> oled.valueInfo("Line 1 Chance", settings.chancePercent() + "%");
                 case 2 -> oled.valueInfo("Line 1 Gate", settings.gatePercent() + "%");
-                case 3 -> oled.valueInfo("Play Start", formatPlayStart(cursorClip.getPlayStart().get()));
+                case 3 -> oled.valueInfo("Clip Start", formatPlayStart(cursorClip.getPlayStart().get()));
                 default -> { }
             }
             return;
@@ -344,7 +347,7 @@ public final class FugueStepMode extends Layer {
             case 0 -> oled.valueInfo("Template Root", NoteGridLayout.noteName(driver.getSharedRootNote()));
             case 1 -> oled.valueInfo("Template Scale", driver.getSharedScaleDisplayName());
             case 2 -> oled.valueInfo("Clip Length", formatSteps(currentLoopSteps()));
-            case 3 -> oled.valueInfo("Play Start", formatPlayStart(cursorClip.getPlayStart().get()));
+            case 3 -> oled.valueInfo("Clip Start", formatPlayStart(cursorClip.getPlayStart().get()));
             default -> { }
         }
     }
@@ -445,8 +448,10 @@ public final class FugueStepMode extends Layer {
         }
         if (!edit.changed) {
             writeTemplatePadEditNote(edit.withChanged(true));
+            final String label = currentTemplatePadEditLabel();
+            templatePadEdit = null;
             regenerateAllEnabledDerivedLinesSilently();
-            oled.valueInfo("Template", "Added " + currentTemplatePadEditLabel());
+            oled.valueInfo("Template", "Added " + label);
             oled.clearScreenDelayed();
             return;
         }
@@ -607,7 +612,7 @@ public final class FugueStepMode extends Layer {
     private void setClipPlayStart(final int startStep) {
         final double playStart = Math.max(0.0, Math.min((loopSteps - 1) * STEP_LENGTH, startStep * STEP_LENGTH));
         cursorClip.getPlayStart().set(playStart);
-        oled.valueInfo("Play Start", formatPlayStart(playStart));
+        oled.valueInfo("Clip Start", formatPlayStart(playStart));
     }
 
     private String formatPlayStart(final double beatTime) {
@@ -644,8 +649,16 @@ public final class FugueStepMode extends Layer {
 
     private void selectEncoderMode(final EncoderMode mode) {
         activeEncoderMode = mode;
-        oled.detailInfo("Fugue Line", lineLabel(activeLineIndex()));
+        showEncoderModeInfo();
         oled.clearScreenDelayed();
+    }
+
+    private void showEncoderModeInfo() {
+        if (activeLineIndex() == FugueClipAdapter.SOURCE_CHANNEL) {
+            oled.detailInfo("Fugue Settings", "1 Root\n2 Scale\n3 Clip Len\n4 Clip Start");
+            return;
+        }
+        oled.detailInfo(lineLabel(activeLineIndex()), "1 Dir\n2 Tempo\n3 Start\n4 Pitch");
     }
 
     private void selectLine(final int line) {
@@ -1098,7 +1111,7 @@ public final class FugueStepMode extends Layer {
     }
 
     private String lineLabel(final int line) {
-        return "Line " + (line + 1);
+        return line == FugueClipAdapter.SOURCE_CHANNEL ? "Template" : "Var " + (line + 1);
     }
 
     private record TemplatePadEdit(int column, int bucketStart, int step, int pitch, boolean existed, boolean changed,

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -45,15 +45,15 @@ public final class FugueStepMode extends Layer {
     private final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> noteStepsByChannel = new HashMap<>();
     private final FugueLineSettings[] lineSettings = {
             FugueLineSettings.init(),
-            FuguePreset.BASS_AUGMENTED.settings(),
-            FuguePreset.HIGH_HALF.settings(),
-            FuguePreset.REVERSE_DOUBLE.settings()
+            FuguePreset.BASS_OCTAVE.settings(),
+            FuguePreset.THIRD_TRIPLET.settings(),
+            FuguePreset.TENTH_DOUBLE.settings()
     };
     private final FuguePreset[] linePresets = {
             FuguePreset.INIT,
-            FuguePreset.BASS_AUGMENTED,
-            FuguePreset.HIGH_HALF,
-            FuguePreset.REVERSE_DOUBLE
+            FuguePreset.BASS_OCTAVE,
+            FuguePreset.THIRD_TRIPLET,
+            FuguePreset.TENTH_DOUBLE
     };
     private final boolean[] lineEnabled = {true, true, true, true};
 
@@ -522,6 +522,9 @@ public final class FugueStepMode extends Layer {
     }
 
     private void regenerateAllEnabledDerivedLinesSilently() {
+        if (!hasSourceNotes()) {
+            return;
+        }
         for (int line = FugueClipAdapter.FIRST_DERIVED_CHANNEL; line <= FugueClipAdapter.LAST_DERIVED_CHANNEL; line++) {
             if (lineEnabled[line]) {
                 regenerateLine(line);
@@ -543,6 +546,11 @@ public final class FugueStepMode extends Layer {
     }
 
     private void regenerateAllDerivedLines() {
+        if (!hasSourceNotes()) {
+            oled.valueInfo("Fugue", "No Ch1 notes");
+            oled.clearScreenDelayed();
+            return;
+        }
         for (int line = FugueClipAdapter.FIRST_DERIVED_CHANNEL; line <= FugueClipAdapter.LAST_DERIVED_CHANNEL; line++) {
             regenerateLine(line);
         }
@@ -607,6 +615,9 @@ public final class FugueStepMode extends Layer {
             return;
         }
         final FuguePattern source = sourcePattern();
+        if (!hasNotes(source)) {
+            return;
+        }
         final FuguePattern transformed = MelodicLineTransformer.transform(source, lineSettings[line],
                 driver.getSharedMusicalScale(), driver.getSharedRootNote());
         FugueClipAdapter.writeDerivedLine(cursorClip, noteStepsByChannel, line, transformed, STEP_LENGTH);
@@ -649,6 +660,21 @@ public final class FugueStepMode extends Layer {
 
     private void handlePlayingStep(final int clipPlayingStep) {
         this.playingStep = clipPlayingStep >= 0 && clipPlayingStep < STEP_COUNT ? clipPlayingStep : -1;
+    }
+
+    private boolean hasSourceNotes() {
+        return hasNotes(sourcePattern());
+    }
+
+    private boolean hasNotes(final FuguePattern pattern) {
+        for (int i = 0; i < pattern.loopSteps(); i++) {
+            for (final MelodicPattern.Step step : pattern.notesAt(i)) {
+                if (step.active() && !step.tieFromPrevious() && step.pitch() != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private String lineLabel(final int line) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
@@ -38,6 +38,9 @@ public final class MelodicLineTransformer {
                                              final int rootNote) {
         final int directionalIndex = directionalIndex(sourceIndex, phraseSteps, settings.direction());
         final int destination = transformedDestination(directionalIndex, phraseSteps, loopSteps, settings);
+        if (destination < 0 || destination >= loopSteps) {
+            return;
+        }
         final int pitch = ScaleAwareTransposer.transposeDiatonicThenChromatic(sourceStep.pitch(),
                 settings.pitchDegreeOffset(), settings.pitchSemitoneOffset(), scale, rootNote);
         final MelodicPattern.Step transformed = transformedStep(sourceStep, destination, pitch, settings);
@@ -66,6 +69,9 @@ public final class MelodicLineTransformer {
         final int period = settings.speed().isSpeedUp()
                 ? settings.speed().transformedLoopSteps(phraseSteps)
                 : loopSteps;
+        if (settings.speed().isSlowDown()) {
+            return settings.startOffset() + settings.speed().scaleStart(directionalIndex);
+        }
         return Math.floorMod(settings.startOffset() + settings.speed().scaleStart(directionalIndex), period);
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
@@ -128,7 +128,7 @@ public final class MelodicLineTransformer {
             case REVERSE -> loopSteps - 1 - sourceIndex;
             case PING_PONG -> sourceIndex < loopSteps / 2
                     ? sourceIndex
-                    : loopSteps - 1 - sourceIndex;
+                    : loopSteps / 2 + loopSteps - 1 - sourceIndex;
         };
     }
 }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/MelodicLineTransformer.java
@@ -1,0 +1,134 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extensions.framework.MusicalScale;
+import com.oikoaudio.fire.melodic.MelodicPattern;
+
+import java.util.List;
+
+public final class MelodicLineTransformer {
+    private MelodicLineTransformer() {
+    }
+
+    public static FuguePattern transform(final FuguePattern source,
+                                           final FugueLineSettings settings,
+                                           final MusicalScale scale,
+                                           final int rootNote) {
+        final List<List<MelodicPattern.Step>> out = FuguePattern.emptyPolySteps();
+
+        final int loopSteps = source.loopSteps();
+        final int phraseSteps = settings.speed().isSpeedUp() ? repeatedPhraseSteps(source) : loopSteps;
+        for (int sourceIndex = 0; sourceIndex < phraseSteps; sourceIndex++) {
+            for (final MelodicPattern.Step sourceStep : source.notesAt(sourceIndex)) {
+                if (!sourceStep.active() || sourceStep.tieFromPrevious() || sourceStep.pitch() == null) {
+                    continue;
+                }
+                writeTransformedStep(out, sourceStep, sourceIndex, phraseSteps, loopSteps, settings, scale, rootNote);
+            }
+        }
+        return new FuguePattern(out, loopSteps, true);
+    }
+
+    private static void writeTransformedStep(final List<List<MelodicPattern.Step>> out,
+                                             final MelodicPattern.Step sourceStep,
+                                             final int sourceIndex,
+                                             final int phraseSteps,
+                                             final int loopSteps,
+                                             final FugueLineSettings settings,
+                                             final MusicalScale scale,
+                                             final int rootNote) {
+        final int directionalIndex = directionalIndex(sourceIndex, phraseSteps, settings.direction());
+        final int destination = transformedDestination(directionalIndex, phraseSteps, loopSteps, settings);
+        final int pitch = ScaleAwareTransposer.transposeDiatonicThenChromatic(sourceStep.pitch(),
+                settings.pitchDegreeOffset(), settings.pitchSemitoneOffset(), scale, rootNote);
+        final MelodicPattern.Step transformed = transformedStep(sourceStep, destination, pitch, settings);
+        out.get(destination).add(transformed);
+        if (settings.speed().isSpeedUp()) {
+            repeatSpeedUpStep(out, transformed, loopSteps, settings.speed().transformedLoopSteps(phraseSteps));
+        }
+    }
+
+    private static MelodicPattern.Step transformedStep(final MelodicPattern.Step sourceStep,
+                                                       final int destination,
+                                                       final int pitch,
+                                                       final FugueLineSettings settings) {
+        return new MelodicPattern.Step(destination, true, false, pitch,
+                Math.max(1, Math.min(127, sourceStep.velocity() + settings.velocityOffset())),
+                Math.max(0.02, settings.speed().scaleGate(sourceStep.gate()) * settings.gatePercent() / 100.0),
+                sourceStep.chance() * settings.chancePercent() / 100.0,
+                sourceStep.accent(), sourceStep.slide(),
+                sourceStep.recurrenceLength(), sourceStep.recurrenceMask());
+    }
+
+    private static int transformedDestination(final int directionalIndex,
+                                              final int phraseSteps,
+                                              final int loopSteps,
+                                              final FugueLineSettings settings) {
+        final int period = settings.speed().isSpeedUp()
+                ? settings.speed().transformedLoopSteps(phraseSteps)
+                : loopSteps;
+        return Math.floorMod(settings.startOffset() + settings.speed().scaleStart(directionalIndex), period);
+    }
+
+    private static void repeatSpeedUpStep(final List<List<MelodicPattern.Step>> out,
+                                          final MelodicPattern.Step transformed,
+                                          final int loopSteps,
+                                          final int period) {
+        for (int destination = transformed.index() + period; destination < loopSteps; destination += period) {
+            out.get(destination).add(transformed.withIndex(destination));
+        }
+    }
+
+    private static int repeatedPhraseSteps(final FuguePattern source) {
+        final int loopSteps = source.loopSteps();
+        for (int candidate = 1; candidate <= loopSteps / 2; candidate++) {
+            if (loopSteps % candidate == 0 && repeatsEvery(source, candidate)) {
+                return candidate;
+            }
+        }
+        return loopSteps;
+    }
+
+    private static boolean repeatsEvery(final FuguePattern source, final int period) {
+        final int loopSteps = source.loopSteps();
+        for (int step = period; step < loopSteps; step++) {
+            if (!sameMusicalStepList(source.notesAt(step), source.notesAt(step % period))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean sameMusicalStepList(final List<MelodicPattern.Step> a,
+                                               final List<MelodicPattern.Step> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (!sameMusicalStep(a.get(i), b.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean sameMusicalStep(final MelodicPattern.Step a, final MelodicPattern.Step b) {
+        return a.active() == b.active()
+                && a.tieFromPrevious() == b.tieFromPrevious()
+                && java.util.Objects.equals(a.pitch(), b.pitch())
+                && a.velocity() == b.velocity()
+                && Math.abs(a.gate() - b.gate()) < 0.0001
+                && Math.abs(a.chance() - b.chance()) < 0.0001
+                && a.accent() == b.accent()
+                && a.slide() == b.slide();
+    }
+
+    private static int directionalIndex(final int sourceIndex, final int loopSteps, final FugueDirection direction) {
+        return switch (direction) {
+            case FORWARD -> sourceIndex;
+            case REVERSE -> loopSteps - 1 - sourceIndex;
+            case PING_PONG -> sourceIndex < loopSteps / 2
+                    ? sourceIndex
+                    : loopSteps - 1 - sourceIndex;
+        };
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/ScaleAwareTransposer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/ScaleAwareTransposer.java
@@ -1,0 +1,81 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extensions.framework.MusicalScale;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ScaleAwareTransposer {
+    private ScaleAwareTransposer() {
+    }
+
+    public static int transpose(final int midiNote, final int semitoneOffset,
+                                final MusicalScale scale, final int rootNote) {
+        final int target = clampMidi(midiNote + semitoneOffset);
+        if (Math.floorMod(semitoneOffset, 12) == 0) {
+            return target;
+        }
+        if (scale == null || scale.isMidiNoteInScale(rootNote, target)) {
+            return target;
+        }
+        for (int distance = 1; distance <= 12; distance++) {
+            final int upward = target + distance;
+            if (upward <= 127 && scale.isMidiNoteInScale(rootNote, upward)) {
+                return upward;
+            }
+            final int downward = target - distance;
+            if (downward >= 0 && scale.isMidiNoteInScale(rootNote, downward)) {
+                return downward;
+            }
+        }
+        return target;
+    }
+
+    public static int transposeByScaleDegrees(final int midiNote, final int degreeOffset,
+                                              final MusicalScale scale, final int rootNote) {
+        if (degreeOffset == 0 || scale == null) {
+            return clampMidi(midiNote);
+        }
+        final List<Integer> scaleNotes = scaleNotes(scale, rootNote);
+        if (scaleNotes.isEmpty()) {
+            return clampMidi(midiNote);
+        }
+        final int sourceIndex = nearestScaleIndex(scaleNotes, midiNote);
+        final int targetIndex = Math.max(0, Math.min(scaleNotes.size() - 1, sourceIndex + degreeOffset));
+        return scaleNotes.get(targetIndex);
+    }
+
+    public static int transposeDiatonicThenChromatic(final int midiNote, final int degreeOffset,
+                                                     final int semitoneOffset,
+                                                     final MusicalScale scale, final int rootNote) {
+        final int degreeTarget = transposeByScaleDegrees(midiNote, degreeOffset, scale, rootNote);
+        return transpose(degreeTarget, semitoneOffset, scale, rootNote);
+    }
+
+    private static List<Integer> scaleNotes(final MusicalScale scale, final int rootNote) {
+        final List<Integer> notes = new ArrayList<>();
+        for (int note = 0; note <= 127; note++) {
+            if (scale.isMidiNoteInScale(rootNote, note)) {
+                notes.add(note);
+            }
+        }
+        return notes;
+    }
+
+    private static int nearestScaleIndex(final List<Integer> scaleNotes, final int midiNote) {
+        int bestIndex = 0;
+        int bestDistance = Integer.MAX_VALUE;
+        for (int i = 0; i < scaleNotes.size(); i++) {
+            final int distance = Math.abs(scaleNotes.get(i) - midiNote);
+            if (distance < bestDistance) {
+                bestIndex = i;
+                bestDistance = distance;
+            }
+        }
+        return bestIndex;
+    }
+
+    private static int clampMidi(final int note) {
+        return Math.max(0, Math.min(127, note));
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/nestedrhythm/NestedRhythmMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/nestedrhythm/NestedRhythmMode.java
@@ -172,14 +172,14 @@ public final class NestedRhythmMode extends Layer implements StepSequencerHost, 
         refreshSelectedClipState();
         patternButtons.setUpCallback(pressed -> {
             if (pressed) {
-                generatePattern("Generate", summaryLabel());
-            }
-        }, () -> BiColorLightState.GREEN_HALF);
-        patternButtons.setDownCallback(pressed -> {
-            if (pressed) {
                 clearPulseEdits();
             }
         }, () -> BiColorLightState.AMBER_HALF);
+        patternButtons.setDownCallback(pressed -> {
+            if (pressed) {
+                generatePattern("Generate", summaryLabel());
+            }
+        }, () -> BiColorLightState.GREEN_HALF);
         encoderLayer.activate();
         maybeGenerateOnEmptySelectedClip();
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -1072,6 +1072,10 @@ public abstract class PitchedSurfaceLayer extends Layer implements StepSequencer
                 return;
             }
             if (pressed) {
+                if (isChordStepSurface()) {
+                    driver.enterFugueStepMode();
+                    return;
+                }
                 driver.enterMelodicStepMode();
             }
             return;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/utils/PatternButtons.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/utils/PatternButtons.java
@@ -31,13 +31,13 @@ public class PatternButtons {
             if (pressed) {
                 upCallback.accept(true);
             }
-        }, upLightSupplier);
+        }, () -> upLightSupplier.get());
 
         downButton.bindPressed(layer, pressed -> {
             if (pressed) {
                 downCallback.accept(true);
             }
-        }, downLightSupplier);
+        }, () -> downLightSupplier.get());
     }
 
     // Methods to register callbacks:

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -192,7 +192,7 @@
         <tbody>
           <tr><td><code>DRUM</code></td><td>Drum sequencing</td><td>XOX-style drum sequencing; press again for <code>Nested Rhythm</code></td></tr>
           <tr><td><code>NOTE</code></td><td>Live note input</td><td>16x4 note surface; press again for harmonic note layout</td></tr>
-          <tr><td><code>STEP SEQ</code></td><td>Step sequencing</td><td>Enters <code>Melodic Step</code>; press again for <code>Chord Step</code></td></tr>
+          <tr><td><code>STEP</code></td><td>Step sequencing</td><td>Enters <code>Melodic Step</code>; press again for <code>Chord Step</code>, then <code>Fugue</code></td></tr>
           <tr><td><code>PERFORM</code></td><td>Clip launching</td><td>16x4 clip grid and track actions</td></tr>
       </tbody>
       </table>
@@ -242,9 +242,9 @@
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
-          <tr><td><code>STEP SEQ</code></td><td>Enter <code>Melodic Step</code></td></tr>
-          <tr><td><code>SHIFT + STEP SEQ</code></td><td>Accent entry and editing</td></tr>
-          <tr><td><code>ALT + STEP SEQ</code></td><td>Fill</td></tr>
+          <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step</code></td></tr>
+          <tr><td><code>SHIFT + STEP</code></td><td>Accent entry and editing</td></tr>
+          <tr><td><code>ALT + STEP</code></td><td>Fill</td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Move or rotate pattern</td></tr>
           <tr><td><code>SHIFT + BANK LEFT/RIGHT</code></td><td>Fine nudge</td></tr>
           <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Halve / double clip length</td></tr>
@@ -279,11 +279,11 @@
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
-          <tr><td><code>DRUM</code> while in standard <code>DRUM</code></td><td>Enter <code>Nested Rhythm</code></td></tr>
-          <tr><td><code>DRUM</code> while in <code>Nested Rhythm</code></td><td>Return to standard <code>DRUM</code></td></tr>
-          <tr><td><code>STEP SEQ</code></td><td>Enter <code>Melodic Step</code></td></tr>
-          <tr><td><code>PATTERN UP</code></td><td>Generate current nested rhythm into the selected clip</td></tr>
-          <tr><td><code>PATTERN DOWN</code> or <code>ALT + MUTE_4</code></td><td>Reset hit edits for the selected clip</td></tr>
+          <tr><td><code>DRUM</code> while in <code>XOX Drum mode</code></td><td>Enter <code>Nested Rhythm mode</code></td></tr>
+          <tr><td><code>DRUM</code> while in <code>Nested Rhythm</code></td><td>Return to <code>XOX Drum mode</code></td></tr>
+          <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step mode</code></td></tr>
+          <tr><td><code>PATTERN UP</code> or <code>ALT + MUTE_4</code></td><td>Reset hit edits for the selected clip</td></tr>
+          <tr><td><code>PATTERN DOWN</code></td><td>Generate current nested rhythm into the selected clip</td></tr>
           <tr><td>Hold <code>MUTE_2</code> + projected rhythm pad</td><td>Set last step within the 32-step edit view</td></tr>
           <tr><td>Hold projected rhythm pad</td><td>Target nearest generated hit</td></tr>
           <tr><td>Tap bottom-row hit pad</td><td>Toggle that hit</td></tr>
@@ -422,6 +422,18 @@
       </table>
       <p>Chord banks are static libraries of chord formulas and voicing variants. Changing shared <code>Root Key</code> or <code>Scale</code> does not switch bank, page, or slot; it only changes how the selected slot is rendered. <code>As Is</code> transposes the stored chord shape from the current root. <code>In Scale</code> rebuilds that slot from the current shared scale and root.</p>
       <p>Coarse nudge is intentionally disabled in <code>Chord Step</code>; micro-timing is currently temperamental and should be treated as experimental.</p>
+      <h3>Fugue mode</h3>
+      <p>Press <code>STEP</code> from <code>Chord Step</code> to enter <code>Fugue</code>. <code>Fugue</code> treats MIDI channel 1 as the source line and generates related lines on channels 2-4.</p>
+      <table>
+        <thead><tr><th>Control</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td><code>PATTERN DOWN</code></td><td>Reread channel 1 from the clip and rebuild derived lines</td></tr>
+          <tr><td>Encoder turn on a derived-line page</td><td>Immediately rebuild that line with the new parameter</td></tr>
+          <tr><td>Channel 1 pads and encoders</td><td>Edit the source/template line</td></tr>
+      </tbody>
+      </table>
+      <p>If you change channel 1 notes or expression directly in Bitwig, press <code>PATTERN DOWN</code> to update the generated lines from the current DAW clip state. Fugue deliberately avoids live regeneration during Bitwig note-editor drags, so you can audition an alternate source line in isolation and avoid rewriting derived notes while the DAW is still editing the source event.</p>
+      <p>For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.</p>
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using <code>Default Clip Length</code>, then launch.</p>
       <table>

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/TopLevelModeStateTest.java
@@ -42,6 +42,16 @@ class TopLevelModeStateTest {
     }
 
     @Test
+    void melodicExitFallsBackToNotePlayIfPreviousWasFugueStep() {
+        final TopLevelModeState state = new TopLevelModeState();
+
+        state.activateFugueStep();
+        state.enterMelodicStepMode();
+
+        assertEquals(TopLevelModeState.Mode.NOTE_PLAY, state.exitMelodicStepMode());
+    }
+
+    @Test
     void topLevelStepPressIgnoreMatchesModifierRules() {
         final TopLevelModeState state = new TopLevelModeState();
 

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
@@ -70,7 +70,7 @@ class FugueClipAdapterTest {
         final double[] generatedChance = {1.0};
         final boolean[] chanceEnabled = {false};
         final int[] writtenNotes = {0};
-        final PinnableCursorClip clip = writableClip(generatedChance, chanceEnabled, writtenNotes);
+        final PinnableCursorClip clip = writableClip(generatedChance, chanceEnabled, writtenNotes, true);
         final List<MelodicPattern.Step> steps = new ArrayList<>();
         for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
             steps.add(MelodicPattern.Step.rest(i));
@@ -82,6 +82,25 @@ class FugueClipAdapterTest {
         assertEquals(1, writtenNotes[0]);
         assertEquals(0.5, generatedChance[0]);
         assertTrue(chanceEnabled[0]);
+    }
+
+    @Test
+    void writeDerivedLineToleratesMissingGeneratedStepObject() {
+        final double[] generatedChance = {1.0};
+        final boolean[] chanceEnabled = {false};
+        final int[] writtenNotes = {0};
+        final PinnableCursorClip clip = writableClip(generatedChance, chanceEnabled, writtenNotes, false);
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        steps.set(0, new MelodicPattern.Step(0, true, false, 60, 96, 1.0, 0.5, false, false, 0, 0));
+
+        FugueClipAdapter.writeDerivedLine(clip, Map.of(), 1, new FuguePattern(steps, 16), 0.125);
+
+        assertEquals(1, writtenNotes[0]);
+        assertEquals(1.0, generatedChance[0]);
+        assertFalse(chanceEnabled[0]);
     }
 
     private static void put(final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps, final NoteStep note) {
@@ -113,11 +132,13 @@ class FugueClipAdapterTest {
 
     private static PinnableCursorClip writableClip(final double[] generatedChance,
                                                    final boolean[] chanceEnabled,
-                                                   final int[] writtenNotes) {
+                                                   final int[] writtenNotes,
+                                                   final boolean returnGeneratedStep) {
         final NoteStep generatedStep = (NoteStep) Proxy.newProxyInstance(
                 NoteStep.class.getClassLoader(),
                 new Class[]{NoteStep.class},
                 (proxy, method, args) -> switch (method.getName()) {
+                    case "state" -> NoteStep.State.NoteOn;
                     case "setChance" -> {
                         generatedChance[0] = (double) args[0];
                         yield null;
@@ -137,7 +158,7 @@ class FugueClipAdapterTest {
                         writtenNotes[0]++;
                         yield null;
                     }
-                    case "getStep" -> generatedStep;
+                    case "getStep" -> returnGeneratedStep ? generatedStep : null;
                     case "toString" -> "WritableClipStub";
                     default -> defaultValue(method.getReturnType());
                 });

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
@@ -1,10 +1,13 @@
 package com.oikoaudio.fire.fugue;
 
 import com.bitwig.extension.controller.api.NoteStep;
+import com.bitwig.extension.controller.api.PinnableCursorClip;
 import com.oikoaudio.fire.melodic.MelodicPattern;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,6 +65,25 @@ class FugueClipAdapterTest {
         assertEquals(2.0, source.step(0).gate());
     }
 
+    @Test
+    void writeDerivedLineAppliesChanceToGeneratedNotes() {
+        final double[] generatedChance = {1.0};
+        final boolean[] chanceEnabled = {false};
+        final int[] writtenNotes = {0};
+        final PinnableCursorClip clip = writableClip(generatedChance, chanceEnabled, writtenNotes);
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        steps.set(0, new MelodicPattern.Step(0, true, false, 60, 96, 1.0, 0.5, false, false, 0, 0));
+
+        FugueClipAdapter.writeDerivedLine(clip, Map.of(), 1, new FuguePattern(steps, 16), 0.125);
+
+        assertEquals(1, writtenNotes[0]);
+        assertEquals(0.5, generatedChance[0]);
+        assertTrue(chanceEnabled[0]);
+    }
+
     private static void put(final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps, final NoteStep note) {
         steps.computeIfAbsent(note.channel(), ignored -> new HashMap<>())
                 .computeIfAbsent(note.x(), ignored -> new HashMap<>())
@@ -85,6 +107,38 @@ class FugueClipAdapterTest {
                     case "duration" -> duration;
                     case "recurrenceLength", "recurrenceMask" -> 0;
                     case "toString" -> "NoteStepStub";
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static PinnableCursorClip writableClip(final double[] generatedChance,
+                                                   final boolean[] chanceEnabled,
+                                                   final int[] writtenNotes) {
+        final NoteStep generatedStep = (NoteStep) Proxy.newProxyInstance(
+                NoteStep.class.getClassLoader(),
+                new Class[]{NoteStep.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "setChance" -> {
+                        generatedChance[0] = (double) args[0];
+                        yield null;
+                    }
+                    case "setIsChanceEnabled" -> {
+                        chanceEnabled[0] = (boolean) args[0];
+                        yield null;
+                    }
+                    case "toString" -> "GeneratedNoteStepStub";
+                    default -> defaultValue(method.getReturnType());
+                });
+        return (PinnableCursorClip) Proxy.newProxyInstance(
+                PinnableCursorClip.class.getClassLoader(),
+                new Class[]{PinnableCursorClip.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "setStep" -> {
+                        writtenNotes[0]++;
+                        yield null;
+                    }
+                    case "getStep" -> generatedStep;
+                    case "toString" -> "WritableClipStub";
                     default -> defaultValue(method.getReturnType());
                 });
     }

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/FugueClipAdapterTest.java
@@ -1,0 +1,107 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extension.controller.api.NoteStep;
+import com.oikoaudio.fire.melodic.MelodicPattern;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FugueClipAdapterTest {
+
+    @Test
+    void sourceOnlyUsesChannelOne() {
+        final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps = new HashMap<>();
+        put(steps, note(0, 0, 60));
+        put(steps, note(1, 0, 72));
+
+        final FuguePattern source = FugueClipAdapter.sourceFromChannelOne(steps, 16, 0.25);
+
+        assertTrue(source.step(0).active());
+        assertEquals(60, source.step(0).pitch());
+        assertFalse(source.step(1).active());
+    }
+
+    @Test
+    void explicitChannelReadIgnoresOtherChannels() {
+        final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps = new HashMap<>();
+        put(steps, note(0, 0, 60));
+        put(steps, note(2, 0, 79));
+
+        final FuguePattern source = FugueClipAdapter.fromChannel(steps, 2, 16, 0.25);
+
+        assertTrue(source.step(0).active());
+        assertEquals(79, source.step(0).pitch());
+    }
+
+    @Test
+    void sourceKeepsMultipleNotesOnSameStep() {
+        final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps = new HashMap<>();
+        put(steps, note(0, 0, 67));
+        put(steps, note(0, 0, 60));
+
+        final FuguePattern source = FugueClipAdapter.sourceFromChannelOne(steps, 16, 0.125);
+
+        assertEquals(2, source.notesAt(0).size());
+        assertEquals(60, source.notesAt(0).get(0).pitch());
+        assertEquals(67, source.notesAt(0).get(1).pitch());
+    }
+
+    @Test
+    void sourceUsesStepLengthForGateSoFineGridCanRepresentSixteenthNotes() {
+        final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps = new HashMap<>();
+        put(steps, note(0, 0, 60, 0.25));
+
+        final FuguePattern source = FugueClipAdapter.sourceFromChannelOne(steps, 16, 0.125);
+
+        assertEquals(2.0, source.step(0).gate());
+    }
+
+    private static void put(final Map<Integer, Map<Integer, Map<Integer, NoteStep>>> steps, final NoteStep note) {
+        steps.computeIfAbsent(note.channel(), ignored -> new HashMap<>())
+                .computeIfAbsent(note.x(), ignored -> new HashMap<>())
+                .put(note.y(), note);
+    }
+
+    private static NoteStep note(final int channel, final int x, final int pitch) {
+        return note(channel, x, pitch, 0.25);
+    }
+
+    private static NoteStep note(final int channel, final int x, final int pitch, final double duration) {
+        return (NoteStep) Proxy.newProxyInstance(
+                NoteStep.class.getClassLoader(),
+                new Class[]{NoteStep.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "channel" -> channel;
+                    case "x" -> x;
+                    case "y" -> pitch;
+                    case "state" -> NoteStep.State.NoteOn;
+                    case "velocity", "chance" -> 0.75;
+                    case "duration" -> duration;
+                    case "recurrenceLength", "recurrenceMask" -> 0;
+                    case "toString" -> "NoteStepStub";
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(final Class<?> returnType) {
+        if (returnType == void.class) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == double.class) {
+            return 0.0;
+        }
+        return null;
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
@@ -80,6 +80,17 @@ class MelodicLineTransformerTest {
     }
 
     @Test
+    void pingPongKeepsSecondHalfInsideSecondHalf() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(longSource(),
+                new FugueLineSettings(FugueDirection.PING_PONG, FugueSpeed.NORMAL, 0, 0), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 16, 62);
+        assertStep(transformed, 39, 67);
+        assertStep(transformed, 55, 65);
+    }
+
+    @Test
     void speedUpCanCreateThirtySecondNotesFromSixteenthSourceSteps() {
         final FuguePattern transformed = MelodicLineTransformer.transform(sixteenthRunSource(),
                 new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 0), major(), 0);
@@ -217,6 +228,15 @@ class MelodicLineTransformerTest {
             steps.set(offset + 8, note(offset + 8, 64));
         }
         return new FuguePattern(steps, 128);
+    }
+
+    private static FuguePattern longSource() {
+        final List<MelodicPattern.Step> steps = emptySteps();
+        steps.set(0, note(0, 60));
+        steps.set(16, note(16, 62));
+        steps.set(40, note(40, 65));
+        steps.set(56, note(56, 67));
+        return new FuguePattern(steps, 64);
     }
 
     private static FuguePattern sixteenthRunSource() {

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
@@ -1,0 +1,290 @@
+package com.oikoaudio.fire.fugue;
+
+import com.bitwig.extensions.framework.MusicalScale;
+import com.bitwig.extensions.framework.MusicalScaleLibrary;
+import com.oikoaudio.fire.melodic.MelodicPattern;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MelodicLineTransformerTest {
+
+    @Test
+    void initKeepsSourcePlacementAndPitch() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                FugueLineSettings.init(), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 4, 62);
+        assertStep(transformed, 8, 64);
+    }
+
+    @Test
+    void reverseMirrorsInsideLoop() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.REVERSE, FugueSpeed.NORMAL, 0, 0), major(), 0);
+
+        assertStep(transformed, 15, 60);
+        assertStep(transformed, 11, 62);
+        assertStep(transformed, 7, 64);
+    }
+
+    @Test
+    void startOffsetMovesLineWithoutChangingSource() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.NORMAL, 2, 0), major(), 0);
+
+        assertStep(transformed, 2, 60);
+        assertStep(transformed, 6, 62);
+        assertStep(transformed, 10, 64);
+    }
+
+    @Test
+    void speedUpCompressesStepPositions() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 0), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 2, 62);
+        assertStep(transformed, 4, 64);
+    }
+
+    @Test
+    void speedUpRepeatsCompressedPhraseAcrossFullLoop() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 0), major(), 0);
+
+        assertStep(transformed, 8, 60);
+        assertStep(transformed, 10, 62);
+        assertStep(transformed, 12, 64);
+    }
+
+    @Test
+    void speedUpUsesRepeatedPhraseUnitRatherThanCompressingWholeExpandedLoop() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(repeatedSource(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_4, 0, 0), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 1, 62);
+        assertStep(transformed, 2, 64);
+        assertStep(transformed, 4, 60);
+        assertStep(transformed, 5, 62);
+        assertStep(transformed, 6, 64);
+        assertStep(transformed, 124, 60);
+        assertStep(transformed, 125, 62);
+        assertStep(transformed, 126, 64);
+    }
+
+    @Test
+    void speedUpCanCreateThirtySecondNotesFromSixteenthSourceSteps() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(sixteenthRunSource(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_2, 0, 0), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 1, 62);
+        assertStep(transformed, 2, 64);
+    }
+
+    @Test
+    void transformPreservesPolyphonicSourceSteps() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(polyphonicSource(),
+                FugueLineSettings.init(), major(), 0);
+
+        assertEquals(2, transformed.notesAt(0).size());
+        assertEquals(60, transformed.notesAt(0).get(0).pitch());
+        assertEquals(67, transformed.notesAt(0).get(1).pitch());
+    }
+
+    @Test
+    void speedScalingCanCreateShortAndLongGates() {
+        final FuguePattern fast = MelodicLineTransformer.transform(oneStepSourceWithGate(1.0),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.TIMES_8, 0, 0), major(), 0);
+        final FuguePattern slow = MelodicLineTransformer.transform(oneStepSourceWithGate(1.0),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 0, 0), major(), 0);
+
+        assertEquals(0.125, fast.step(0).gate());
+        assertEquals(8.0, slow.step(0).gate());
+    }
+
+    @Test
+    void speedPaletteIncludesTripletAndDottedSlots() {
+        assertEquals("2 dt", FugueSpeed.NORMAL.next(1).label());
+        assertEquals("1 trp", FugueSpeed.TIMES_2_DOTTED.next(1).label());
+        assertEquals("2", FugueSpeed.TIMES_TRIPLET.next(1).label());
+        assertEquals("2 trp", FugueSpeed.TIMES_2.next(1).label());
+        assertEquals("3 dt", FugueSpeed.TIMES_2_TRIPLET.next(1).label());
+        assertEquals("8", FugueSpeed.TIMES_6.next(1).label());
+        assertEquals("8", FugueSpeed.TIMES_8.next(1).label());
+        assertEquals("/8", FugueSpeed.DIVIDE_8.next(-1).label());
+    }
+
+    @Test
+    void pitchOffsetMovesByScaleDegreesByDefault() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.NORMAL, 0, 6), major(), 0);
+
+        assertStep(transformed, 0, 71);
+        assertStep(transformed, 4, 72);
+        assertStep(transformed, 8, 74);
+        assertTrue(major().isMidiNoteInScale(0, transformed.step(0).pitch()));
+    }
+
+    @Test
+    void semitoneOffsetStaysExactEvenForChromaticSourceNotes() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(chromaticSource(),
+                FugueLineSettings.semitone(FugueDirection.FORWARD, FugueSpeed.NORMAL, 0, 12), major(), 0);
+
+        assertStep(transformed, 0, 73);
+        assertStep(transformed, 4, 75);
+    }
+
+    @Test
+    void chromaticScaleMakesDegreeOffsetBehaveLikeSemitones() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(chromaticSource(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.NORMAL, 0, 12), chromatic(), 0);
+
+        assertStep(transformed, 0, 73);
+        assertStep(transformed, 4, 75);
+    }
+
+    @Test
+    void pitchIntervalsCanStepContinuouslyAndJumpOctaves() {
+        assertEquals(1, FuguePitchIntervals.nextDegreeInterval(0, 1));
+        assertEquals(2, FuguePitchIntervals.nextDegreeInterval(1, 1));
+        assertEquals(12, FuguePitchIntervals.nextDegreeInterval(11, 1));
+        assertEquals(19, FuguePitchIntervals.octaveJump(12, 1));
+        assertEquals(5, FuguePitchIntervals.octaveJump(12, -1));
+        assertEquals("+19", FuguePitchIntervals.label(11));
+        assertEquals("+40", FuguePitchIntervals.label(23));
+    }
+
+    @Test
+    void lineExpressionSettingsModifyGeneratedNotes() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(source(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.NORMAL, 0, 0, 0, -16, 50, 150),
+                major(), 0);
+
+        final MelodicPattern.Step step = transformed.step(0);
+        assertEquals(80, step.velocity());
+        assertEquals(0.5, step.chance());
+        assertEquals(1.2, step.gate());
+    }
+
+    @Test
+    void presetExampleStaysDeterministic() {
+        final FuguePattern a = MelodicLineTransformer.transform(source(),
+                FuguePreset.REVERSE_DOUBLE.settings(), major(), 0);
+        final FuguePattern b = MelodicLineTransformer.transform(source(),
+                FuguePreset.REVERSE_DOUBLE.settings(), major(), 0);
+
+        assertEquals(activeMask(a), activeMask(b));
+        assertEquals(pitchMask(a), pitchMask(b));
+    }
+
+    private static FuguePattern source() {
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        steps.set(0, note(0, 60));
+        steps.set(4, note(4, 62));
+        steps.set(8, note(8, 64));
+        return new FuguePattern(steps, 16);
+    }
+
+    private static FuguePattern chromaticSource() {
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        steps.set(0, note(0, 61));
+        steps.set(4, note(4, 63));
+        return new FuguePattern(steps, 16);
+    }
+
+    private static FuguePattern repeatedSource() {
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        for (int offset = 0; offset < FuguePattern.MAX_STEPS; offset += 16) {
+            steps.set(offset, note(offset, 60));
+            steps.set(offset + 4, note(offset + 4, 62));
+            steps.set(offset + 8, note(offset + 8, 64));
+        }
+        return new FuguePattern(steps, 128);
+    }
+
+    private static FuguePattern sixteenthRunSource() {
+        final List<MelodicPattern.Step> steps = emptySteps();
+        steps.set(0, noteWithGate(0, 60, 2.0));
+        steps.set(2, noteWithGate(2, 62, 2.0));
+        steps.set(4, noteWithGate(4, 64, 2.0));
+        return new FuguePattern(steps, 32);
+    }
+
+    private static FuguePattern polyphonicSource() {
+        final List<List<MelodicPattern.Step>> steps = FuguePattern.emptyPolySteps();
+        steps.get(0).add(note(0, 60));
+        steps.get(0).add(note(0, 67));
+        return new FuguePattern(steps, 16, true);
+    }
+
+    private static FuguePattern oneStepSourceWithGate(final double gate) {
+        final List<MelodicPattern.Step> steps = emptySteps();
+        steps.set(0, noteWithGate(0, 60, gate));
+        return new FuguePattern(steps, 16);
+    }
+
+    private static List<MelodicPattern.Step> emptySteps() {
+        final List<MelodicPattern.Step> steps = new ArrayList<>();
+        for (int i = 0; i < FuguePattern.MAX_STEPS; i++) {
+            steps.add(MelodicPattern.Step.rest(i));
+        }
+        return steps;
+    }
+
+    private static MelodicPattern.Step note(final int index, final int pitch) {
+        return new MelodicPattern.Step(index, true, false, pitch, 96, 0.8, false, false);
+    }
+
+    private static MelodicPattern.Step noteWithGate(final int index, final int pitch, final double gate) {
+        return new MelodicPattern.Step(index, true, false, pitch, 96, gate, false, false);
+    }
+
+    private static MusicalScale major() {
+        return MusicalScaleLibrary.getInstance().getMusicalScale("Ionan (Major)");
+    }
+
+    private static MusicalScale chromatic() {
+        return MusicalScaleLibrary.getInstance().getMusicalScale("Chromatic");
+    }
+
+    private static void assertStep(final FuguePattern pattern, final int stepIndex, final int pitch) {
+        assertTrue(pattern.step(stepIndex).active(), "Expected active step " + stepIndex);
+        assertEquals(pitch, pattern.step(stepIndex).pitch());
+    }
+
+    private static String activeMask(final FuguePattern pattern) {
+        final StringBuilder out = new StringBuilder();
+        for (int i = 0; i < pattern.loopSteps(); i++) {
+            out.append(pattern.step(i).active() ? '1' : '0');
+        }
+        return out.toString();
+    }
+
+    private static String pitchMask(final FuguePattern pattern) {
+        final StringBuilder out = new StringBuilder();
+        for (int i = 0; i < pattern.loopSteps(); i++) {
+            if (i > 0) {
+                out.append(',');
+            }
+            out.append(pattern.step(i).pitch() == null ? -1 : pattern.step(i).pitch());
+        }
+        return out.toString();
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/fugue/MelodicLineTransformerTest.java
@@ -122,6 +122,18 @@ class MelodicLineTransformerTest {
     }
 
     @Test
+    void slowTempoExpandsPositionsWithoutWrappingOntoEarlierBeats() {
+        final FuguePattern transformed = MelodicLineTransformer.transform(sixteenthRunSource(),
+                new FugueLineSettings(FugueDirection.FORWARD, FugueSpeed.DIVIDE_8, 0, 0), major(), 0);
+
+        assertStep(transformed, 0, 60);
+        assertStep(transformed, 16, 62);
+        assertEquals(1, transformed.notesAt(0).stream().filter(step -> step.pitch() != null).count());
+        assertEquals(1, transformed.notesAt(16).stream().filter(step -> step.pitch() != null).count());
+        assertTrue(transformed.step(1).pitch() == null);
+    }
+
+    @Test
     void speedPaletteIncludesTripletAndDottedSlots() {
         assertEquals("2 dt", FugueSpeed.NORMAL.next(1).label());
         assertEquals("1 trp", FugueSpeed.TIMES_2_DOTTED.next(1).label());
@@ -169,8 +181,8 @@ class MelodicLineTransformerTest {
         assertEquals(12, FuguePitchIntervals.nextDegreeInterval(11, 1));
         assertEquals(19, FuguePitchIntervals.octaveJump(12, 1));
         assertEquals(5, FuguePitchIntervals.octaveJump(12, -1));
-        assertEquals("+19", FuguePitchIntervals.label(11));
-        assertEquals("+40", FuguePitchIntervals.label(23));
+        assertEquals("+11d", FuguePitchIntervals.label(11));
+        assertEquals("+23d", FuguePitchIntervals.label(23));
     }
 
     @Test

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -192,7 +192,7 @@
         <tbody>
           <tr><td><code>DRUM</code></td><td>Drum sequencing</td><td>XOX-style drum sequencing; press again for <code>Nested Rhythm</code></td></tr>
           <tr><td><code>NOTE</code></td><td>Live note input</td><td>16x4 note surface; press again for harmonic note layout</td></tr>
-          <tr><td><code>STEP SEQ</code></td><td>Step sequencing</td><td>Enters <code>Melodic Step</code>; press again for <code>Chord Step</code></td></tr>
+          <tr><td><code>STEP</code></td><td>Step sequencing</td><td>Enters <code>Melodic Step</code>; press again for <code>Chord Step</code>, then <code>Fugue</code></td></tr>
           <tr><td><code>PERFORM</code></td><td>Clip launching</td><td>16x4 clip grid and track actions</td></tr>
       </tbody>
       </table>
@@ -242,9 +242,9 @@
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
-          <tr><td><code>STEP SEQ</code></td><td>Enter <code>Melodic Step</code></td></tr>
-          <tr><td><code>SHIFT + STEP SEQ</code></td><td>Accent entry and editing</td></tr>
-          <tr><td><code>ALT + STEP SEQ</code></td><td>Fill</td></tr>
+          <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step</code></td></tr>
+          <tr><td><code>SHIFT + STEP</code></td><td>Accent entry and editing</td></tr>
+          <tr><td><code>ALT + STEP</code></td><td>Fill</td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Move or rotate pattern</td></tr>
           <tr><td><code>SHIFT + BANK LEFT/RIGHT</code></td><td>Fine nudge</td></tr>
           <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Halve / double clip length</td></tr>
@@ -279,11 +279,11 @@
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
-          <tr><td><code>DRUM</code> while in standard <code>DRUM</code></td><td>Enter <code>Nested Rhythm</code></td></tr>
-          <tr><td><code>DRUM</code> while in <code>Nested Rhythm</code></td><td>Return to standard <code>DRUM</code></td></tr>
-          <tr><td><code>STEP SEQ</code></td><td>Enter <code>Melodic Step</code></td></tr>
-          <tr><td><code>PATTERN UP</code></td><td>Generate current nested rhythm into the selected clip</td></tr>
-          <tr><td><code>PATTERN DOWN</code> or <code>ALT + MUTE_4</code></td><td>Reset hit edits for the selected clip</td></tr>
+          <tr><td><code>DRUM</code> while in <code>XOX Drum mode</code></td><td>Enter <code>Nested Rhythm mode</code></td></tr>
+          <tr><td><code>DRUM</code> while in <code>Nested Rhythm</code></td><td>Return to <code>XOX Drum mode</code></td></tr>
+          <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step mode</code></td></tr>
+          <tr><td><code>PATTERN UP</code> or <code>ALT + MUTE_4</code></td><td>Reset hit edits for the selected clip</td></tr>
+          <tr><td><code>PATTERN DOWN</code></td><td>Generate current nested rhythm into the selected clip</td></tr>
           <tr><td>Hold <code>MUTE_2</code> + projected rhythm pad</td><td>Set last step within the 32-step edit view</td></tr>
           <tr><td>Hold projected rhythm pad</td><td>Target nearest generated hit</td></tr>
           <tr><td>Tap bottom-row hit pad</td><td>Toggle that hit</td></tr>
@@ -422,6 +422,18 @@
       </table>
       <p>Chord banks are static libraries of chord formulas and voicing variants. Changing shared <code>Root Key</code> or <code>Scale</code> does not switch bank, page, or slot; it only changes how the selected slot is rendered. <code>As Is</code> transposes the stored chord shape from the current root. <code>In Scale</code> rebuilds that slot from the current shared scale and root.</p>
       <p>Coarse nudge is intentionally disabled in <code>Chord Step</code>; micro-timing is currently temperamental and should be treated as experimental.</p>
+      <h3>Fugue mode</h3>
+      <p>Press <code>STEP</code> from <code>Chord Step</code> to enter <code>Fugue</code>. <code>Fugue</code> treats MIDI channel 1 as the source line and generates related lines on channels 2-4.</p>
+      <table>
+        <thead><tr><th>Control</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td><code>PATTERN DOWN</code></td><td>Reread channel 1 from the clip and rebuild derived lines</td></tr>
+          <tr><td>Encoder turn on a derived-line page</td><td>Immediately rebuild that line with the new parameter</td></tr>
+          <tr><td>Channel 1 pads and encoders</td><td>Edit the source/template line</td></tr>
+      </tbody>
+      </table>
+      <p>If you change channel 1 notes or expression directly in Bitwig, press <code>PATTERN DOWN</code> to update the generated lines from the current DAW clip state. Fugue deliberately avoids live regeneration during Bitwig note-editor drags, so you can audition an alternate source line in isolation and avoid rewriting derived notes while the DAW is still editing the source event.</p>
+      <p>For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.</p>
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using <code>Default Clip Length</code>, then launch.</p>
       <table>


### PR DESCRIPTION
This version adds a new `Fugue` mode (accessible via `STEP`) to the Akai Fire extension. It uses MIDI channel 1 as a template melodic line and generates derived new lines to channels 2-4 in the same clip, using Bach-type operations (transpose/reverse/move etc).

Improvements:
- Swapped Nested Rhythm pattern gestures so `PATTERN DOWN` generates the current nested rhythm and `PATTERN UP` resets hit edits, to better match related gestures in other modes.
- Updated the user guide and bundled help with notes on the new Fugue workflow.