### PR TITLE
feat: add controller navigation and clip recording controls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 This document now tracks intentional modifications made to the `bitwig-oikontrol` project.
 
+## 2.9.0 - Perform scene launch page and Rec+pad recordin
+- New Perform scene launch page (toggle on Perform)
+- REC + pad recording
+- ALT + PERFORM toggles horizontal/vertical clip launch pad view
+- Renamed the controller display name (Fire Oikontrol) to fit in better with other controllers
+- Distribute a single bwextension built from the two modules. If you want the individual controller extension those can still be built from source using the just-commands
+
 ## 2.8.0 - Fugue mode and generative workflow polish
 - Added Akai Fire `Fugue` step mode. It uses MIDI channel 1 as a template melodic line and generates derived new lines to channels 2-4 in the same clip, using Bach-type operations (transpose/reverse/move etc).
 - Added `REC + pad` in Akai Fire `PERFORM` mode to target recording directly into a visible launcher slot using the configured default clip length.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -149,6 +149,8 @@ Hold `SHIFT + BROWSER` to edit shared settings from the four encoders.
 | `User 1` | Shared octave |
 | `User 2` | `ClipRecLen`: launcher recording length |
 
+The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding `SHIFT + BROWSER` to toggle `Show deactivated tracks`; the same persistent option is available in the controller preferences and defaults to off.
+
 ### Main SELECT encoder
 
 Tap `SELECT` to swap between `Last Touched Parameter` and the current alternate role. Press `SHIFT + SELECT` to cycle the alternate role.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -143,6 +143,15 @@ When the popup browser is open, `SELECT` turn moves through results, `SELECT` pr
 Tap `SELECT` to swap between `Last Touched Parameter` and the current alternate role. Press `SHIFT + SELECT` to cycle the alternate role.
 Press `ALT + SELECT` to open or close the selected device window.
 
+Global `SELECT` turn chords:
+
+| Control | Action |
+| --- | --- |
+| Hold `PATTERN` + turn `SELECT` | Move the play position by the current meter's beat unit |
+| Hold `SHIFT + PATTERN` + turn `SELECT` | Move the play position by fine 1/16-beat steps |
+| Hold `ALT` + turn `SELECT` | Zoom the arranger/detail timeline horizontally |
+| Hold `SHIFT + ALT` + turn `SELECT` | Zoom arranger/detail lanes vertically |
+
 | Role | Turn | Press / hold behavior |
 | --- | --- | --- |
 | `Last Touched Parameter` | Adjust last touched Bitwig parameter | Reset parameter to default |
@@ -376,7 +385,7 @@ The `Scene Launch` page keeps the same encoder and navigation controls as Perfor
 
 On `Scene Launch`, `BANK LEFT/RIGHT` also scrolls the visible scene window, with `SHIFT + BANK LEFT/RIGHT` scrolling by one scene.
 
-On remote encoder pages, hold `ALT` while turning an encoder to control remotes 5-8 on the same page. Hold `ALT` and turn `SELECT` to change the remote page for the active remote encoder page: project remotes on `Channel`, track remotes on `User 1`, and device remotes on `User 2`. This applies in both vertical and horizontal perform layouts.
+On remote encoder pages, hold `ALT` while turning an encoder to control remotes 5-8 on the same page.
 
 | Encoder page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
 | --- | --- | --- | --- | --- |

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -373,6 +373,8 @@ For immediate derived-line feedback, change source expression from the controlle
 
 `PERFORM` is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using `Default Clip Length`, then launch.
 
+`Perform Clip Launcher Layout` chooses whether the mode starts as `PerformV` or `PerformH`. `ALT + PERFORM` still toggles the layout for the current session.
+
 | Control | Action |
 | --- | --- |
 | `REC` + pad | Record into the targeted launcher slot using `Default Clip Length` |
@@ -419,6 +421,7 @@ On remote encoder pages, hold `ALT` while turning an encoder to control remotes 
 
 - `Clip Launch Mode`
 - `Clip Launch Quantization`
+- `Perform Clip Launcher Layout`
 - `Default Clip Length`
 - `SELECT Encoder Startup`
 - `Default Root Key`

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -132,11 +132,22 @@ Pad colors in `DRUM` and `PERFORM` follow Bitwig track, drum-lane, and clip colo
 | `SHIFT + PATTERN` | Metronome |
 | `ALT + PATTERN` | Clip launcher overdub |
 | `BROWSER` | Open or close Bitwig popup browser |
-| `SHIFT + BROWSER` | Hold global pitch settings overlay |
+| `SHIFT + BROWSER` | Hold global settings overlay |
 | `ALT + BROWSER` | Open browser after the current device / insertion context |
 | `SHIFT + ALT + BROWSER` | Open browser before the current device / insertion context |
 
 When the popup browser is open, `SELECT` turn moves through results, `SELECT` press commits the selected result, and `BROWSER` closes the browser.
+
+### Global settings overlay
+
+Hold `SHIFT + BROWSER` to edit shared settings from the four encoders.
+
+| Encoder | Setting |
+| --- | --- |
+| `Channel` | Shared root key |
+| `Mixer` | Shared scale |
+| `User 1` | Shared octave |
+| `User 2` | Default launcher recording length |
 
 ### Main SELECT encoder
 
@@ -379,7 +390,7 @@ For immediate derived-line feedback, change source expression from the controlle
 
 Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold `ALT` and press a pad to stop that track. `KNOB MODE` still cycles the Perform encoder pages while the track-control pad page is active.
 
-Hold `REC` and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.
+Hold `REC` and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after `Default Clip Length`, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.
 
 The `Scene Launch` page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold `MUTE_1` and press a scene pad to select it as the scene copy source, hold `MUTE_3` and press a scene pad to copy the selected scene to that target, and hold `MUTE_4` and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. `MUTE_2` is unused on this page.
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -147,7 +147,7 @@ Hold `SHIFT + BROWSER` to edit shared settings from the four encoders.
 | `Channel` | Shared root key |
 | `Mixer` | Shared scale |
 | `User 1` | Shared octave |
-| `User 2` | Default launcher recording length |
+| `User 2` | `ClipRecLen`: launcher recording length |
 
 ### Main SELECT encoder
 
@@ -390,7 +390,7 @@ For immediate derived-line feedback, change source expression from the controlle
 
 Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold `ALT` and press a pad to stop that track. `KNOB MODE` still cycles the Perform encoder pages while the track-control pad page is active.
 
-Hold `REC` and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after `Default Clip Length`, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.
+Hold `REC` and press a pad to target recording directly into that visible slot. For fixed `Default Clip Length` values, the script sets Bitwig's clip launcher post-record action to play the recorded clip after that length. If `Default Clip Length` is set to `Off`, recording continues until manually stopped without post-processing. If it is set to `Round`, recording continues until manually stopped, then the recorded clip loop length is rounded to the nearest whole bar. Press `REC` again to end an `Off` or `Round` launcher recording and launch the recorded clip, even after switching to another mode. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.
 
 The `Scene Launch` page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold `MUTE_1` and press a scene pad to select it as the scene copy source, hold `MUTE_3` and press a scene pad to copy the selected scene to that target, and hold `MUTE_4` and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. `MUTE_2` is unused on this page.
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
@@ -56,7 +56,7 @@ public class AkaiFireOikontrolDefinition extends ControllerExtensionDefinition {
 
     @Override
     public int getRequiredAPIVersion() {
-        return 24;
+        return 25;
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolDefinition.java
@@ -56,7 +56,7 @@ public class AkaiFireOikontrolDefinition extends ControllerExtensionDefinition {
 
     @Override
     public int getRequiredAPIVersion() {
-        return 25;
+        return 24;
     }
 
     @Override

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -1554,10 +1554,11 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void showGlobalSettingsOverview() {
         oled.detailInfo("Global Settings",
-                "1: Root %s\n2: Scale %s\n3: Oct %d".formatted(
+                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: Rec %s".formatted(
                         com.oikoaudio.fire.note.NoteGridLayout.noteName(sharedPitchContext.getRootNote()),
                         sharedPitchContext.getScaleDisplayName(),
-                        sharedPitchContext.getOctave()));
+                        sharedPitchContext.getOctave(),
+                        defaultClipLengthLabel()));
     }
 
     private void adjustGlobalSettings(final int encoderIndex, final int inc) {
@@ -1578,6 +1579,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (encoderIndex == 2) {
             sharedPitchContext.adjustOctave(inc);
             oled.valueInfo("Octave", Integer.toString(sharedPitchContext.getOctave()));
+            return;
+        }
+        if (encoderIndex == 3) {
+            adjustDefaultClipLength(inc);
             return;
         }
         showGlobalSettingsOverview();
@@ -1601,7 +1606,35 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             oled.valueInfo("Octave", Integer.toString(sharedPitchContext.getOctave()));
             return;
         }
+        if (encoderIndex == 3) {
+            oled.valueInfo("Launcher Rec", defaultClipLengthLabel());
+            return;
+        }
         showGlobalSettingsOverview();
+    }
+
+    private void adjustDefaultClipLength(final int inc) {
+        if (defaultClipLengthPref == null || inc == 0) {
+            return;
+        }
+        final String current = FireControlPreferences.normalizeDefaultClipLength(defaultClipLengthPref.get());
+        int currentIndex = 0;
+        for (int i = 0; i < FireControlPreferences.DEFAULT_CLIP_LENGTHS.length; i++) {
+            if (FireControlPreferences.DEFAULT_CLIP_LENGTHS[i].equals(current)) {
+                currentIndex = i;
+                break;
+            }
+        }
+        final int nextIndex = Math.max(0,
+                Math.min(FireControlPreferences.DEFAULT_CLIP_LENGTHS.length - 1, currentIndex + inc));
+        defaultClipLengthPref.set(FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
+        oled.valueInfo("Launcher Rec", FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
+    }
+
+    private String defaultClipLengthLabel() {
+        return FireControlPreferences.normalizeDefaultClipLength(defaultClipLengthPref == null
+                ? FireControlPreferences.CLIP_LENGTH_2_BARS
+                : defaultClipLengthPref.get());
     }
 
     private RgbLigthState globalSettingsPadState(final int padIndex) {
@@ -1793,7 +1826,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (browserButton == null || !browserButton.isPressed()) {
             return;
         }
-        if (isGlobalShiftHeld() || isGlobalAltHeld() || globalSettingsOverlayActive || isPopupBrowserActive()) {
+        if (globalSettingsOverlayActive || isPopupBrowserActive()) {
             return;
         }
         openPopupBrowser();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -117,6 +117,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private Preferences preferences;
     private SettableEnumValue clipLaunchModePref;
     private SettableEnumValue clipLaunchQuantizationPref;
+    private SettableEnumValue performClipLauncherLayoutPref;
     private SettableEnumValue defaultClipLengthPref;
     private SettableEnumValue mainEncoderStartupPref;
     private SettableEnumValue euclidScopePref;
@@ -316,6 +317,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         clipLaunchQuantizationPref.markInterested();
         clipLaunchQuantizationPref.addValueObserver(this::applyLaunchQuantizationPreference);
         applyLaunchQuantizationPreference(clipLaunchQuantizationPref.get());
+
+        performClipLauncherLayoutPref = preferences.getEnumSetting("Perform Clip Launcher Layout",
+                FireControlPreferences.CATEGORY_CLIP_LAUNCH,
+                FireControlPreferences.PERFORM_LAYOUTS,
+                FireControlPreferences.PERFORM_LAYOUT_VERTICAL);
+        performClipLauncherLayoutPref.markInterested();
 
         defaultClipLengthPref = preferences.getEnumSetting("Default Clip Length",
                 FireControlPreferences.CATEGORY_CLIP_LAUNCH,
@@ -1151,6 +1158,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         return clipLaunchModePref == null
                 ? FireControlPreferences.CLIP_LAUNCH_MODE_SYNCED
                 : clipLaunchModePref.get();
+    }
+
+    public String getPerformClipLauncherLayoutPreference() {
+        return FireControlPreferences.normalizePerformLayout(performClipLauncherLayoutPref == null
+                ? FireControlPreferences.PERFORM_LAYOUT_VERTICAL
+                : performClipLauncherLayoutPref.get());
     }
 
     public int getDefaultClipLengthBeats() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -62,7 +62,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private static AkaiFireOikontrolExtension instance;
     private HardwareSurface surface;
+    private Application application;
     private Transport transport;
+    private Arranger arranger;
+    private DetailEditor detailEditor;
     private MidiIn midiIn;
     private MidiOut midiOut;
     private Layers layers;
@@ -135,6 +138,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private int drumTrackIndexBeforeAutoPin = -1;
     private boolean mainEncoderPressed = false;
     private boolean mainEncoderTurnedWhilePressed = false;
+    private boolean patternPressed = false;
+    private boolean patternGestureConsumed = false;
+    private boolean patternPressShiftHeld = false;
+    private boolean patternPressAltHeld = false;
     private boolean suppressNextMelodicStepRelease = false;
     private boolean drumPinPreferenceObserved = false;
     private boolean globalSettingsOverlayActive = false;
@@ -198,6 +205,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         focusedParameter.name().markInterested();
         focusedParameter.displayedValue().markInterested();
         focusedParameter.value().markInterested();
+        application = host.createApplication();
+        arranger = host.createArranger();
+        detailEditor = host.createDetailEditor();
         groove = host.createGroove();
         groove.getEnabled().name().markInterested();
         groove.getEnabled().displayedValue().markInterested();
@@ -436,6 +446,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void setUpTransportControl() {
         transport.isPlaying().markInterested();
+        transport.getPosition().markInterested();
         transport.timeSignature().markInterested();
         transport.timeSignature().numerator().markInterested();
         transport.timeSignature().denominator().markInterested();
@@ -703,16 +714,24 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private void handlePatternPressed(final boolean pressed) {
-        if (!pressed) {
+        patternPressed = pressed;
+        if (pressed) {
+            patternGestureConsumed = false;
+            patternPressShiftHeld = getButton(NoteAssign.SHIFT).isPressed();
+            patternPressAltHeld = isGlobalAltHeld();
             return;
         }
-        if (getButton(NoteAssign.SHIFT).isPressed()) {
+        if (patternGestureConsumed) {
+            patternGestureConsumed = false;
+            return;
+        }
+        if (patternPressShiftHeld) {
             final boolean nextState = !transport.isMetronomeEnabled().get();
             transport.isMetronomeEnabled().toggle();
             notifyAction("Metronome", nextState ? "On" : "Off");
             return;
         }
-        if (isGlobalAltHeld()) {
+        if (patternPressAltHeld) {
             final boolean nextState = !transport.isClipLauncherOverdubEnabled().get();
             transport.isClipLauncherOverdubEnabled().toggle();
             notifyAction("Launcher Overdub", nextState ? "On" : "Off");
@@ -1145,7 +1164,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     public String getMainEncoderRolePreference() {
-        return FireControlPreferences.normalizeMainEncoderRole(currentMainEncoderRole);
+        return resolveMainEncoderRoleForActiveMode(currentMainEncoderRole);
     }
 
     private void applyMainEncoderStartupPreference(final String preferenceValue) {
@@ -1159,7 +1178,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         final String cycleSource = FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED.equals(getMainEncoderRolePreference())
                 ? alternateMainEncoderRole
                 : getMainEncoderRolePreference();
-        final String nextRole = FireControlPreferences.nextAlternateMainEncoderRole(cycleSource);
+        final String nextRole = FireControlPreferences.nextAlternateMainEncoderRole(cycleSource, isDrumGridRoleAvailable());
         currentMainEncoderRole = nextRole;
         alternateMainEncoderRole = nextRole;
         notifyAction("Encoder Role", nextRole);
@@ -1168,7 +1187,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     public String toggleMainEncoderRolePreference() {
         final String normalizedCurrentRole = getMainEncoderRolePreference();
-        final String normalizedAlternateRole = FireControlPreferences.normalizeMainEncoderRole(alternateMainEncoderRole);
+        final String normalizedAlternateRole = resolveMainEncoderRoleForActiveMode(alternateMainEncoderRole);
         final String nextRole = FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED.equals(normalizedCurrentRole)
                 ? (FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED.equals(normalizedAlternateRole)
                 ? FireControlPreferences.MAIN_ENCODER_TRACK_SELECT
@@ -1177,6 +1196,18 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         currentMainEncoderRole = nextRole;
         notifyAction("Encoder Role", nextRole);
         return nextRole;
+    }
+
+    private boolean isDrumGridRoleAvailable() {
+        return modeState.activeMode() == Mode.DRUM;
+    }
+
+    private String resolveMainEncoderRoleForActiveMode(final String role) {
+        final String normalizedRole = FireControlPreferences.normalizeMainEncoderRole(role);
+        if (FireControlPreferences.MAIN_ENCODER_DRUM_GRID.equals(normalizedRole) && !isDrumGridRoleAvailable()) {
+            return FireControlPreferences.MAIN_ENCODER_TRACK_SELECT;
+        }
+        return normalizedRole;
     }
 
     public boolean isStepSeqPadAuditionEnabled() {
@@ -1630,6 +1661,65 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     public boolean wasMainEncoderTurnedWhilePressed() {
         return mainEncoderTurnedWhilePressed;
+    }
+
+    public boolean handleMainEncoderGlobalChord(final int inc) {
+        if (inc == 0 || isPopupBrowserActive()) {
+            return false;
+        }
+        if (patternPressed) {
+            patternGestureConsumed = true;
+            adjustTransportPositionByGrid(inc, isGlobalShiftHeld());
+            return true;
+        }
+        if (isGlobalAltHeld()) {
+            if (isGlobalShiftHeld()) {
+                zoomTimelineVertically(inc);
+            } else {
+                zoomTimelineHorizontally(inc);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void adjustTransportPositionByGrid(final int inc, final boolean fine) {
+        if (transport == null) {
+            return;
+        }
+        final double beatStep = fine ? 0.25 : Math.max(0.125, 4.0 / Math.max(1, transportTimeSignatureDenominator));
+        transport.getPosition().inc(inc * beatStep);
+        oled.valueInfo("Play Position", transport.getPosition().getFormatted());
+    }
+
+    private void zoomTimelineHorizontally(final int inc) {
+        if (application == null) {
+            return;
+        }
+        for (int i = 0; i < Math.abs(inc); i++) {
+            if (inc > 0) {
+                application.zoomIn();
+            } else {
+                application.zoomOut();
+            }
+        }
+        oled.valueInfo("Timeline Zoom", inc > 0 ? "In" : "Out");
+    }
+
+    private void zoomTimelineVertically(final int inc) {
+        if (arranger == null || detailEditor == null) {
+            return;
+        }
+        for (int i = 0; i < Math.abs(inc); i++) {
+            if (inc > 0) {
+                arranger.zoomInLaneHeightsSelected();
+                detailEditor.zoomInLaneHeights();
+            } else {
+                arranger.zoomOutLaneHeightsSelected();
+                detailEditor.zoomOutLaneHeights();
+            }
+        }
+        oled.valueInfo("Lane Zoom", inc > 0 ? "In" : "Out");
     }
 
     public void adjustSelectedTrack(final int inc, final boolean pageStep) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -42,11 +42,14 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private static final int BROWSER_OPEN_DEFER_MS = 40;
     private static final int SETTINGS_PAD_COLUMNS = 16;
     private static final int SETTINGS_PAD_ROWS = 4;
+    private static final int SETTINGS_SHOW_DEACTIVATED_TRACKS_PAD = 63;
     private static final int GLOBAL_ROOT_ENCODER_THRESHOLD = 16;
     private static final int GLOBAL_SCALE_ENCODER_THRESHOLD = 8;
     private static final int GLOBAL_OCTAVE_ENCODER_THRESHOLD = 8;
     private static final RgbLigthState SETTINGS_LOGO_ON = new RgbLigthState(127, 20, 0, true);
     private static final RgbLigthState SETTINGS_LOGO_OFF = RgbLigthState.OFF;
+    private static final RgbLigthState SETTINGS_TOGGLE_ON = new RgbLigthState(0, 96, 96, true);
+    private static final RgbLigthState SETTINGS_TOGGLE_OFF = new RgbLigthState(0, 32, 32, true);
     private static final boolean[][] SETTINGS_LOGO = {
             {true, true, true, false, true, true, true, false, true, true, true, false, true, true, true, true},
             {true, false, false, false, false, true, false, false, true, false, true, false, true, false, false, false},
@@ -125,6 +128,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private SettableEnumValue melodicSeedModePref;
     private SettableEnumValue livePitchOffsetBehaviorPref;
     private SettableBooleanValue encoderTouchResetPref;
+    private SettableBooleanValue showDeactivatedTracksPref;
     private SettableRangedValue padBrightnessPref;
     private SettableRangedValue padSaturationPref;
     private SettableRangedValue melodicFixedSeedPref;
@@ -422,6 +426,11 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         encoderTouchResetEnabled = encoderTouchResetPref.get();
         encoderTouchResetPref.addValueObserver(value -> encoderTouchResetEnabled = value);
 
+        showDeactivatedTracksPref = preferences.getBooleanSetting("Show deactivated tracks",
+                FireControlPreferences.CATEGORY_FUNCTIONALITIES,
+                FireControlPreferences.SHOW_DEACTIVATED_TRACKS_DEFAULT);
+        showDeactivatedTracksPref.markInterested();
+
         // Deferred for now: the current live NOTE implementation still relies on
         // Bitwig key-translation updates, so "New Notes Only" does not preserve
         // already-held notes correctly when the pitch offset changes. Keep the
@@ -533,6 +542,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         for (int padIndex = 0; padIndex < rgbButtons.length; padIndex++) {
             final int currentPad = padIndex;
             rgbButtons[padIndex].bindPressed(globalSettingsLayer, pressed -> {
+                handleGlobalSettingsPad(currentPad, pressed);
             }, () -> globalSettingsPadState(currentPad));
         }
     }
@@ -1572,11 +1582,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void showGlobalSettingsOverview() {
         oled.detailInfo("Global Settings",
-                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: ClipRecLen %s".formatted(
+                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: ClipRecLen %s\nTracks: %s".formatted(
                         com.oikoaudio.fire.note.NoteGridLayout.noteName(sharedPitchContext.getRootNote()),
                         sharedPitchContext.getScaleDisplayName(),
                         sharedPitchContext.getOctave(),
-                        defaultClipLengthLabel()));
+                        defaultClipLengthLabel(),
+                        showDeactivatedTracks() ? "All" : "Active"));
     }
 
     private void adjustGlobalSettings(final int encoderIndex, final int inc) {
@@ -1631,6 +1642,15 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         showGlobalSettingsOverview();
     }
 
+    private void handleGlobalSettingsPad(final int padIndex, final boolean pressed) {
+        if (!pressed || padIndex != SETTINGS_SHOW_DEACTIVATED_TRACKS_PAD || showDeactivatedTracksPref == null) {
+            return;
+        }
+        showDeactivatedTracksPref.set(!showDeactivatedTracks());
+        oled.valueInfo("Tracks", showDeactivatedTracks() ? "All" : "Active");
+        refreshSurfaceLights();
+    }
+
     private void adjustDefaultClipLength(final int inc) {
         if (defaultClipLengthPref == null || inc == 0) {
             return;
@@ -1656,6 +1676,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private RgbLigthState globalSettingsPadState(final int padIndex) {
+        if (padIndex == SETTINGS_SHOW_DEACTIVATED_TRACKS_PAD) {
+            return showDeactivatedTracks() ? SETTINGS_TOGGLE_ON : SETTINGS_TOGGLE_OFF;
+        }
         final int row = padIndex / SETTINGS_PAD_COLUMNS;
         final int column = padIndex % SETTINGS_PAD_COLUMNS;
         if (row < 0 || row >= SETTINGS_PAD_ROWS || column < 0 || column >= SETTINGS_PAD_COLUMNS) {
@@ -1677,6 +1700,12 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     public boolean isGlobalSettingsOverlayActive() {
         return globalSettingsOverlayActive;
+    }
+
+    public boolean showDeactivatedTracks() {
+        return showDeactivatedTracksPref != null
+                ? showDeactivatedTracksPref.get()
+                : FireControlPreferences.SHOW_DEACTIVATED_TRACKS_DEFAULT;
     }
 
     public boolean isGlobalAltHeld() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -675,6 +675,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             notifyAction("Arranger Write", nextState ? "On" : "Off");
             return;
         }
+        if (pressed && performMode != null && performMode.stopManualLauncherRecordingIfAny()) {
+            performRecordPadGestureConsumed = true;
+            return;
+        }
         if (modeState.activeMode() == Mode.PERFORM) {
             if (pressed) {
                 performRecordPadGestureConsumed = false;
@@ -1145,6 +1149,16 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
                 : FireControlPreferences.toClipLengthBeats(defaultClipLengthPref.get()));
     }
 
+    public boolean shouldRoundLauncherRecordingToNearestBar() {
+        return defaultClipLengthPref != null
+                && FireControlPreferences.isRoundToNearestBarClipLength(defaultClipLengthPref.get());
+    }
+
+    public boolean shouldDisableLauncherPostRecordingAction() {
+        return defaultClipLengthPref != null
+                && FireControlPreferences.isOffClipLength(defaultClipLengthPref.get());
+    }
+
     public boolean isPerformRecordTargetingHeld() {
         final BiColorButton recButton = getButton(NoteAssign.REC);
         return modeState.activeMode() == Mode.PERFORM
@@ -1158,7 +1172,11 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         performRecordPadGestureConsumed = true;
     }
 
-    public void prepareFixedLengthLauncherRecording() {
+    public void prepareLauncherRecording() {
+        if (shouldDisableLauncherPostRecordingAction() || shouldRoundLauncherRecordingToNearestBar()) {
+            transport.clipLauncherPostRecordingAction().set("off");
+            return;
+        }
         transport.clipLauncherPostRecordingAction().set("play_recorded");
         transport.getClipLauncherPostRecordingTimeOffset().set(getDefaultClipLengthBeats());
     }
@@ -1554,7 +1572,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void showGlobalSettingsOverview() {
         oled.detailInfo("Global Settings",
-                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: Rec %s".formatted(
+                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: ClipRecLen %s".formatted(
                         com.oikoaudio.fire.note.NoteGridLayout.noteName(sharedPitchContext.getRootNote()),
                         sharedPitchContext.getScaleDisplayName(),
                         sharedPitchContext.getOctave(),
@@ -1607,7 +1625,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         if (encoderIndex == 3) {
-            oled.valueInfo("Launcher Rec", defaultClipLengthLabel());
+            oled.valueInfo("ClipRecLen", defaultClipLengthLabel());
             return;
         }
         showGlobalSettingsOverview();
@@ -1628,7 +1646,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         final int nextIndex = Math.max(0,
                 Math.min(FireControlPreferences.DEFAULT_CLIP_LENGTHS.length - 1, currentIndex + inc));
         defaultClipLengthPref.set(FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
-        oled.valueInfo("Launcher Rec", FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
+        oled.valueInfo("ClipRecLen", FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
     }
 
     private String defaultClipLengthLabel() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -51,11 +51,16 @@ public final class FireControlPreferences {
     public static final String CLIP_LENGTH_2_BARS = "2 bars";
     public static final String CLIP_LENGTH_4_BARS = "4 bars";
     public static final String CLIP_LENGTH_8_BARS = "8 bars";
+    public static final String CLIP_LENGTH_OFF = "Off";
+    public static final String CLIP_LENGTH_ROUND_NEAREST_BAR = "Round";
+    private static final String CLIP_LENGTH_ROUND_NEAREST_BAR_LEGACY = "Round to nearest bar";
     public static final String[] DEFAULT_CLIP_LENGTHS = {
+            CLIP_LENGTH_OFF,
             CLIP_LENGTH_1_BAR,
             CLIP_LENGTH_2_BARS,
             CLIP_LENGTH_4_BARS,
-            CLIP_LENGTH_8_BARS
+            CLIP_LENGTH_8_BARS,
+            CLIP_LENGTH_ROUND_NEAREST_BAR
     };
 
     public static final String MAIN_ENCODER_LAST_TOUCHED = "Last Touched Parameter";
@@ -321,6 +326,9 @@ public final class FireControlPreferences {
     }
 
     public static String normalizeDefaultClipLength(final String preferenceValue) {
+        if (CLIP_LENGTH_ROUND_NEAREST_BAR_LEGACY.equals(preferenceValue)) {
+            return CLIP_LENGTH_ROUND_NEAREST_BAR;
+        }
         for (final String value : DEFAULT_CLIP_LENGTHS) {
             if (value.equals(preferenceValue)) {
                 return value;
@@ -336,6 +344,14 @@ public final class FireControlPreferences {
             case CLIP_LENGTH_8_BARS -> 32.0;
             default -> 8.0;
         };
+    }
+
+    public static boolean isRoundToNearestBarClipLength(final String preferenceValue) {
+        return CLIP_LENGTH_ROUND_NEAREST_BAR.equals(normalizeDefaultClipLength(preferenceValue));
+    }
+
+    public static boolean isOffClipLength(final String preferenceValue) {
+        return CLIP_LENGTH_OFF.equals(normalizeDefaultClipLength(preferenceValue));
     }
 
     public static boolean shouldAutoPinFirstDrumMachine(final String preferenceValue) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -55,6 +55,12 @@ public final class FireControlPreferences {
     public static final String CLIP_LENGTH_OFF = "Off";
     public static final String CLIP_LENGTH_ROUND_NEAREST_BAR = "Round";
     private static final String CLIP_LENGTH_ROUND_NEAREST_BAR_LEGACY = "Round to nearest bar";
+    public static final String PERFORM_LAYOUT_VERTICAL = "Vertical";
+    public static final String PERFORM_LAYOUT_HORIZONTAL = "Horizontal";
+    public static final String[] PERFORM_LAYOUTS = {
+            PERFORM_LAYOUT_VERTICAL,
+            PERFORM_LAYOUT_HORIZONTAL
+    };
     public static final String[] DEFAULT_CLIP_LENGTHS = {
             CLIP_LENGTH_OFF,
             CLIP_LENGTH_1_BAR,
@@ -336,6 +342,15 @@ public final class FireControlPreferences {
             }
         }
         return CLIP_LENGTH_2_BARS;
+    }
+
+    public static String normalizePerformLayout(final String preferenceValue) {
+        for (final String value : PERFORM_LAYOUTS) {
+            if (value.equals(preferenceValue)) {
+                return value;
+            }
+        }
+        return PERFORM_LAYOUT_VERTICAL;
     }
 
     public static double toClipLengthBeats(final String preferenceValue) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -6,6 +6,7 @@ public final class FireControlPreferences {
     public static final String CATEGORY_PINNING = "Pinning";
     public static final String CATEGORY_HARDWARE = "Hardware";
     public static final String CATEGORY_GENERATIVE_CONTROL = "Generative control";
+    public static final boolean SHOW_DEACTIVATED_TRACKS_DEFAULT = false;
 
     public static final double PAD_BRIGHTNESS_MIN = 20.0;
     public static final double PAD_BRIGHTNESS_MAX = 100.0;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -50,10 +50,12 @@ public final class FireControlPreferences {
     public static final String CLIP_LENGTH_1_BAR = "1 bar";
     public static final String CLIP_LENGTH_2_BARS = "2 bars";
     public static final String CLIP_LENGTH_4_BARS = "4 bars";
+    public static final String CLIP_LENGTH_8_BARS = "8 bars";
     public static final String[] DEFAULT_CLIP_LENGTHS = {
             CLIP_LENGTH_1_BAR,
             CLIP_LENGTH_2_BARS,
-            CLIP_LENGTH_4_BARS
+            CLIP_LENGTH_4_BARS,
+            CLIP_LENGTH_8_BARS
     };
 
     public static final String MAIN_ENCODER_LAST_TOUCHED = "Last Touched Parameter";
@@ -331,6 +333,7 @@ public final class FireControlPreferences {
         return switch (normalizeDefaultClipLength(preferenceValue)) {
             case CLIP_LENGTH_1_BAR -> 4.0;
             case CLIP_LENGTH_4_BARS -> 16.0;
+            case CLIP_LENGTH_8_BARS -> 32.0;
             default -> 8.0;
         };
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -193,6 +193,10 @@ public final class FireControlPreferences {
     }
 
     public static String nextAlternateMainEncoderRole(final String currentRole) {
+        return nextAlternateMainEncoderRole(currentRole, true);
+    }
+
+    public static String nextAlternateMainEncoderRole(final String currentRole, final boolean includeDrumGrid) {
         final String normalizedRole = normalizeMainEncoderRole(currentRole);
         if (MAIN_ENCODER_SHUFFLE.equals(normalizedRole)) {
             return MAIN_ENCODER_TEMPO;
@@ -204,7 +208,7 @@ public final class FireControlPreferences {
             return MAIN_ENCODER_TRACK_SELECT;
         }
         if (MAIN_ENCODER_TRACK_SELECT.equals(normalizedRole)) {
-            return MAIN_ENCODER_DRUM_GRID;
+            return includeDrumGrid ? MAIN_ENCODER_DRUM_GRID : MAIN_ENCODER_SHUFFLE;
         }
         return MAIN_ENCODER_SHUFFLE;
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/fugue/FugueStepMode.java
@@ -222,6 +222,9 @@ public final class FugueStepMode extends Layer {
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         final boolean fine = driver.isGlobalShiftHeld();
         final String mainEncoderRole = driver.getMainEncoderRolePreference();
         if (AkaiFireOikontrolExtension.MAIN_ENCODER_TEMPO_ROLE.equals(mainEncoderRole)) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/melodic/MelodicStepMode.java
@@ -1122,6 +1122,9 @@ public class MelodicStepMode extends Layer implements StepSequencerHost, SeqClip
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         final boolean fine = driver.isGlobalShiftHeld();
         final String mainEncoderRole = driver.getMainEncoderRolePreference();
         if (AkaiFireOikontrolExtension.MAIN_ENCODER_NOTE_REPEAT_ROLE.equals(mainEncoderRole)) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/nestedrhythm/NestedRhythmMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/nestedrhythm/NestedRhythmMode.java
@@ -455,6 +455,9 @@ public final class NestedRhythmMode extends Layer implements StepSequencerHost, 
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         final boolean fine = driver.isGlobalShiftHeld();
         final String mainEncoderRole = driver.getMainEncoderRolePreference();
         if (AkaiFireOikontrolExtension.MAIN_ENCODER_TEMPO_ROLE.equals(mainEncoderRole)) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/PitchedSurfaceLayer.java
@@ -2423,6 +2423,9 @@ public abstract class PitchedSurfaceLayer extends Layer implements StepSequencer
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         if (!noteStepActive && noteRepeatHandler.getNoteRepeatActive().get()) {
             // While transient live note repeat is active, keep SELECT dedicated to repeat-rate edits.
             // Turning through the minimum rate should not drop straight into the underlying encoder role.

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -113,7 +113,12 @@ public class PerformClipLauncherMode extends Layer {
     private int selectedSceneIndex = -1;
     private int selectedSceneActionIndex = -1;
     private int pendingSceneLaunchIndex = -1;
+    private int manualRecordingTrackIndex = -1;
+    private int manualRecordingSceneIndex = -1;
     private boolean mainEncoderPressConsumed = false;
+    private boolean manualRecordingPending = false;
+    private boolean manualRecordingWasRecording = false;
+    private boolean manualRecordingShouldRound = false;
     private boolean trackActionMode = false;
     private boolean sceneActionMode = false;
     private PerformLayout layout = PerformLayout.vertical();
@@ -219,6 +224,7 @@ public class PerformClipLauncherMode extends Layer {
                         selectedSceneIndex = trackBank.sceneBank().scrollPosition().get() + row;
                     }
                 });
+                slot.isRecording().addValueObserver(recording -> handleSlotRecordingChanged(column, row, recording));
                 slotColors[slotIndex] = ColorLookup.getColor(slot.color().get());
             }
         }
@@ -638,6 +644,12 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
 
+        if (slot.isRecording().get()) {
+            slot.launch();
+            oled.valueInfo("Clip Record", slotLabel(absoluteTrackIndex, absoluteSceneIndex));
+            return;
+        }
+
         if (hasContent) {
             slot.launch();
             oled.valueInfo("Launch Clip", slotLabel(absoluteTrackIndex, absoluteSceneIndex));
@@ -654,9 +666,90 @@ public class PerformClipLauncherMode extends Layer {
         driver.consumePerformRecordPadGesture();
         track.selectInMixer();
         slot.select();
-        driver.prepareFixedLengthLauncherRecording();
+        if (driver.shouldDisableLauncherPostRecordingAction() || driver.shouldRoundLauncherRecordingToNearestBar()) {
+            armManualRecording(absoluteTrackIndex, absoluteSceneIndex, driver.shouldRoundLauncherRecordingToNearestBar());
+        }
+        driver.prepareLauncherRecording();
         slot.record();
         oled.valueInfo("Record Clip", slotLabel(absoluteTrackIndex, absoluteSceneIndex));
+    }
+
+    private void armManualRecording(final int absoluteTrackIndex, final int absoluteSceneIndex, final boolean shouldRound) {
+        manualRecordingPending = true;
+        manualRecordingWasRecording = false;
+        manualRecordingShouldRound = shouldRound;
+        manualRecordingTrackIndex = absoluteTrackIndex;
+        manualRecordingSceneIndex = absoluteSceneIndex;
+    }
+
+    public boolean stopManualLauncherRecordingIfAny() {
+        if (!manualRecordingPending) {
+            return false;
+        }
+        final int visibleTrackIndex = manualRecordingTrackIndex - trackBank.scrollPosition().get();
+        final int visibleSceneIndex = manualRecordingSceneIndex - trackBank.sceneBank().scrollPosition().get();
+        if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
+                || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
+            oled.valueInfo("Clip Record", "Target off page");
+            return true;
+        }
+        final Track track = trackBank.getItemAt(visibleTrackIndex);
+        final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+        track.selectInMixer();
+        slot.select();
+        slot.launch();
+        oled.valueInfo("Clip Record", slotLabel(manualRecordingTrackIndex, manualRecordingSceneIndex));
+        return true;
+    }
+
+    private void handleSlotRecordingChanged(final int visibleTrackIndex, final int visibleSceneIndex,
+                                            final boolean recording) {
+        if (!manualRecordingPending) {
+            return;
+        }
+        final int absoluteTrackIndex = trackBank.scrollPosition().get() + visibleTrackIndex;
+        final int absoluteSceneIndex = trackBank.sceneBank().scrollPosition().get() + visibleSceneIndex;
+        if (absoluteTrackIndex != manualRecordingTrackIndex || absoluteSceneIndex != manualRecordingSceneIndex) {
+            return;
+        }
+        if (recording) {
+            manualRecordingWasRecording = true;
+            return;
+        }
+        if (!manualRecordingWasRecording) {
+            return;
+        }
+
+        manualRecordingPending = false;
+        manualRecordingWasRecording = false;
+        if (manualRecordingShouldRound) {
+            roundRecordedClipLength(absoluteTrackIndex, absoluteSceneIndex);
+        }
+    }
+
+    private void roundRecordedClipLength(final int absoluteTrackIndex, final int absoluteSceneIndex) {
+        driver.getHost().scheduleTask(() -> {
+            final int visibleTrackIndex = absoluteTrackIndex - trackBank.scrollPosition().get();
+            final int visibleSceneIndex = absoluteSceneIndex - trackBank.sceneBank().scrollPosition().get();
+            if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
+                    || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
+                oled.valueInfo("Round Clip", "Target off page");
+                return;
+            }
+            final Track track = trackBank.getItemAt(visibleTrackIndex);
+            final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+            track.selectInMixer();
+            slot.select();
+            driver.getHost().scheduleTask(() -> {
+                final double currentLength = performCursorClip.getLoopLength().get();
+                final double roundedLength = roundToNearestBar(
+                        currentLength,
+                        driver.getTransportTimeSignatureNumerator(),
+                        driver.getTransportTimeSignatureDenominator());
+                performCursorClip.getLoopLength().set(roundedLength);
+                oled.valueInfo("Round Clip", formatBars(roundedLength));
+            }, 1);
+        }, 50);
     }
 
     private void handleDuplicatePressed(final boolean pressed) {
@@ -1058,6 +1151,16 @@ public class PerformClipLauncherMode extends Layer {
 
     static int remoteParameterIndex(final int encoderIndex, final boolean altHeld) {
         return (altHeld ? 4 : 0) + encoderIndex;
+    }
+
+    static double roundToNearestBar(final double beatLength, final int meterNumerator, final int meterDenominator) {
+        final int numerator = Math.max(1, meterNumerator);
+        final int denominator = Math.max(1, meterDenominator);
+        final double barLength = numerator * (4.0 / denominator);
+        if (Double.isNaN(beatLength) || Double.isInfinite(beatLength) || beatLength <= 0) {
+            return barLength;
+        }
+        return Math.max(barLength, Math.round(beatLength / barLength) * barLength);
     }
 
     static int remotePageIndexAfterTurn(final int currentPage, final int pageCount, final int inc) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -16,6 +16,7 @@ import com.bitwig.extensions.framework.Layer;
 import com.bitwig.extensions.framework.values.BooleanValueObject;
 import com.oikoaudio.fire.AkaiFireOikontrolExtension;
 import com.oikoaudio.fire.ColorLookup;
+import com.oikoaudio.fire.FireControlPreferences;
 import com.oikoaudio.fire.NoteAssign;
 import com.oikoaudio.fire.SharedMusicalContext;
 import com.oikoaudio.fire.control.BiColorButton;
@@ -127,6 +128,9 @@ public class PerformClipLauncherMode extends Layer {
         super(driver.getLayers(), "PERFORM_CLIP_LAUNCHER");
         this.driver = driver;
         this.sharedMusicalContext = driver.getSharedMusicalContext();
+        this.layout = FireControlPreferences.PERFORM_LAYOUT_HORIZONTAL.equals(driver.getPerformClipLauncherLayoutPreference())
+                ? PerformLayout.horizontal()
+                : PerformLayout.vertical();
         final ControllerHost host = driver.getHost();
         this.oled = driver.getOled();
         this.trackBank = host.createTrackBank(MAX_TRACKS, 0, MAX_SCENES);

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -130,6 +130,7 @@ public class PerformClipLauncherMode extends Layer {
         final ControllerHost host = driver.getHost();
         this.oled = driver.getOled();
         this.trackBank = host.createTrackBank(MAX_TRACKS, 0, MAX_SCENES);
+        setTrackBankFlatteningMode(host, trackBank, "FLATTEN");
         this.cursorTrack = driver.getViewControl().getCursorTrack();
         this.project = host.getProject();
         this.projectRemoteControls = project.getRootTrackGroup().createCursorRemoteControlsPage(8);
@@ -1507,6 +1508,22 @@ public class PerformClipLauncherMode extends Layer {
 
     private int toSlotIndex(final int trackIndex, final int sceneIndex) {
         return sceneIndex * MAX_TRACKS + trackIndex;
+    }
+
+    private static void setTrackBankFlatteningMode(final ControllerHost host, final TrackBank trackBank,
+                                                   final String modeName) {
+        if (host.getHostApiVersion() < 25) {
+            return;
+        }
+
+        try {
+            final Class<?> modeClass = Class.forName("com.bitwig.extension.controller.api.TrackBankFlatteningMode");
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            final Object mode = Enum.valueOf((Class<Enum>) modeClass.asSubclass(Enum.class), modeName);
+            trackBank.getClass().getMethod("setFlatteningMode", modeClass).invoke(trackBank, mode);
+        } catch (final ReflectiveOperationException | IllegalArgumentException e) {
+            host.errorln("Unable to set Akai Fire Perform track-bank flattening mode: " + e.getMessage());
+        }
     }
 
     private static int clamp(final int value, final int min, final int max) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -766,6 +766,9 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         if (isAltHeld()) {
             handleRemotePageNavigation(inc);
             return;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -130,7 +130,6 @@ public class PerformClipLauncherMode extends Layer {
         final ControllerHost host = driver.getHost();
         this.oled = driver.getOled();
         this.trackBank = host.createTrackBank(MAX_TRACKS, 0, MAX_SCENES);
-        setTrackBankFlatteningMode(host, trackBank, "FLATTEN");
         this.cursorTrack = driver.getViewControl().getCursorTrack();
         this.project = host.getProject();
         this.projectRemoteControls = project.getRootTrackGroup().createCursorRemoteControlsPage(8);
@@ -187,6 +186,7 @@ public class PerformClipLauncherMode extends Layer {
             track.arm().markInterested();
             track.mute().markInterested();
             track.solo().markInterested();
+            track.isActivated().markInterested();
             track.isStopped().markInterested();
             track.isQueuedForStop().markInterested();
             final int column = trackIndex;
@@ -503,7 +503,10 @@ public class PerformClipLauncherMode extends Layer {
                 || visibleSceneIndex >= visibleSceneCount()) {
             return;
         }
-        final Track track = trackBank.getItemAt(visibleTrackIndex);
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        if (track == null) {
+            return;
+        }
         final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
         handleSlotPressed(track, slot, visibleTrackIndex, visibleSceneIndex, pressed);
     }
@@ -517,11 +520,12 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
         final int visibleTrackIndex = padIndex % PerformLayout.PAD_COLUMNS;
-        final Track track = trackBank.getItemAt(visibleTrackIndex);
-        if (track == null || !track.exists().get()) {
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        final Track track = sourceTrackIndex >= 0 ? trackBank.getItemAt(sourceTrackIndex) : null;
+        if (track == null) {
             return;
         }
-        final int absoluteTrackIndex = trackBank.scrollPosition().get() + visibleTrackIndex;
+        final int absoluteTrackIndex = trackBank.scrollPosition().get() + sourceTrackIndex;
         final String trackLabel = trackLabel(absoluteTrackIndex, visibleTrackIndex);
         track.selectInMixer();
         switch (actionRow) {
@@ -606,7 +610,11 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
 
-        final int absoluteTrackIndex = trackBank.scrollPosition().get() + visibleTrackIndex;
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        if (sourceTrackIndex < 0) {
+            return;
+        }
+        final int absoluteTrackIndex = trackBank.scrollPosition().get() + sourceTrackIndex;
         final int absoluteSceneIndex = trackBank.sceneBank().scrollPosition().get() + visibleSceneIndex;
         final boolean hasContent = slot.hasContent().get();
 
@@ -687,14 +695,18 @@ public class PerformClipLauncherMode extends Layer {
         if (!manualRecordingPending) {
             return false;
         }
-        final int visibleTrackIndex = manualRecordingTrackIndex - trackBank.scrollPosition().get();
+        final int visibleTrackIndex = visibleTrackIndexForSourceTrack(manualRecordingTrackIndex - trackBank.scrollPosition().get());
         final int visibleSceneIndex = manualRecordingSceneIndex - trackBank.sceneBank().scrollPosition().get();
         if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
                 || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
             oled.valueInfo("Clip Record", "Target off page");
             return true;
         }
-        final Track track = trackBank.getItemAt(visibleTrackIndex);
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        if (track == null) {
+            oled.valueInfo("Clip Record", "Target off page");
+            return true;
+        }
         final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
         track.selectInMixer();
         slot.select();
@@ -730,14 +742,18 @@ public class PerformClipLauncherMode extends Layer {
 
     private void roundRecordedClipLength(final int absoluteTrackIndex, final int absoluteSceneIndex) {
         driver.getHost().scheduleTask(() -> {
-            final int visibleTrackIndex = absoluteTrackIndex - trackBank.scrollPosition().get();
+            final int visibleTrackIndex = visibleTrackIndexForSourceTrack(absoluteTrackIndex - trackBank.scrollPosition().get());
             final int visibleSceneIndex = absoluteSceneIndex - trackBank.sceneBank().scrollPosition().get();
             if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
                     || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
                 oled.valueInfo("Round Clip", "Target off page");
                 return;
             }
-            final Track track = trackBank.getItemAt(visibleTrackIndex);
+            final Track track = trackForVisibleTrack(visibleTrackIndex);
+            if (track == null) {
+                oled.valueInfo("Round Clip", "Target off page");
+                return;
+            }
             final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
             track.selectInMixer();
             slot.select();
@@ -768,7 +784,7 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
 
-        final int visibleTrackIndex = selectedTrackIndex - trackBank.scrollPosition().get();
+        final int visibleTrackIndex = visibleTrackIndexForSourceTrack(selectedTrackIndex - trackBank.scrollPosition().get());
         final int visibleSceneIndex = selectedSceneIndex - trackBank.sceneBank().scrollPosition().get();
         if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
                 || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
@@ -776,7 +792,11 @@ public class PerformClipLauncherMode extends Layer {
             return;
         }
 
-        final Track track = trackBank.getItemAt(visibleTrackIndex);
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        if (track == null) {
+            oled.valueInfo("Duplicate Clip", "Selected clip off page");
+            return;
+        }
         track.selectInMixer();
         slot.select();
         driver.getHost().scheduleTask(() -> {
@@ -1218,13 +1238,14 @@ public class PerformClipLauncherMode extends Layer {
         }
         final int trackOffset = trackBank.scrollPosition().get();
         final int sceneOffset = trackBank.sceneBank().scrollPosition().get();
-        final int visibleTrackIndex = selectedTrackIndex - trackOffset;
+        final int visibleTrackIndex = visibleTrackIndexForSourceTrack(selectedTrackIndex - trackOffset);
         final int visibleSceneIndex = selectedSceneIndex - sceneOffset;
         if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()
                 || visibleSceneIndex < 0 || visibleSceneIndex >= visibleSceneCount()) {
             return null;
         }
-        return trackBank.getItemAt(visibleTrackIndex).clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        return track != null ? track.clipLauncherSlotBank().getItemAt(visibleSceneIndex) : null;
     }
 
     private int resolveSceneCopySource() {
@@ -1249,7 +1270,7 @@ public class PerformClipLauncherMode extends Layer {
     private boolean sceneHasPlayingClip(final int visibleSceneIndex) {
         for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
             final Track track = trackBank.getItemAt(trackIndex);
-            if (track.exists().get() && track.clipLauncherSlotBank().getItemAt(visibleSceneIndex).isPlaying().get()) {
+            if (isControllableTrack(track) && track.clipLauncherSlotBank().getItemAt(visibleSceneIndex).isPlaying().get()) {
                 return true;
             }
         }
@@ -1259,7 +1280,7 @@ public class PerformClipLauncherMode extends Layer {
     private boolean sceneHasRecordingClip(final int visibleSceneIndex) {
         for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
             final Track track = trackBank.getItemAt(trackIndex);
-            if (track.exists().get() && track.clipLauncherSlotBank().getItemAt(visibleSceneIndex).isRecording().get()) {
+            if (isControllableTrack(track) && track.clipLauncherSlotBank().getItemAt(visibleSceneIndex).isRecording().get()) {
                 return true;
             }
         }
@@ -1318,7 +1339,11 @@ public class PerformClipLauncherMode extends Layer {
                 || visibleSceneIndex >= visibleSceneCount()) {
             return RgbLigthState.OFF;
         }
-        final ClipLauncherSlot slot = trackBank.getItemAt(visibleTrackIndex).clipLauncherSlotBank().getItemAt(visibleSceneIndex);
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        if (track == null) {
+            return RgbLigthState.OFF;
+        }
+        final ClipLauncherSlot slot = track.clipLauncherSlotBank().getItemAt(visibleSceneIndex);
         return getSlotState(slot, visibleTrackIndex, visibleSceneIndex);
     }
 
@@ -1362,9 +1387,11 @@ public class PerformClipLauncherMode extends Layer {
             return slot.isSelected().get() ? RgbLigthState.GRAY_2 : RgbLigthState.GRAY_1;
         }
 
-        final RgbLigthState baseColor = slotColors[toSlotIndex(visibleTrackIndex, visibleSceneIndex)] == null
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        final int slotColorIndex = sourceTrackIndex >= 0 ? toSlotIndex(sourceTrackIndex, visibleSceneIndex) : -1;
+        final RgbLigthState baseColor = slotColorIndex < 0 || slotColors[slotColorIndex] == null
                 ? RgbLigthState.WHITE
-                : slotColors[toSlotIndex(visibleTrackIndex, visibleSceneIndex)];
+                : slotColors[slotColorIndex];
         if (slot.isRecording().get()) {
             return blinkFast(baseColor.getBrightest(), baseColor);
         }
@@ -1394,8 +1421,8 @@ public class PerformClipLauncherMode extends Layer {
             return RgbLigthState.OFF;
         }
         final int visibleTrackIndex = padIndex % PerformLayout.PAD_COLUMNS;
-        final Track track = trackBank.getItemAt(visibleTrackIndex);
-        if (track == null || !track.exists().get()) {
+        final Track track = trackForVisibleTrack(visibleTrackIndex);
+        if (track == null) {
             return RgbLigthState.OFF;
         }
         final RgbLigthState baseColor = actionRow.color;
@@ -1415,9 +1442,8 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private boolean isVisibleTrackSelected(final int visibleTrackIndex) {
-        return visibleTrackIndex >= 0
-                && visibleTrackIndex < selectedVisibleTracks.length
-                && selectedVisibleTracks[visibleTrackIndex];
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        return sourceTrackIndex >= 0 && selectedVisibleTracks[sourceTrackIndex];
     }
 
     private RgbLigthState settingsLogoState(final int padIndex) {
@@ -1438,10 +1464,11 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private String slotLabel(final int absoluteTrackIndex, final int absoluteSceneIndex) {
-        final int visibleTrackIndex = absoluteTrackIndex - trackBank.scrollPosition().get();
+        final int visibleTrackIndex = visibleTrackIndexForSourceTrack(absoluteTrackIndex - trackBank.scrollPosition().get());
         final int visibleSceneIndex = absoluteSceneIndex - trackBank.sceneBank().scrollPosition().get();
-        final String trackName = visibleTrackIndex >= 0 && visibleTrackIndex < MAX_TRACKS
-                ? nameOrFallback(trackNames[visibleTrackIndex], "Track " + (absoluteTrackIndex + 1))
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        final String trackName = sourceTrackIndex >= 0
+                ? nameOrFallback(trackNames[sourceTrackIndex], "Track " + (absoluteTrackIndex + 1))
                 : "Track " + (absoluteTrackIndex + 1);
         final String sceneName = visibleSceneIndex >= 0 && visibleSceneIndex < MAX_SCENES
                 ? nameOrFallback(sceneNames[visibleSceneIndex], "Scene " + (absoluteSceneIndex + 1))
@@ -1463,8 +1490,9 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private String trackLabel(final int absoluteTrackIndex, final int visibleTrackIndex) {
-        return visibleTrackIndex >= 0 && visibleTrackIndex < MAX_TRACKS
-                ? nameOrFallback(trackNames[visibleTrackIndex], "Track " + (absoluteTrackIndex + 1))
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        return sourceTrackIndex >= 0
+                ? nameOrFallback(trackNames[sourceTrackIndex], "Track " + (absoluteTrackIndex + 1))
                 : "Track " + (absoluteTrackIndex + 1);
     }
 
@@ -1510,20 +1538,47 @@ public class PerformClipLauncherMode extends Layer {
         return sceneIndex * MAX_TRACKS + trackIndex;
     }
 
-    private static void setTrackBankFlatteningMode(final ControllerHost host, final TrackBank trackBank,
-                                                   final String modeName) {
-        if (host.getHostApiVersion() < 25) {
-            return;
-        }
+    private Track trackForVisibleTrack(final int visibleTrackIndex) {
+        final int sourceTrackIndex = sourceTrackIndexForVisibleTrack(visibleTrackIndex);
+        return sourceTrackIndex >= 0 ? trackBank.getItemAt(sourceTrackIndex) : null;
+    }
 
-        try {
-            final Class<?> modeClass = Class.forName("com.bitwig.extension.controller.api.TrackBankFlatteningMode");
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            final Object mode = Enum.valueOf((Class<Enum>) modeClass.asSubclass(Enum.class), modeName);
-            trackBank.getClass().getMethod("setFlatteningMode", modeClass).invoke(trackBank, mode);
-        } catch (final ReflectiveOperationException | IllegalArgumentException e) {
-            host.errorln("Unable to set Akai Fire Perform track-bank flattening mode: " + e.getMessage());
+    private int sourceTrackIndexForVisibleTrack(final int visibleTrackIndex) {
+        if (visibleTrackIndex < 0 || visibleTrackIndex >= visibleTrackCount()) {
+            return -1;
         }
+        int visible = 0;
+        for (int sourceTrackIndex = 0; sourceTrackIndex < MAX_TRACKS; sourceTrackIndex++) {
+            final Track track = trackBank.getItemAt(sourceTrackIndex);
+            if (isControllableTrack(track)) {
+                if (visible == visibleTrackIndex) {
+                    return sourceTrackIndex;
+                }
+                visible++;
+            }
+        }
+        return -1;
+    }
+
+    private int visibleTrackIndexForSourceTrack(final int sourceTrackIndex) {
+        if (sourceTrackIndex < 0 || sourceTrackIndex >= MAX_TRACKS) {
+            return -1;
+        }
+        int visible = 0;
+        for (int candidate = 0; candidate < MAX_TRACKS; candidate++) {
+            final Track track = trackBank.getItemAt(candidate);
+            if (isControllableTrack(track)) {
+                if (candidate == sourceTrackIndex) {
+                    return visible;
+                }
+                visible++;
+            }
+        }
+        return -1;
+    }
+
+    private boolean isControllableTrack(final Track track) {
+        return track != null && track.exists().get() && (driver.showDeactivatedTracks() || track.isActivated().get());
     }
 
     private static int clamp(final int value, final int min, final int max) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformLayout.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformLayout.java
@@ -14,6 +14,10 @@ final class PerformLayout {
         return new PerformLayout(Orientation.VERTICAL);
     }
 
+    static PerformLayout horizontal() {
+        return new PerformLayout(Orientation.HORIZONTAL);
+    }
+
     PerformLayout toggle() {
         return new PerformLayout(orientation == Orientation.VERTICAL ? Orientation.HORIZONTAL : Orientation.VERTICAL);
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -202,7 +202,6 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
     private void observingNotes(int x, int y, int state) {
 
 
-        host.println("Observing note: x=" + x + ", y=" + y + ", stat=" + state);
         // Get or create the inner map for step x.
         Map<Integer, Integer> stepNotes = currentNotesInClip.get(x);
         if (stepNotes == null) {
@@ -211,10 +210,8 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
         }
         if (state == State.Empty.ordinal()) {
             stepNotes.remove(y);
-            host.println("Removed note at x=" + x + ", y=" + y);
         } else {
             stepNotes.put(y, state);
-            host.println("Stored note at x=" + x + ", y=" + y + ", stat=" + state);
         }
     }
 

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/sequence/DrumSequenceMode.java
@@ -599,6 +599,9 @@ public class DrumSequenceMode extends Layer implements StepSequencerHost, SeqCli
             return;
         }
         driver.markMainEncoderTurned();
+        if (driver.handleMainEncoderGlobalChord(inc)) {
+            return;
+        }
         final String mainEncoderRole = getEffectiveMainEncoderRole();
         final boolean fine = isShiftHeld();
         if (FireControlPreferences.MAIN_ENCODER_NOTE_REPEAT.equals(mainEncoderRole)) {

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -227,6 +227,7 @@
           <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
+      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -458,6 +458,7 @@
       <p>For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.</p>
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using <code>Default Clip Length</code>, then launch.</p>
+      <p><code>Perform Clip Launcher Layout</code> chooses whether the mode starts as <code>PerformV</code> or <code>PerformH</code>. <code>ALT + PERFORM</code> still toggles the layout for the current session.</p>
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
@@ -502,6 +503,7 @@
       <ul>
         <li><code>Clip Launch Mode</code></li>
         <li><code>Clip Launch Quantization</code></li>
+        <li><code>Perform Clip Launcher Layout</code></li>
         <li><code>Default Clip Length</code></li>
         <li><code>SELECT Encoder Startup</code></li>
         <li><code>Default Root Key</code></li>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -224,7 +224,7 @@
           <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
           <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
           <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
       <h3>Main SELECT encoder</h3>
@@ -477,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. For fixed <code>Default Clip Length</code> values, the script sets Bitwig's clip launcher post-record action to play the recorded clip after that length. If <code>Default Clip Length</code> is set to <code>Off</code>, recording continues until manually stopped without post-processing. If it is set to <code>Round</code>, recording continues until manually stopped, then the recorded clip loop length is rounded to the nearest whole bar. Press <code>REC</code> again to end an <code>Off</code> or <code>Round</code> launcher recording and launch the recorded clip, even after switching to another mode. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -210,12 +210,23 @@
           <tr><td><code>SHIFT + PATTERN</code></td><td>Metronome</td></tr>
           <tr><td><code>ALT + PATTERN</code></td><td>Clip launcher overdub</td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global pitch settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
+      <h3>Global settings overlay</h3>
+      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <table>
+        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <tbody>
+          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
+          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
+          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
+          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+      </tbody>
+      </table>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -466,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -218,6 +218,16 @@
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
+      <p>Global <code>SELECT</code> turn chords:</p>
+      <table>
+        <thead><tr><th>Control</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
+          <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
+          <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
+          <tr><td>Hold <code>SHIFT + ALT</code> + turn <code>SELECT</code></td><td>Zoom arranger/detail lanes vertically</td></tr>
+      </tbody>
+      </table>
       <table>
         <thead><tr><th>Role</th><th>Turn</th><th>Press / hold behavior</th></tr></thead>
         <tbody>
@@ -459,7 +469,7 @@
       <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
-      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page. Hold <code>ALT</code> and turn <code>SELECT</code> to change the remote page for the active remote encoder page: project remotes on <code>Channel</code>, track remotes on <code>User 1</code>, and device remotes on <code>User 2</code>. This applies in both vertical and horizontal perform layouts.</p>
+      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>
       <table>
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
@@ -104,6 +104,8 @@ class FireControlPreferencesTest {
 
     @Test
     void normalizesDefaultClipLengthPreferenceValues() {
+        assertEquals(FireControlPreferences.CLIP_LENGTH_OFF,
+                FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_OFF));
         assertEquals(FireControlPreferences.CLIP_LENGTH_1_BAR,
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_1_BAR));
         assertEquals(FireControlPreferences.CLIP_LENGTH_2_BARS,
@@ -112,12 +114,19 @@ class FireControlPreferencesTest {
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_4_BARS));
         assertEquals(FireControlPreferences.CLIP_LENGTH_8_BARS,
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_8_BARS));
+        assertEquals(FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR,
+                FireControlPreferences.normalizeDefaultClipLength(
+                        FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR));
+        assertEquals(FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR,
+                FireControlPreferences.normalizeDefaultClipLength("Round to nearest bar"));
         assertEquals(FireControlPreferences.CLIP_LENGTH_2_BARS,
                 FireControlPreferences.normalizeDefaultClipLength("unexpected"));
     }
 
     @Test
     void mapsDefaultClipLengthPreferenceToBeats() {
+        assertEquals(8.0,
+                FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_OFF));
         assertEquals(4.0,
                 FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_1_BAR));
         assertEquals(8.0,
@@ -126,7 +135,30 @@ class FireControlPreferencesTest {
                 FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_4_BARS));
         assertEquals(32.0,
                 FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_8_BARS));
+        assertEquals(8.0,
+                FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR));
         assertEquals(8.0, FireControlPreferences.toClipLengthBeats("unexpected"));
+    }
+
+    @Test
+    void detectsRoundToNearestBarClipLengthPreference() {
+        assertEquals(true,
+                FireControlPreferences.isRoundToNearestBarClipLength(
+                        FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR));
+        assertEquals(true,
+                FireControlPreferences.isRoundToNearestBarClipLength("Round to nearest bar"));
+        assertEquals(false,
+                FireControlPreferences.isRoundToNearestBarClipLength(FireControlPreferences.CLIP_LENGTH_2_BARS));
+        assertEquals(false, FireControlPreferences.isRoundToNearestBarClipLength("unexpected"));
+    }
+
+    @Test
+    void detectsOffClipLengthPreference() {
+        assertEquals(true,
+                FireControlPreferences.isOffClipLength(FireControlPreferences.CLIP_LENGTH_OFF));
+        assertEquals(false,
+                FireControlPreferences.isOffClipLength(FireControlPreferences.CLIP_LENGTH_ROUND_NEAREST_BAR));
+        assertEquals(false, FireControlPreferences.isOffClipLength("unexpected"));
     }
 
     @Test

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
@@ -103,6 +103,16 @@ class FireControlPreferencesTest {
     }
 
     @Test
+    void normalizesPerformClipLauncherLayoutPreferenceValues() {
+        assertEquals(FireControlPreferences.PERFORM_LAYOUT_VERTICAL,
+                FireControlPreferences.normalizePerformLayout(FireControlPreferences.PERFORM_LAYOUT_VERTICAL));
+        assertEquals(FireControlPreferences.PERFORM_LAYOUT_HORIZONTAL,
+                FireControlPreferences.normalizePerformLayout(FireControlPreferences.PERFORM_LAYOUT_HORIZONTAL));
+        assertEquals(FireControlPreferences.PERFORM_LAYOUT_VERTICAL,
+                FireControlPreferences.normalizePerformLayout("unexpected"));
+    }
+
+    @Test
     void normalizesDefaultClipLengthPreferenceValues() {
         assertEquals(FireControlPreferences.CLIP_LENGTH_OFF,
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_OFF));

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
@@ -59,6 +59,16 @@ class FireControlPreferencesTest {
     }
 
     @Test
+    void skipsDrumGridWhenCyclingAlternateMainEncoderRolesOutsideDrumMode() {
+        assertEquals(FireControlPreferences.MAIN_ENCODER_SHUFFLE,
+                FireControlPreferences.nextAlternateMainEncoderRole(
+                        FireControlPreferences.MAIN_ENCODER_TRACK_SELECT, false));
+        assertEquals(FireControlPreferences.MAIN_ENCODER_SHUFFLE,
+                FireControlPreferences.nextAlternateMainEncoderRole(
+                        FireControlPreferences.MAIN_ENCODER_DRUM_GRID, false));
+    }
+
+    @Test
     void normalizesMainEncoderStartupStatePreferenceValues() {
         assertEquals(FireControlPreferences.MAIN_ENCODER_STARTUP_LAST_TOUCHED,
                 FireControlPreferences.normalizeMainEncoderStartupState(

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
@@ -110,6 +110,8 @@ class FireControlPreferencesTest {
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_2_BARS));
         assertEquals(FireControlPreferences.CLIP_LENGTH_4_BARS,
                 FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_4_BARS));
+        assertEquals(FireControlPreferences.CLIP_LENGTH_8_BARS,
+                FireControlPreferences.normalizeDefaultClipLength(FireControlPreferences.CLIP_LENGTH_8_BARS));
         assertEquals(FireControlPreferences.CLIP_LENGTH_2_BARS,
                 FireControlPreferences.normalizeDefaultClipLength("unexpected"));
     }
@@ -122,6 +124,8 @@ class FireControlPreferencesTest {
                 FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_2_BARS));
         assertEquals(16.0,
                 FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_4_BARS));
+        assertEquals(32.0,
+                FireControlPreferences.toClipLengthBeats(FireControlPreferences.CLIP_LENGTH_8_BARS));
         assertEquals(8.0, FireControlPreferences.toClipLengthBeats("unexpected"));
     }
 

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/perform/PerformClipRecordingLengthTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/perform/PerformClipRecordingLengthTest.java
@@ -1,0 +1,30 @@
+package com.oikoaudio.fire.perform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PerformClipRecordingLengthTest {
+
+    @Test
+    void roundsSlightlyLateFourFourRecordingsDownToThePreviousBar() {
+        assertEquals(16.0, PerformClipLauncherMode.roundToNearestBar(16.1, 4, 4));
+    }
+
+    @Test
+    void roundsFourFourRecordingsToTheNearestBar() {
+        assertEquals(20.0, PerformClipLauncherMode.roundToNearestBar(18.5, 4, 4));
+        assertEquals(16.0, PerformClipLauncherMode.roundToNearestBar(17.4, 4, 4));
+    }
+
+    @Test
+    void respectsTransportMeterWhenRounding() {
+        assertEquals(9.0, PerformClipLauncherMode.roundToNearestBar(7.6, 6, 8));
+    }
+
+    @Test
+    void keepsRoundedLengthAtLeastOneBar() {
+        assertEquals(4.0, PerformClipLauncherMode.roundToNearestBar(0.3, 4, 4));
+        assertEquals(3.0, PerformClipLauncherMode.roundToNearestBar(Double.NaN, 6, 8));
+    }
+}

--- a/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtension.java
+++ b/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtension.java
@@ -26,6 +26,7 @@ import com.bitwig.extension.controller.api.RemoteControl;
 import com.bitwig.extension.controller.api.RemoteControlsPage;
 import com.bitwig.extension.controller.api.SendBank;
 import com.bitwig.extension.controller.api.SettableBooleanValue;
+import com.bitwig.extension.controller.api.SettableRangedValue;
 import com.bitwig.extension.controller.api.Track;
 import com.bitwig.extension.controller.api.TrackBank;
 import com.bitwig.extensions.controllers.novation.launch_control_xl.drum.DrumLedRenderer;
@@ -65,6 +66,8 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
    static final int[] TRACK_CONTROL_NOTES = {73, 74, 75, 76, 89, 90, 91, 92};
    static final int[] KNOB_CC_OFFSETS = {13, 29, 49};
    static final int SLIDER_CC_BASE = 77;
+   private static final int STRIP_COUNT = 8;
+   private static final int TRACK_BANK_WIDTH = 32;
    private static final int SEND_UP_CC = 104;
    private static final int SEND_DOWN_CC = 105;
    private static final int TRACK_LEFT_CC = 106;
@@ -126,6 +129,19 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       RecordArm
    }
 
+   enum TrackBooleanTarget
+   {
+      MUTE,
+      SOLO,
+      ARM
+   }
+
+   enum TrackValueTarget
+   {
+      VOLUME,
+      PAN
+   }
+
    public LaunchControlXlControllerExtension(
       final LaunchControlXlControllerExtensionDefinition definition,
       final ControllerHost host)
@@ -182,14 +198,13 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
          markParameterInterested(mProjectRemoteControlsCursor.getParameter(i));
       }
 
-      mTrackBank = mHost.createMainTrackBank(8, 3, 0);
-      setTrackBankFlatteningMode(mTrackBank, "FLATTEN");
+      mTrackBank = mHost.createMainTrackBank(TRACK_BANK_WIDTH, 3, 0);
       mTrackBank.followCursorTrack(mCursorTrack);
       mTrackBank.canScrollBackwards().markInterested();
       mTrackBank.canScrollForwards().markInterested();
 
       mTrackBank.cursorIndex().markInterested();
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < TRACK_BANK_WIDTH; ++i)
       {
          final Track track = mTrackBank.getItemAt(i);
          track.solo().markInterested();
@@ -197,6 +212,7 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
          track.mute().markInterested();
          track.volume().markInterested();
          track.exists().markInterested();
+         track.isActivated().markInterested();
 
          final SendBank sendBank = track.sendBank();
          sendBank.canScrollBackwards().markInterested();
@@ -461,20 +477,20 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       final Layers layers = new Layers(this);
       mMainLayer = new Layer(layers, "Main");
 
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final Track track = mTrackBank.getItemAt(i);
-         mMainLayer.bind(mHardwareSliders[i], track.volume());
-         mMainLayer.bindPressed(mBtTrackFocus[i], () -> mCursorTrack.selectChannel(track));
+         final int stripIndex = i;
+         mMainLayer.bind(mHardwareSliders[i], value -> setTrackValue(stripIndex, TrackValueTarget.VOLUME, value));
+         mMainLayer.bindPressed(mBtTrackFocus[i], () -> selectTrackStrip(stripIndex));
       }
 
       mMainLayer.bindPressed(mBtSendUp, () -> {
-         for (int i = 0; i < 8; ++i)
-            mTrackBank.getItemAt(i).sendBank().scrollBackwards();
+         for (int i = 0; i < STRIP_COUNT; ++i)
+            scrollSendBank(i, -1);
       });
       mMainLayer.bindPressed(mBtSendDown, () -> {
-         for (int i = 0; i < 8; ++i)
-            mTrackBank.getItemAt(i).sendBank().scrollForwards();
+         for (int i = 0; i < STRIP_COUNT; ++i)
+            scrollSendBank(i, 1);
       });
       mMainLayer.bindPressed(mBtTrackLeft, mTrackBank.scrollBackwardsAction());
       mMainLayer.bindPressed(mBtTrackRight, mTrackBank.scrollForwardsAction());
@@ -588,105 +604,107 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
    private void createModeLayers(final Layers layers)
    {
       mSend2FullDeviceLayer = new Layer(layers, "2 Sends Full Device");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final SendBank sendBank = mTrackBank.getItemAt(i).sendBank();
-         mSend2FullDeviceLayer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend2FullDeviceLayer.bind(mHardwareKnobs[8 + i], sendBank.getItemAt(1));
+         final int stripIndex = i;
+         mSend2FullDeviceLayer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend2FullDeviceLayer.bind(mHardwareKnobs[8 + i], value -> setSendValue(stripIndex, 1, value));
          mSend2FullDeviceLayer.bind(mHardwareKnobs[16 + i], mRemoteControls.getParameter(i));
       }
 
       mSend2ProjectLayer = new Layer(layers, "2 Sends and Project Remotes");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final SendBank sendBank = mTrackBank.getItemAt(i).sendBank();
-         mSend2ProjectLayer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend2ProjectLayer.bind(mHardwareKnobs[8 + i], sendBank.getItemAt(1));
+         final int stripIndex = i;
+         mSend2ProjectLayer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend2ProjectLayer.bind(mHardwareKnobs[8 + i], value -> setSendValue(stripIndex, 1, value));
          mSend2ProjectLayer.bind(mHardwareKnobs[16 + i], mProjectRemoteControlsCursor.getParameter(i));
       }
 
       mSend2Device1Layer = new Layer(layers, "2 Sends 1 Device");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final SendBank sendBank = mTrackBank.getItemAt(i).sendBank();
-         mSend2Device1Layer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend2Device1Layer.bind(mHardwareKnobs[8 + i], sendBank.getItemAt(1));
-         mSend2Device1Layer.bind(mHardwareKnobs[16 + i], deviceParam(i, 0));
+         final int stripIndex = i;
+         mSend2Device1Layer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend2Device1Layer.bind(mHardwareKnobs[8 + i], value -> setSendValue(stripIndex, 1, value));
+         mSend2Device1Layer.bind(mHardwareKnobs[16 + i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 0), value));
       }
 
       mSend1Device2Layer = new Layer(layers, "1 Sends 2 Device");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final SendBank sendBank = mTrackBank.getItemAt(i).sendBank();
-         mSend1Device2Layer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend1Device2Layer.bind(mHardwareKnobs[8 + i], deviceParam(i, 0));
-         mSend1Device2Layer.bind(mHardwareKnobs[16 + i], deviceParam(i, 1));
+         final int stripIndex = i;
+         mSend1Device2Layer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend1Device2Layer.bind(mHardwareKnobs[8 + i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 0), value));
+         mSend1Device2Layer.bind(mHardwareKnobs[16 + i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 1), value));
       }
 
       mDevice3Layer = new Layer(layers, "3 Device");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         mDevice3Layer.bind(mHardwareKnobs[i], deviceParam(i, 0));
-         mDevice3Layer.bind(mHardwareKnobs[8 + i], deviceParam(i, 1));
-         mDevice3Layer.bind(mHardwareKnobs[16 + i], deviceParam(i, 2));
+         final int stripIndex = i;
+         mDevice3Layer.bind(mHardwareKnobs[i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 0), value));
+         mDevice3Layer.bind(mHardwareKnobs[8 + i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 1), value));
+         mDevice3Layer.bind(mHardwareKnobs[16 + i], value -> setRemoteValue(deviceParamForStrip(stripIndex, 2), value));
       }
 
       mSend2Pan1Layer = new Layer(layers, "2 Sends 1 Pan");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final Track track = mTrackBank.getItemAt(i);
-         final SendBank sendBank = track.sendBank();
-         mSend2Pan1Layer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend2Pan1Layer.bind(mHardwareKnobs[8 + i], sendBank.getItemAt(1));
-         mSend2Pan1Layer.bind(mHardwareKnobs[16 + i], track.pan());
+         final int stripIndex = i;
+         mSend2Pan1Layer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend2Pan1Layer.bind(mHardwareKnobs[8 + i], value -> setSendValue(stripIndex, 1, value));
+         mSend2Pan1Layer.bind(mHardwareKnobs[16 + i], value -> setTrackValue(stripIndex, TrackValueTarget.PAN, value));
       }
 
       mSend3Layer = new Layer(layers, "3 Sends");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final Track track = mTrackBank.getItemAt(i);
-         final SendBank sendBank = track.sendBank();
-         mSend3Layer.bind(mHardwareKnobs[i], sendBank.getItemAt(0));
-         mSend3Layer.bind(mHardwareKnobs[8 + i], sendBank.getItemAt(1));
-         mSend3Layer.bind(mHardwareKnobs[16 + i], sendBank.getItemAt(2));
+         final int stripIndex = i;
+         mSend3Layer.bind(mHardwareKnobs[i], value -> setSendValue(stripIndex, 0, value));
+         mSend3Layer.bind(mHardwareKnobs[8 + i], value -> setSendValue(stripIndex, 1, value));
+         mSend3Layer.bind(mHardwareKnobs[16 + i], value -> setSendValue(stripIndex, 2, value));
       }
 
       mTrack3layer = new Layer(layers, "3 Track Remotes");
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final CursorRemoteControlsPage remoteControlPage = mTrackRemoteControls[i];
-         mTrack3layer.bind(mHardwareKnobs[i], remoteControlPage.getParameter(0));
-         mTrack3layer.bind(mHardwareKnobs[8 + i], remoteControlPage.getParameter(1));
-         mTrack3layer.bind(mHardwareKnobs[16 + i], remoteControlPage.getParameter(2));
+         final int stripIndex = i;
+         mTrack3layer.bind(mHardwareKnobs[i], value -> setRemoteValue(trackParamForStrip(stripIndex, 0), value));
+         mTrack3layer.bind(mHardwareKnobs[8 + i], value -> setRemoteValue(trackParamForStrip(stripIndex, 1), value));
+         mTrack3layer.bind(mHardwareKnobs[16 + i], value -> setRemoteValue(trackParamForStrip(stripIndex, 2), value));
       }
    }
 
    private void createTrackControlsLayers(final Layers layers)
    {
       mMuteLayer = new Layer(layers, "Mute");
-      for (int i = 0; i < 8; ++i)
-         mMuteLayer.bindToggle(mBtTrackControl[i], mTrackBank.getItemAt(i).mute());
+      for (int i = 0; i < STRIP_COUNT; ++i)
+      {
+         final int stripIndex = i;
+         mMuteLayer.bindPressed(mBtTrackControl[i], () -> toggleTrackBoolean(stripIndex, TrackBooleanTarget.MUTE));
+      }
 
       mSoloLayer = new Layer(layers, "Solo");
-      for (int i = 0; i < 8; ++i)
-         mSoloLayer.bindToggle(mBtTrackControl[i], mTrackBank.getItemAt(i).solo());
+      for (int i = 0; i < STRIP_COUNT; ++i)
+      {
+         final int stripIndex = i;
+         mSoloLayer.bindPressed(mBtTrackControl[i], () -> toggleTrackBoolean(stripIndex, TrackBooleanTarget.SOLO));
+      }
 
       mRecordArmLayer = new Layer(layers, "Record Arm");
-      for (int i = 0; i < 8; ++i)
-         mRecordArmLayer.bindToggle(mBtTrackControl[i], mTrackBank.getItemAt(i).arm());
+      for (int i = 0; i < STRIP_COUNT; ++i)
+      {
+         final int stripIndex = i;
+         mRecordArmLayer.bindPressed(mBtTrackControl[i], () -> toggleTrackBoolean(stripIndex, TrackBooleanTarget.ARM));
+      }
 
       mTrackRemoteButtonLayer = new Layer(layers, "Track Remote Button");
       for (int i = 0; i < 8; ++i)
       {
-         final int I = i;
+         final int stripIndex = i;
          mTrackRemoteButtonLayer.bindPressed(mBtTrackControl[i], () -> {
-            final CursorRemoteControlsPage remotePage = mTrackRemoteControls[I];
-            if (remotePage != null)
-            {
-               final RemoteControl param = remotePage.getParameter(3);
-               final double current = param.value().get();
-               param.value().set(current > 0 ? 0 : 127, 127);
-            }
+            toggleRemoteParameter(trackParamForStrip(stripIndex, 3));
          });
       }
    }
@@ -959,7 +977,129 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       {
          return;
       }
-      param.value().set(value, 127);
+      param.value().set(value);
+   }
+
+   private void setTrackValue(final int stripIndex, final TrackValueTarget target, final double value)
+   {
+      final Track track = trackForStrip(stripIndex);
+      if (track == null)
+      {
+         return;
+      }
+      switch (target)
+      {
+         case VOLUME -> track.volume().set(value);
+         case PAN -> track.pan().set(value);
+      }
+   }
+
+   private void setSendValue(final int stripIndex, final int sendIndex, final double value)
+   {
+      final SendBank sendBank = sendBankForStrip(stripIndex);
+      if (sendBank == null)
+      {
+         return;
+      }
+      final SettableRangedValue send = sendBank.getItemAt(sendIndex).value();
+      if (sendBank.getItemAt(sendIndex).exists().get())
+      {
+         send.set(value);
+      }
+   }
+
+   private void scrollSendBank(final int stripIndex, final int direction)
+   {
+      final SendBank sendBank = sendBankForStrip(stripIndex);
+      if (sendBank == null)
+      {
+         return;
+      }
+      if (direction < 0)
+      {
+         sendBank.scrollBackwards();
+      }
+      else if (direction > 0)
+      {
+         sendBank.scrollForwards();
+      }
+   }
+
+   private void selectTrackStrip(final int stripIndex)
+   {
+      final Track track = trackForStrip(stripIndex);
+      if (track != null)
+      {
+         mCursorTrack.selectChannel(track);
+      }
+   }
+
+   private void toggleTrackBoolean(final int stripIndex, final TrackBooleanTarget target)
+   {
+      final Track track = trackForStrip(stripIndex);
+      if (track == null)
+      {
+         return;
+      }
+      switch (target)
+      {
+         case MUTE -> track.mute().toggle();
+         case SOLO -> track.solo().toggle(false);
+         case ARM -> track.arm().toggle();
+      }
+   }
+
+   private RemoteControl deviceParamForStrip(final int stripIndex, final int paramIndex)
+   {
+      final int sourceTrackIndex = sourceTrackIndexForStrip(stripIndex);
+      return sourceTrackIndex >= 0 ? deviceParam(sourceTrackIndex, paramIndex) : null;
+   }
+
+   private RemoteControl trackParamForStrip(final int stripIndex, final int paramIndex)
+   {
+      final int sourceTrackIndex = sourceTrackIndexForStrip(stripIndex);
+      return sourceTrackIndex >= 0 ? mTrackRemoteControls[sourceTrackIndex].getParameter(paramIndex) : null;
+   }
+
+   private SendBank sendBankForStrip(final int stripIndex)
+   {
+      final Track track = trackForStrip(stripIndex);
+      return track != null ? track.sendBank() : null;
+   }
+
+   private Track trackForStrip(final int stripIndex)
+   {
+      final int sourceTrackIndex = sourceTrackIndexForStrip(stripIndex);
+      return sourceTrackIndex >= 0 ? mTrackBank.getItemAt(sourceTrackIndex) : null;
+   }
+
+   private int sourceTrackIndexForStrip(final int stripIndex)
+   {
+      if (stripIndex < 0 || stripIndex >= STRIP_COUNT)
+      {
+         return -1;
+      }
+      int visible = 0;
+      for (int sourceTrackIndex = 0; sourceTrackIndex < TRACK_BANK_WIDTH; sourceTrackIndex++)
+      {
+         final Track track = mTrackBank.getItemAt(sourceTrackIndex);
+         if (isControllableTrack(track))
+         {
+            if (visible == stripIndex)
+            {
+               return sourceTrackIndex;
+            }
+            visible++;
+         }
+      }
+      return -1;
+   }
+
+   private boolean isControllableTrack(final Track track)
+   {
+      return track != null
+         && track.exists().get()
+         && (mDrumSettings != null && mDrumSettings.showDeactivatedTracksEnabled() || track.isActivated().get());
    }
 
    /**
@@ -1184,7 +1324,7 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
 
    private void setSizeOfSendBank(final int size)
    {
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < TRACK_BANK_WIDTH; ++i)
       {
          final Track track = mTrackBank.getItemAt(i);
          final SendBank sendBank = track.sendBank();
@@ -1311,12 +1451,13 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
 
       final int selectedTrack = mTrackBank.cursorIndex().get();
 
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final Track track = mTrackBank.getItemAt(i);
-         final boolean trackExists = track.exists().get();
+         final int sourceTrackIndex = sourceTrackIndexForStrip(i);
+         final Track track = sourceTrackIndex >= 0 ? mTrackBank.getItemAt(sourceTrackIndex) : null;
+         final boolean trackExists = track != null;
          final int defaultFocusColor = trackExists
-            ? (selectedTrack == i ? SimpleLedColor.Amber.value() : SimpleLedColor.AmberLow.value())
+            ? (selectedTrack == sourceTrackIndex ? SimpleLedColor.Amber.value() : SimpleLedColor.AmberLow.value())
             : SimpleLedColor.Off.value();
          final int focusColor = mArpLayerController != null
             ? mArpLayerController.applyFocusColor(i, defaultFocusColor)
@@ -1353,8 +1494,8 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
                   : SimpleLedColor.RedLow.value();
                case None ->
                {
-                  final RemoteControl param = mTrackRemoteControls[i].getParameter(3);
-                  final boolean exists = param.exists().get();
+                  final RemoteControl param = trackParamForStrip(i, 3);
+                  final boolean exists = param != null && param.exists().get();
                   final double value = exists ? param.value().get() : 0;
                   controlColor = exists ? levelColor(value, off, amberLow, amber) : off;
                }
@@ -1458,10 +1599,10 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
          return;
       }
 
-      for (int i = 0; i < 8; ++i)
+      for (int i = 0; i < STRIP_COUNT; ++i)
       {
-         final Track track = mTrackBank.getItemAt(i);
-         final SendBank sendBank = track.sendBank();
+         final Track track = trackForStrip(i);
+         final SendBank sendBank = track != null ? track.sendBank() : null;
 
          final int green = SimpleLedColor.Green.value();
          final int greenLow = SimpleLedColor.GreenLow.value();
@@ -1470,20 +1611,28 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
          final int amberLow = SimpleLedColor.AmberLow.value();
          final int red = SimpleLedColor.Red.value();
 
+         if (sendBank == null)
+         {
+            mKnobsLed[i].setColor(off);
+            mKnobsLed[8 + i].setColor(off);
+            mKnobsLed[16 + i].setColor(off);
+            continue;
+         }
+
          switch (mMode)
          {
             case Send2Device1 ->
             {
                mKnobsLed[i].setColor(levelColor(sendBank.getItemAt(0).exists().get() ? sendBank.getItemAt(0).value().get() : 0, off, greenLow, green));
                mKnobsLed[8 + i].setColor(levelColor(sendBank.getItemAt(1).exists().get() ? sendBank.getItemAt(1).value().get() : 0, off, greenLow, green));
-               final RemoteControl deviceParam0 = deviceParam(i, 0);
+               final RemoteControl deviceParam0 = deviceParamForStrip(i, 0);
                mKnobsLed[16 + i].setColor(levelColor(deviceParam0 != null && deviceParam0.exists().get() ? deviceParam0.value().get() : 0, off, amberLow, amber));
             }
             case Send2Pan1 ->
             {
                mKnobsLed[i].setColor(levelColor(sendBank.getItemAt(0).exists().get() ? sendBank.getItemAt(0).value().get() : 0, off, greenLow, green));
                mKnobsLed[8 + i].setColor(levelColor(sendBank.getItemAt(1).exists().get() ? sendBank.getItemAt(1).value().get() : 0, off, greenLow, green));
-               mKnobsLed[16 + i].setColor(track.exists().get() ? red : off);
+               mKnobsLed[16 + i].setColor(track != null ? red : off);
             }
             case Send3 ->
             {
@@ -1494,25 +1643,28 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
             case Send1Device2 ->
             {
                mKnobsLed[i].setColor(levelColor(sendBank.getItemAt(0).exists().get() ? sendBank.getItemAt(0).value().get() : 0, off, greenLow, green));
-               final RemoteControl deviceParam0 = deviceParam(i, 0);
-               final RemoteControl deviceParam1 = deviceParam(i, 1);
+               final RemoteControl deviceParam0 = deviceParamForStrip(i, 0);
+               final RemoteControl deviceParam1 = deviceParamForStrip(i, 1);
                mKnobsLed[8 + i].setColor(levelColor(deviceParam0 != null && deviceParam0.exists().get() ? deviceParam0.value().get() : 0, off, amberLow, amber));
                mKnobsLed[16 + i].setColor(levelColor(deviceParam1 != null && deviceParam1.exists().get() ? deviceParam1.value().get() : 0, off, amberLow, amber));
             }
             case Device3 ->
             {
-               final RemoteControl deviceParam0 = deviceParam(i, 0);
-               final RemoteControl deviceParam1 = deviceParam(i, 1);
-               final RemoteControl deviceParam2 = deviceParam(i, 2);
+               final RemoteControl deviceParam0 = deviceParamForStrip(i, 0);
+               final RemoteControl deviceParam1 = deviceParamForStrip(i, 1);
+               final RemoteControl deviceParam2 = deviceParamForStrip(i, 2);
                mKnobsLed[i].setColor(levelColor(deviceParam0 != null && deviceParam0.exists().get() ? deviceParam0.value().get() : 0, off, amberLow, amber));
                mKnobsLed[8 + i].setColor(levelColor(deviceParam1 != null && deviceParam1.exists().get() ? deviceParam1.value().get() : 0, off, amberLow, amber));
                mKnobsLed[16 + i].setColor(levelColor(deviceParam2 != null && deviceParam2.exists().get() ? deviceParam2.value().get() : 0, off, amberLow, amber));
             }
             case Track3 ->
             {
-               mKnobsLed[i].setColor(levelColor(mTrackRemoteControls[i].getParameter(0).exists().get() ? mTrackRemoteControls[i].getParameter(0).value().get() : 0, off, amberLow, amber));
-               mKnobsLed[8 + i].setColor(levelColor(mTrackRemoteControls[i].getParameter(1).exists().get() ? mTrackRemoteControls[i].getParameter(1).value().get() : 0, off, amberLow, amber));
-               mKnobsLed[16 + i].setColor(levelColor(mTrackRemoteControls[i].getParameter(2).exists().get() ? mTrackRemoteControls[i].getParameter(2).value().get() : 0, off, amberLow, amber));
+               final RemoteControl trackParam0 = trackParamForStrip(i, 0);
+               final RemoteControl trackParam1 = trackParamForStrip(i, 1);
+               final RemoteControl trackParam2 = trackParamForStrip(i, 2);
+               mKnobsLed[i].setColor(levelColor(trackParam0 != null && trackParam0.exists().get() ? trackParam0.value().get() : 0, off, amberLow, amber));
+               mKnobsLed[8 + i].setColor(levelColor(trackParam1 != null && trackParam1.exists().get() ? trackParam1.value().get() : 0, off, amberLow, amber));
+               mKnobsLed[16 + i].setColor(levelColor(trackParam2 != null && trackParam2.exists().get() ? trackParam2.value().get() : 0, off, amberLow, amber));
             }
             case Send2FullDevice ->
             {
@@ -1616,9 +1768,9 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       mSoloLed.setColor(mTrackControl == TrackControl.Solo ? yellow : off);
       mRecordArmLed.setColor(mTrackControl == TrackControl.RecordArm ? yellow : off);
 
-      final SendBank sendBank = mTrackBank.getItemAt(0).sendBank();
-      mUpButtonLed.setColor(sendBank.canScrollBackwards().get() ? yellow : off);
-      mDownButtonLed.setColor(sendBank.canScrollForwards().get() ? yellow : off);
+      final SendBank sendBank = sendBankForStrip(0);
+      mUpButtonLed.setColor(sendBank != null && sendBank.canScrollBackwards().get() ? yellow : off);
+      mDownButtonLed.setColor(sendBank != null && sendBank.canScrollForwards().get() ? yellow : off);
 
       if (mIsDeviceOn)
       {
@@ -1643,9 +1795,9 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
    private PinnableCursorDevice mCursorDevice;
    private CursorRemoteControlsPage mRemoteControls;
    private final CursorRemoteControlsPage[] mDeviceRemotePages = new CursorRemoteControlsPage[7];
-   private final CursorDevice[] mTrackDeviceCursors = new CursorDevice[8];
-   private final CursorRemoteControlsPage[] mTrackCursorDeviceRemoteControls = new CursorRemoteControlsPage[8];
-   private final CursorRemoteControlsPage[] mTrackRemoteControls = new CursorRemoteControlsPage[8];
+   private final CursorDevice[] mTrackDeviceCursors = new CursorDevice[TRACK_BANK_WIDTH];
+   private final CursorRemoteControlsPage[] mTrackCursorDeviceRemoteControls = new CursorRemoteControlsPage[TRACK_BANK_WIDTH];
+   private final CursorRemoteControlsPage[] mTrackRemoteControls = new CursorRemoteControlsPage[TRACK_BANK_WIDTH];
    private boolean mDevicePerTrackSupported;
    private CursorRemoteControlsPage mProjectRemoteControlsCursor;
    private RhArpLayerController mArpLayerController;
@@ -1771,21 +1923,4 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       }
    }
 
-   private void setTrackBankFlatteningMode(final TrackBank trackBank, final String modeName)
-   {
-      if (mHost.getHostApiVersion() < 25)
-         return;
-
-      try
-      {
-         final Class<?> modeClass = Class.forName("com.bitwig.extension.controller.api.TrackBankFlatteningMode");
-         @SuppressWarnings({"unchecked", "rawtypes"})
-         final Object mode = Enum.valueOf((Class<Enum>) modeClass.asSubclass(Enum.class), modeName);
-         trackBank.getClass().getMethod("setFlatteningMode", modeClass).invoke(trackBank, mode);
-      }
-      catch (final ReflectiveOperationException | IllegalArgumentException e)
-      {
-         mHost.errorln("Unable to set Launch Control XL track-bank flattening mode: " + e.getMessage());
-      }
-   }
 }

--- a/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtension.java
+++ b/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtension.java
@@ -183,6 +183,7 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       }
 
       mTrackBank = mHost.createMainTrackBank(8, 3, 0);
+      setTrackBankFlatteningMode(mTrackBank, "FLATTEN");
       mTrackBank.followCursorTrack(mCursorTrack);
       mTrackBank.canScrollBackwards().markInterested();
       mTrackBank.canScrollForwards().markInterested();
@@ -1767,6 +1768,24 @@ public class LaunchControlXlControllerExtension extends ControllerExtension
       if (DEBUG_TELEMETRY && sHostActions != null)
       {
          sHostActions.debug(message);
+      }
+   }
+
+   private void setTrackBankFlatteningMode(final TrackBank trackBank, final String modeName)
+   {
+      if (mHost.getHostApiVersion() < 25)
+         return;
+
+      try
+      {
+         final Class<?> modeClass = Class.forName("com.bitwig.extension.controller.api.TrackBankFlatteningMode");
+         @SuppressWarnings({"unchecked", "rawtypes"})
+         final Object mode = Enum.valueOf((Class<Enum>) modeClass.asSubclass(Enum.class), modeName);
+         trackBank.getClass().getMethod("setFlatteningMode", modeClass).invoke(trackBank, mode);
+      }
+      catch (final ReflectiveOperationException | IllegalArgumentException e)
+      {
+         mHost.errorln("Unable to set Launch Control XL track-bank flattening mode: " + e.getMessage());
       }
    }
 }

--- a/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtensionDefinition.java
+++ b/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtensionDefinition.java
@@ -86,7 +86,7 @@ public class LaunchControlXlControllerExtensionDefinition extends ControllerExte
    @Override
    public int getRequiredAPIVersion()
    {
-      return 24;
+      return 25;
    }
 
    @Override

--- a/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtensionDefinition.java
+++ b/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/LaunchControlXlControllerExtensionDefinition.java
@@ -86,7 +86,7 @@ public class LaunchControlXlControllerExtensionDefinition extends ControllerExte
    @Override
    public int getRequiredAPIVersion()
    {
-      return 25;
+      return 24;
    }
 
    @Override

--- a/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/drum/DrumSettings.java
+++ b/modules/launchcontrol/src/main/java/com/bitwig/extensions/controllers/novation/launch_control_xl/drum/DrumSettings.java
@@ -10,12 +10,15 @@ public final class DrumSettings
 {
    private final SettableBooleanValue auditionOnSelect;
    private final SettableBooleanValue accentMomentary;
+   private final SettableBooleanValue showDeactivatedTracks;
 
    private DrumSettings(final SettableBooleanValue auditionOnSelect,
-                        final SettableBooleanValue accentMomentary)
+                        final SettableBooleanValue accentMomentary,
+                        final SettableBooleanValue showDeactivatedTracks)
    {
       this.auditionOnSelect = auditionOnSelect;
       this.accentMomentary = accentMomentary;
+      this.showDeactivatedTracks = showDeactivatedTracks;
    }
 
    public static DrumSettings from(final ControllerHost host)
@@ -29,7 +32,12 @@ public final class DrumSettings
          "Drum accent buttons momentary",
          category,
          true);
-      return new DrumSettings(auditionOnSelect, accentMomentary);
+      final SettableBooleanValue showDeactivatedTracks = host.getPreferences().getBooleanSetting(
+         "Show deactivated tracks",
+         category,
+         false);
+      showDeactivatedTracks.markInterested();
+      return new DrumSettings(auditionOnSelect, accentMomentary, showDeactivatedTracks);
    }
 
    public SettableBooleanValue auditionOnSelect()
@@ -42,6 +50,11 @@ public final class DrumSettings
       return accentMomentary;
    }
 
+   public SettableBooleanValue showDeactivatedTracks()
+   {
+      return showDeactivatedTracks;
+   }
+
    public boolean auditionOnSelectEnabled()
    {
       return auditionOnSelect.get();
@@ -50,5 +63,10 @@ public final class DrumSettings
    public boolean accentMomentaryEnabled()
    {
       return accentMomentary.get();
+   }
+
+   public boolean showDeactivatedTracksEnabled()
+   {
+      return showDeactivatedTracks.get();
    }
 }

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -227,6 +227,7 @@
           <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
+      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -458,6 +458,7 @@
       <p>For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.</p>
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using <code>Default Clip Length</code>, then launch.</p>
+      <p><code>Perform Clip Launcher Layout</code> chooses whether the mode starts as <code>PerformV</code> or <code>PerformH</code>. <code>ALT + PERFORM</code> still toggles the layout for the current session.</p>
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
@@ -502,6 +503,7 @@
       <ul>
         <li><code>Clip Launch Mode</code></li>
         <li><code>Clip Launch Quantization</code></li>
+        <li><code>Perform Clip Launcher Layout</code></li>
         <li><code>Default Clip Length</code></li>
         <li><code>SELECT Encoder Startup</code></li>
         <li><code>Default Root Key</code></li>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -224,7 +224,7 @@
           <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
           <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
           <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
       <h3>Main SELECT encoder</h3>
@@ -477,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. For fixed <code>Default Clip Length</code> values, the script sets Bitwig's clip launcher post-record action to play the recorded clip after that length. If <code>Default Clip Length</code> is set to <code>Off</code>, recording continues until manually stopped without post-processing. If it is set to <code>Round</code>, recording continues until manually stopped, then the recorded clip loop length is rounded to the nearest whole bar. Press <code>REC</code> again to end an <code>Off</code> or <code>Round</code> launcher recording and launch the recorded clip, even after switching to another mode. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -210,12 +210,23 @@
           <tr><td><code>SHIFT + PATTERN</code></td><td>Metronome</td></tr>
           <tr><td><code>ALT + PATTERN</code></td><td>Clip launcher overdub</td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global pitch settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
+      <h3>Global settings overlay</h3>
+      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <table>
+        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <tbody>
+          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
+          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
+          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
+          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+      </tbody>
+      </table>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -466,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -218,6 +218,16 @@
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
+      <p>Global <code>SELECT</code> turn chords:</p>
+      <table>
+        <thead><tr><th>Control</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
+          <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
+          <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
+          <tr><td>Hold <code>SHIFT + ALT</code> + turn <code>SELECT</code></td><td>Zoom arranger/detail lanes vertically</td></tr>
+      </tbody>
+      </table>
       <table>
         <thead><tr><th>Role</th><th>Turn</th><th>Press / hold behavior</th></tr></thead>
         <tbody>
@@ -459,7 +469,7 @@
       <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
-      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page. Hold <code>ALT</code> and turn <code>SELECT</code> to change the remote page for the active remote encoder page: project remotes on <code>Channel</code>, track remotes on <code>User 1</code>, and device remotes on <code>User 2</code>. This applies in both vertical and horizontal perform layouts.</p>
+      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>
       <table>
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -227,6 +227,7 @@
           <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
+      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -458,6 +458,7 @@
       <p>For immediate derived-line feedback, change source expression from the controller instead. Controller-owned edits update the clip and regenerate from the controller's current source state.</p>
       <h3>PERFORM mode</h3>
       <p><code>PERFORM</code> is the 16x4 clip-launch and performance surface. Filled slots select and launch. Empty slots create a new clip using <code>Default Clip Length</code>, then launch.</p>
+      <p><code>Perform Clip Launcher Layout</code> chooses whether the mode starts as <code>PerformV</code> or <code>PerformH</code>. <code>ALT + PERFORM</code> still toggles the layout for the current session.</p>
       <table>
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
@@ -502,6 +503,7 @@
       <ul>
         <li><code>Clip Launch Mode</code></li>
         <li><code>Clip Launch Quantization</code></li>
+        <li><code>Perform Clip Launcher Layout</code></li>
         <li><code>Default Clip Length</code></li>
         <li><code>SELECT Encoder Startup</code></li>
         <li><code>Default Root Key</code></li>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -224,7 +224,7 @@
           <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
           <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
           <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
       </tbody>
       </table>
       <h3>Main SELECT encoder</h3>
@@ -477,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. For fixed <code>Default Clip Length</code> values, the script sets Bitwig's clip launcher post-record action to play the recorded clip after that length. If <code>Default Clip Length</code> is set to <code>Off</code>, recording continues until manually stopped without post-processing. If it is set to <code>Round</code>, recording continues until manually stopped, then the recorded clip loop length is rounded to the nearest whole bar. Press <code>REC</code> again to end an <code>Off</code> or <code>Round</code> launcher recording and launch the recorded clip, even after switching to another mode. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -210,12 +210,23 @@
           <tr><td><code>SHIFT + PATTERN</code></td><td>Metronome</td></tr>
           <tr><td><code>ALT + PATTERN</code></td><td>Clip launcher overdub</td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global pitch settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
+      <h3>Global settings overlay</h3>
+      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <table>
+        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <tbody>
+          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
+          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
+          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
+          <tr><td><code>User 2</code></td><td>Default launcher recording length</td></tr>
+      </tbody>
+      </table>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -466,7 +477,7 @@
       </tbody>
       </table>
       <p>Track-control page rows are select, solo, mute, and arm for the 16 visible tracks. On the select row, hold <code>ALT</code> and press a pad to stop that track. <code>KNOB MODE</code> still cycles the Perform encoder pages while the track-control pad page is active.</p>
-      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
+      <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. The script sets Bitwig's clip launcher post-record action to play the recorded clip after <code>Default Clip Length</code>, which can also be adjusted from the global settings overlay. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
       <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -218,6 +218,16 @@
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
+      <p>Global <code>SELECT</code> turn chords:</p>
+      <table>
+        <thead><tr><th>Control</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
+          <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
+          <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
+          <tr><td>Hold <code>SHIFT + ALT</code> + turn <code>SELECT</code></td><td>Zoom arranger/detail lanes vertically</td></tr>
+      </tbody>
+      </table>
       <table>
         <thead><tr><th>Role</th><th>Turn</th><th>Press / hold behavior</th></tr></thead>
         <tbody>
@@ -459,7 +469,7 @@
       <p>Hold <code>REC</code> and press a pad to target recording directly into that visible slot. Filled MIDI clips can overdub MIDI according to Bitwig's clip launcher behavior; audio launcher clips do not support audio overdub, but clip automation can still be written with clip launcher automation write/overdub enabled.</p>
       <p>The <code>Scene Launch</code> page keeps the same encoder and navigation controls as Perform. Its top row addresses the 16 visible scenes: press a scene pad to launch, hold <code>MUTE_1</code> and press a scene pad to select it as the scene copy source, hold <code>MUTE_3</code> and press a scene pad to copy the selected scene to that target, and hold <code>MUTE_4</code> and press a scene pad to delete it. If no scene source is selected, scene copy falls back to the first visible scene with playing clips, then the first visible scene with recording clips. <code>MUTE_2</code> is unused on this page.</p>
       <p>On <code>Scene Launch</code>, <code>BANK LEFT/RIGHT</code> also scrolls the visible scene window, with <code>SHIFT + BANK LEFT/RIGHT</code> scrolling by one scene.</p>
-      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page. Hold <code>ALT</code> and turn <code>SELECT</code> to change the remote page for the active remote encoder page: project remotes on <code>Channel</code>, track remotes on <code>User 1</code>, and device remotes on <code>User 2</code>. This applies in both vertical and horizontal perform layouts.</p>
+      <p>On remote encoder pages, hold <code>ALT</code> while turning an encoder to control remotes 5-8 on the same page.</p>
       <table>
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>


### PR DESCRIPTION
- add project navigation and timeline zoom gestures
- add round-to-nearest-bar clip recording length
- add controller preference for deactivated track visibility
- skip deactivated tracks in Fire perform and Launch Control mixer views
- add default clip launcher perform layout preference