### PR TITLE
ci: bootstrap sha for commit to release-please from going forward

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "54b21ea0b0489747eedaa2542bff9b2749a77f39",
   "include-component-in-tag": true,
   "release-type": "simple",
   "packages": {


### PR DESCRIPTION
- added bootstrap sha for last commit, from which release-please can start tracking conventional commit messages