### PR TITLE
feat: improve Akai Fire global controls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ This document now tracks intentional modifications made to the `bitwig-oikontrol
 - `SHIFT + NOTE` now toggles Bitwig record quantization off and back to the previous grid, defaulting to `1/16`.
 - `ALT + BANK LEFT/RIGHT` now triggers Bitwig undo/redo in Launcher, Mix, Note, Harmonic, and Drum Pads modes.
 - `SHIFT + BROWSER` now latches the global settings overlay, with `KNOB MODE` switching to a second page for shared input velocity feel and pad color response.
+- The Fire global settings overlay now has a `Pins` page for clamped track, device, and clip pin on/off controls.
 
 ## [2.15.0](https://github.com/oikoaudio/bitwig-oikontrol/compare/oikontrol-v2.14.1...oikontrol-v2.15.0) (2026-05-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ This document now tracks intentional modifications made to the `bitwig-oikontrol
 - Added an Akai Fire `Startup Mode` preference for starting in Note, Harmony, Drum XOX, Launcher, or Mix.
 - `SHIFT + NOTE` now toggles Bitwig record quantization off and back to the previous grid, defaulting to `1/16`.
 - `ALT + BANK LEFT/RIGHT` now triggers Bitwig undo/redo in Launcher, Mix, Note, Harmonic, and Drum Pads modes.
+- `SHIFT + BROWSER` now latches the global settings overlay, with `KNOB MODE` switching to a second page for shared input velocity feel and pad color response.
 
 ## [2.15.0](https://github.com/oikoaudio/bitwig-oikontrol/compare/oikontrol-v2.14.1...oikontrol-v2.15.0) (2026-05-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ This document now tracks intentional modifications made to the `bitwig-oikontrol
 - Added a `Playback Start` SELECT encoder role for moving Bitwig's playback start position by the arranger grid resolution.
 - Added an Akai Fire `Startup Mode` preference for starting in Note, Harmony, Drum XOX, Launcher, or Mix.
 - `SHIFT + NOTE` now toggles Bitwig record quantization off and back to the previous grid, defaulting to `1/16`.
+- `ALT + BANK LEFT/RIGHT` now triggers Bitwig undo/redo in Launcher, Mix, Note, Harmonic, and Drum Pads modes.
 
 ## [2.15.0](https://github.com/oikoaudio/bitwig-oikontrol/compare/oikontrol-v2.14.1...oikontrol-v2.15.0) (2026-05-18)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Fire script is built around the controller's four main mode buttons.
 - **`NOTE`** - live note input with isomorphic and harmonic pad layouts.
 - **`STEP`** - `Melodic Step`, `Chord Step`, and `Fugue` workflows for generated melodies, in-scale chord construction, and transformed melodic lines.
 - **`PERFORM`** - vertical or horizontal clip launching, scene launching, clip management, and a `SHIFT + PERFORM` Mix page.
-- **`SHIFT + BROWSER`** - a latched global settings overlay for shared pitch, launcher recording length, velocity feel, and pad color response.
+- **`SHIFT + BROWSER`** - a latched global settings overlay for shared pitch, launcher recording length, velocity feel, pad color response, and cursor pinning.
 
 Many Fire modes share a common musical context, so changing the root, scale, or octave can reshape live note input, generated melodic material, and chord-oriented workflows together.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Fire script is built around the controller's four main mode buttons.
 - **`NOTE`** - live note input with isomorphic and harmonic pad layouts.
 - **`STEP`** - `Melodic Step`, `Chord Step`, and `Fugue` workflows for generated melodies, in-scale chord construction, and transformed melodic lines.
 - **`PERFORM`** - vertical or horizontal clip launching, scene launching, clip management, and a `SHIFT + PERFORM` Mix page.
-- **`SHIFT + BROWSER`** - a held global settings overlay for shared `Root Key`, `Scale`, and `Octave`.
+- **`SHIFT + BROWSER`** - a latched global settings overlay for shared pitch, launcher recording length, velocity feel, and pad color response.
 
 Many Fire modes share a common musical context, so changing the root, scale, or octave can reshape live note input, generated melodic material, and chord-oriented workflows together.
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -149,8 +149,9 @@ Press `SHIFT + BROWSER` to latch the global settings overlay. Press `SHIFT + BRO
 | --- | --- | --- | --- | --- |
 | `Pitch` | Shared root key | Shared scale | Shared octave | `ClipLen`: launcher recording length |
 | `Input` | Global velocity sensitivity | Global velocity center | Pad brightness | Pad saturation |
+| `Pins` | Pin track | Pin device | Pin clip | -- |
 
-The `Input` velocity settings are shared by live `NOTE`, `Drum Pads`, and `Chord Step` input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle `Show deactivated tracks`; the same persistent option is available in the controller preferences and defaults to off.
+On the `Pins` page, turn an encoder right for `On` and left for `Off`; the pin controls stop at those two states and do not wrap. The `Input` velocity settings are shared by live `NOTE`, `Drum Pads`, and `Chord Step` input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle `Show deactivated tracks`; the same persistent option is available in the controller preferences and defaults to off.
 
 ### Main SELECT encoder
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -219,7 +219,7 @@ Hold one or more step pads, then use the timing gestures to move those held note
 
 Hold `MUTE_3` and press a clip slot, drum pad, or step to paste from the selected item of the same type. Clip-row paste falls back to the playing clip on that track if no clip was explicitly selected.
 
-In `Drum Pads`, `Grid64` plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. `PATTERN UP/DOWN` scrolls the pad window by 16 pads; `BANK LEFT/RIGHT` reminds you to use Pattern for this. On the `Channel` page, encoder 1 selects layouts (`Grid64`, `Velocity`, and `Bongos`) and encoder 2 controls velocity sensitivity / `SHIFT`: velocity center. In `Velocity` and `Bongos`, the left 4x4 block selects the sound. `Velocity` uses the remaining 12x4 pads as fixed velocity zones; `Bongos` leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.
+In `Drum Pads`, `Grid64` plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. `PATTERN UP/DOWN` scrolls the pad window by 16 pads; `BANK LEFT/RIGHT` reminds you to use Pattern for this, while `ALT + BANK LEFT/RIGHT` still undo/redo Bitwig project history. On the `Channel` page, encoder 1 selects layouts (`Grid64`, `Velocity`, and `Bongos`) and encoder 2 controls velocity sensitivity / `SHIFT`: velocity center. In `Velocity` and `Bongos`, the left 4x4 block selects the sound. `Velocity` uses the remaining 12x4 pads as fixed velocity zones; `Bongos` leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.
 
 ### Nested Rhythm mode
 
@@ -287,6 +287,7 @@ Nested Rhythm reads the selected clip loop length from Bitwig when the clip is s
 | `ALT + NOTE` | Toggle the current layout variant: chromatic / in-key in melodic input, bass columns / full field in harmonic input |
 | `STEP` | Enter `Melodic Step`; press again for `Chord Step` |
 | `BANK LEFT/RIGHT` | Shared octave down / up |
+| `ALT + BANK LEFT/RIGHT` | Undo / redo Bitwig project history |
 | `MUTE_1` | Sustain |
 | `MUTE_2` | Sostenuto |
 | `MUTE_3` | Note Repeat toggle |
@@ -449,6 +450,7 @@ For immediate derived-line feedback, change source expression from the controlle
 | `MUTE_4` + pad | Delete |
 | `BANK LEFT/RIGHT` | Scroll tracks by visible page |
 | `SHIFT + BANK LEFT/RIGHT` | Scroll tracks by one |
+| `ALT + BANK LEFT/RIGHT` | Undo / redo Bitwig project history |
 | `PATTERN UP/DOWN` | Scroll scenes by visible page |
 | `SHIFT + PATTERN UP/DOWN` | Scroll scenes by one |
 | `KNOB MODE` | Cycle Launcher encoder pages |

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -135,7 +135,7 @@ Pad colors in `DRUM` and `PERFORM` follow Bitwig track, drum-lane, and clip colo
 | `SHIFT + DRUM` | Tap tempo |
 | `SHIFT + NOTE` | Toggle record quantization, restoring the previous grid or `1/16` |
 | `BROWSER` | Open or close Bitwig popup browser |
-| `SHIFT + BROWSER` | Hold global settings overlay |
+| `SHIFT + BROWSER` | Latch or close global settings overlay |
 | `ALT + BROWSER` | Open browser after the current device / insertion context |
 | `SHIFT + ALT + BROWSER` | Open browser before the current device / insertion context |
 
@@ -143,16 +143,14 @@ When the popup browser is open, `SELECT` turn moves through results, `SELECT` pr
 
 ### Global settings overlay
 
-Hold `SHIFT + BROWSER` to edit shared settings from the four encoders.
+Press `SHIFT + BROWSER` to latch the global settings overlay. Press `SHIFT + BROWSER` again, press `BROWSER`, or press a plain mode button from the latched overlay to close it. Press `KNOB MODE` to switch between settings pages.
 
-| Encoder | Setting |
-| --- | --- |
-| `Channel` | Shared root key |
-| `Mixer` | Shared scale |
-| `User 1` | Shared octave |
-| `User 2` | `ClipRecLen`: launcher recording length |
+| Page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
+| --- | --- | --- | --- | --- |
+| `Pitch` | Shared root key | Shared scale | Shared octave | `ClipLen`: launcher recording length |
+| `Input` | Global velocity sensitivity | Global velocity center | Pad brightness | Pad saturation |
 
-The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding `SHIFT + BROWSER` to toggle `Show deactivated tracks`; the same persistent option is available in the controller preferences and defaults to off.
+The `Input` velocity settings are shared by live `NOTE`, `Drum Pads`, and `Chord Step` input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle `Show deactivated tracks`; the same persistent option is available in the controller preferences and defaults to off.
 
 ### Main SELECT encoder
 
@@ -297,7 +295,7 @@ Nested Rhythm reads the selected clip loop length from Bitwig when the clip is s
 | --- | --- | --- | --- | --- |
 | `Channel` | Mod | Pitch bend | Pitch Gliss / `ALT`: gliss mode | Shared scale / `ALT`: shared root key / `SHIFT`: local layout |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
-| `User 1` | Velocity sensitivity / `SHIFT`: velocity center | Aftertouch | Timbre | Pitch expression |
+| `User 1` | Global velocity sensitivity / `SHIFT`: velocity center | Aftertouch | Timbre | Pitch expression |
 | `User 2` | Selected device remote 1 | Remote 2 | Remote 3 | Remote 4 |
 
 #### Harmonic input
@@ -398,7 +396,7 @@ Press `STEP` from `Melodic Step` to enter `Chord Step`. Press `NOTE` to return t
 
 | Encoder page | Encoder 1 | Encoder 2 | Encoder 3 | Encoder 4 |
 | --- | --- | --- | --- | --- |
-| `Channel` | Chord octave / `ALT`: shared root | Velocity sensitivity / `SHIFT`: velocity center | Chord family / `ALT`: family page | Interpretation / `SHIFT`: shared scale / `ALT`: invert chord |
+| `Channel` | Chord octave / `ALT`: shared root | Global velocity sensitivity / `SHIFT`: velocity center | Chord family / `ALT`: family page | Interpretation / `SHIFT`: shared scale / `ALT`: invert chord |
 | `Mixer` | Track volume | Track pan | Send 1 | Send 2 |
 | `User 1` | Note velocity | Pressure | Timbre | Pitch |
 | `User 2` | Note length | Chance | Velocity spread | Repeats |

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -162,6 +162,7 @@ Global `SELECT` turn chords:
 
 | Control | Action |
 | --- | --- |
+| Hold `SHIFT` + turn `SELECT` | Move the playback start by the current arranger grid resolution |
 | Hold `PATTERN` + turn `SELECT` | Move the play position by the current meter's beat unit |
 | Hold `SHIFT + PATTERN` + turn `SELECT` | Move the play position by fine 1/16-beat steps |
 | Hold `ALT` + turn `SELECT` | Zoom the arranger/detail timeline horizontally |
@@ -174,7 +175,6 @@ Global `SELECT` turn chords:
 | `Tempo` | Adjust project tempo | None |
 | `Note Repeat` | Select repeat division; `Off` disables repeat | Active repeat control |
 | `Track Select` | Previous / next track | Hold while turning to jump by visible pages |
-| `Playback Start` | Move the playback start by the current arranger grid resolution | None |
 | `Drum Grid` | Drum-step grid resolution | `DRUM` mode only |
 
 ### DRUM Mode
@@ -561,7 +561,6 @@ Use `Fugue` when you already have a melodic idea and want related material aroun
 - `Pad Brightness`
 - `Pad Saturation`
 - `Encoder touch reset`
-- `SELECT Encoder`
 - `Euclid Scope`
 - `Drum Mode Pinning`
 - `Step Seq Pad Audition`

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -5,6 +5,7 @@ import com.oikoaudio.fire.control.EncoderStepAccumulator;
 import com.oikoaudio.fire.control.ModeButtonLights;
 import com.oikoaudio.fire.control.RgbButton;
 import com.oikoaudio.fire.control.TouchEncoder;
+import com.oikoaudio.fire.control.UndoRedoBankButtonHandler;
 import com.oikoaudio.fire.chordstep.ChordStepMode;
 import com.oikoaudio.fire.display.OledDisplay;
 import com.oikoaudio.fire.fugue.FugueStepMode;
@@ -239,6 +240,8 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         focusedParameter.displayedValue().markInterested();
         focusedParameter.value().markInterested();
         application = host.createApplication();
+        application.canUndo().markInterested();
+        application.canRedo().markInterested();
         arranger = host.createArranger();
         detailEditor = host.createDetailEditor();
         groove = host.createGroove();
@@ -1956,6 +1959,30 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     public boolean isGlobalShiftHeld() {
         final BiColorButton button = getButton(NoteAssign.SHIFT);
         return button != null ? button.isPressed() : shiftActive.get();
+    }
+
+    public boolean handleGlobalUndoRedoBankButton(final boolean pressed, final int amount) {
+        final UndoRedoBankButtonHandler.Action action =
+                UndoRedoBankButtonHandler.actionFor(pressed, amount, isGlobalAltHeld());
+        if (action == UndoRedoBankButtonHandler.Action.NONE) {
+            return false;
+        }
+        if (action == UndoRedoBankButtonHandler.Action.UNDO) {
+            if (application.canUndo().get()) {
+                application.undo();
+                notifyAction("Undo", "Project");
+            } else {
+                notifyAction("Undo", "None");
+            }
+            return true;
+        }
+        if (application.canRedo().get()) {
+            application.redo();
+            notifyAction("Redo", "Project");
+        } else {
+            notifyAction("Redo", "None");
+        }
+        return true;
     }
 
     public void refreshGlobalSettingsOverlayState() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -1821,6 +1821,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         globalSettingsOverlayActive = true;
+        releaseAutoPinnedDrumContext(true);
         drumSequenceMode.deactivate();
         notePlayMode.deactivate();
         drumPadPlayMode.deactivate();
@@ -1890,6 +1891,17 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private void showGlobalSettingsOverview() {
+        if (globalSettingsEncoderMode == EncoderMode.USER_1) {
+            oled.detailInfo("Global Settings",
+                    "Page: %s\n1: Pin Track %s\n2: Pin Device %s\n3: Pin Clip %s\n4: --".formatted(
+                            globalSettingsPageLabel(),
+                            pinStateLabel(viewControl.getCursorTrack().isPinned().get()),
+                            pinOverviewLabel(viewControl.getSelectedDevice().isPinned().get(),
+                                    viewControl.getSelectedDevice().exists().get()),
+                            pinOverviewLabel(viewControl.getSelectedClip().isPinned().get(),
+                                    viewControl.getSelectedClip().exists().get())));
+            return;
+        }
         if (globalSettingsEncoderMode == EncoderMode.MIXER) {
             oled.detailInfo("Global Settings",
                     "Page: %s\n1: Vel Sens %d%%\n2: Vel Ctr %d\n3: Pad Bright %s\n4: Pad Sat %s".formatted(
@@ -1916,6 +1928,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         }
         if (globalSettingsEncoderMode == EncoderMode.MIXER) {
             adjustGlobalInputSettings(encoderIndex, inc);
+            return;
+        }
+        if (globalSettingsEncoderMode == EncoderMode.USER_1) {
+            adjustGlobalPinSettings(encoderIndex, inc);
             return;
         }
         if (encoderIndex == 0) {
@@ -1949,6 +1965,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         }
         if (globalSettingsEncoderMode == EncoderMode.MIXER) {
             showGlobalInputSetting(encoderIndex);
+            return;
+        }
+        if (globalSettingsEncoderMode == EncoderMode.USER_1) {
+            showGlobalPinSetting(encoderIndex);
             return;
         }
         if (encoderIndex == 0) {
@@ -1989,6 +2009,8 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         }
         globalSettingsEncoderMode = globalSettingsEncoderMode == EncoderMode.CHANNEL
                 ? EncoderMode.MIXER
+                : globalSettingsEncoderMode == EncoderMode.MIXER
+                ? EncoderMode.USER_1
                 : EncoderMode.CHANNEL;
         for (final EncoderStepAccumulator accumulator : globalSettingsAccumulators) {
             accumulator.reset();
@@ -2002,7 +2024,11 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private String globalSettingsPageLabel() {
-        return globalSettingsEncoderMode == EncoderMode.MIXER ? "Input" : "Pitch";
+        return switch (globalSettingsEncoderMode) {
+            case MIXER -> "Input";
+            case USER_1 -> "Pins";
+            default -> "Pitch";
+        };
     }
 
     private void adjustGlobalInputSettings(final int encoderIndex, final int inc) {
@@ -2028,6 +2054,67 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         showGlobalSettingsOverview();
+    }
+
+    private void adjustGlobalPinSettings(final int encoderIndex, final int inc) {
+        if (encoderIndex == 0) {
+            applyPinEncoder("Pin Track", viewControl.getCursorTrack().isPinned(), true, inc);
+            return;
+        }
+        if (encoderIndex == 1) {
+            applyPinEncoder("Pin Device", viewControl.getSelectedDevice().isPinned(),
+                    viewControl.getSelectedDevice().exists().get(), inc);
+            return;
+        }
+        if (encoderIndex == 2) {
+            applyPinEncoder("Pin Clip", viewControl.getSelectedClip().isPinned(),
+                    viewControl.getSelectedClip().exists().get(), inc);
+            return;
+        }
+        showGlobalSettingsOverview();
+    }
+
+    private void showGlobalPinSetting(final int encoderIndex) {
+        if (encoderIndex == 0) {
+            oled.valueInfo("Pin Track", pinStateLabel(viewControl.getCursorTrack().isPinned().get()));
+            return;
+        }
+        if (encoderIndex == 1) {
+            showPinInfo("Pin Device", viewControl.getSelectedDevice().isPinned().get(),
+                    viewControl.getSelectedDevice().exists().get());
+            return;
+        }
+        if (encoderIndex == 2) {
+            showPinInfo("Pin Clip", viewControl.getSelectedClip().isPinned().get(),
+                    viewControl.getSelectedClip().exists().get());
+            return;
+        }
+        showGlobalSettingsOverview();
+    }
+
+    private void applyPinEncoder(final String label,
+                                 final SettableBooleanValue pinValue,
+                                 final boolean targetExists,
+                                 final int inc) {
+        if (!targetExists) {
+            oled.valueInfo(label, "No Target");
+            return;
+        }
+        final boolean targetPinned = inc > 0;
+        pinValue.set(targetPinned);
+        oled.valueInfo(label, pinStateLabel(targetPinned));
+    }
+
+    private void showPinInfo(final String label, final boolean pinned, final boolean targetExists) {
+        oled.valueInfo(label, targetExists ? pinStateLabel(pinned) : "No Target");
+    }
+
+    private String pinOverviewLabel(final boolean pinned, final boolean targetExists) {
+        return targetExists ? pinStateLabel(pinned) : "--";
+    }
+
+    private String pinStateLabel(final boolean pinned) {
+        return pinned ? "On" : "Off";
     }
 
     private void showGlobalInputSetting(final int encoderIndex) {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -74,17 +74,6 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private static final String ACTION_JUMP_TO_END_OF_ARRANGEMENT = "jump_to_end_of_arrangement";
     private static final String RECORD_QUANTIZATION_OFF = "OFF";
     private static final String RECORD_QUANTIZATION_DEFAULT_ON = "1/16";
-    private static final double[] ARRANGER_GRID_ZOOM_LIMITS = {
-            8.8, 27.94, 279.11, 661.61, 1176.20, 2091.03, 4956.52, 8811.59,
-            20886.75, 37132.00, 66012.45, 156473.96, 278175.93, 600000.0, 800000.0
-    };
-    private static final double[] ARRANGER_GRID_STEPS = {
-            1.0, 1.0 / 4.0, 1.0 / 16.0, 1.0 / 32.0, 1.0 / 64.0, 1.0 / 128.0,
-            1.0 / 256.0, 1.0 / 512.0, 1.0 / 1024.0, 1.0 / 2048.0,
-            1.0 / 4096.0, 1.0 / 8192.0, 1.0 / 16384.0, 1.0 / 32768.0,
-            1.0 / 65536.0
-    };
-
     private static AkaiFireOikontrolExtension instance;
     private HardwareSurface surface;
     private Application application;
@@ -1492,19 +1481,13 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private double currentArrangementGridResolution() {
         if (arranger == null || !arranger.getHorizontalScrollbarModel().isZoomable()) {
-            return Math.max(0.125, 4.0 / Math.max(1, transportTimeSignatureDenominator));
+            return ArrangerGridStep.fallbackBeatStep(transportTimeSignatureDenominator);
         }
         final double contentPerPixel = arranger.getHorizontalScrollbarModel().getContentPerPixel().get();
-        if (contentPerPixel <= 0.0) {
-            return Math.max(0.125, 4.0 / Math.max(1, transportTimeSignatureDenominator));
-        }
-        final double inverseContentPerPixel = 1.0 / contentPerPixel;
-        for (int i = 0; i < ARRANGER_GRID_ZOOM_LIMITS.length; i++) {
-            if (inverseContentPerPixel < ARRANGER_GRID_ZOOM_LIMITS[i]) {
-                return ARRANGER_GRID_STEPS[i];
-            }
-        }
-        return ARRANGER_GRID_STEPS[ARRANGER_GRID_STEPS.length - 1];
+        return ArrangerGridStep.fromContentPerPixel(
+                contentPerPixel,
+                transportTimeSignatureNumerator,
+                transportTimeSignatureDenominator);
     }
 
     public boolean isStepSeqPadAuditionEnabled() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -6,6 +6,7 @@ import com.oikoaudio.fire.control.ModeButtonLights;
 import com.oikoaudio.fire.control.RgbButton;
 import com.oikoaudio.fire.control.TouchEncoder;
 import com.oikoaudio.fire.control.UndoRedoBankButtonHandler;
+import com.oikoaudio.fire.control.VelocitySettings;
 import com.oikoaudio.fire.chordstep.ChordStepMode;
 import com.oikoaudio.fire.display.OledDisplay;
 import com.oikoaudio.fire.fugue.FugueStepMode;
@@ -20,6 +21,7 @@ import com.oikoaudio.fire.note.DrumPadPlayMode;
 import com.oikoaudio.fire.note.NotePlayMode;
 import com.oikoaudio.fire.perform.PerformClipLauncherMode;
 import com.oikoaudio.fire.sequence.DrumSequenceMode;
+import com.oikoaudio.fire.sequence.EncoderMode;
 import com.oikoaudio.fire.sequence.NoteRepeatHandler;
 import com.oikoaudio.fire.utils.PatternButtons;
 import com.bitwig.extension.api.util.midi.ShortMidiMessage;
@@ -49,6 +51,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private static final int GLOBAL_ROOT_ENCODER_THRESHOLD = 16;
     private static final int GLOBAL_SCALE_ENCODER_THRESHOLD = 8;
     private static final int GLOBAL_OCTAVE_ENCODER_THRESHOLD = 8;
+    private static final int GLOBAL_VELOCITY_CENTER_DEFAULT = 100;
+    private static final int GLOBAL_VELOCITY_MIN = 1;
+    private static final int GLOBAL_VELOCITY_MAX = 126;
     private static final RgbLigthState SETTINGS_LOGO_ON = new RgbLigthState(127, 20, 0, true);
     private static final RgbLigthState SETTINGS_LOGO_OFF = RgbLigthState.OFF;
     private static final RgbLigthState SETTINGS_TOGGLE_ON = new RgbLigthState(0, 96, 96, true);
@@ -168,6 +173,8 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private boolean suppressNextMelodicStepRelease = false;
     private boolean drumPinPreferenceObserved = false;
     private boolean globalSettingsOverlayActive = false;
+    private final GlobalSettingsOverlayLatch globalSettingsOverlayLatch = new GlobalSettingsOverlayLatch();
+    private EncoderMode globalSettingsEncoderMode = EncoderMode.CHANNEL;
     private String lastRecordQuantizationGrid = RECORD_QUANTIZATION_DEFAULT_ON;
     private int browserPressToken = 0;
     private int transportTimeSignatureNumerator = 4;
@@ -179,6 +186,11 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     private final SharedPitchContextController sharedPitchContext = new SharedPitchContextController(
             new SharedMusicalContext(MusicalScaleLibrary.getInstance()),
             MusicalScaleLibrary.getInstance());
+    private final VelocitySettings sharedVelocitySettings = new VelocitySettings(
+            GLOBAL_VELOCITY_CENTER_DEFAULT,
+            GLOBAL_VELOCITY_MIN,
+            GLOBAL_VELOCITY_MAX,
+            100);
 
     private PatternButtons patternButtons;
     private NotePlayMode notePlayMode;
@@ -286,6 +298,7 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         setUpTransportControl();
         setUpPreferences();
         initializeSharedPitchContext();
+        initializeSharedVelocitySettings();
 
         patternButtons = new PatternButtons(this, mainLayer);
         drumSequenceMode = new DrumSequenceMode(this, noteRepeatHandler);
@@ -599,6 +612,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
                 handleGlobalSettingsPad(currentPad, pressed);
             }, () -> globalSettingsPadState(currentPad));
         }
+        getButton(NoteAssign.KNOB_MODE).bindPressed(globalSettingsLayer,
+                this::handleGlobalSettingsModeAdvance,
+                this::globalSettingsModeLightState);
     }
 
     private BiColorButton addButton(final NoteAssign which, final int ccLightValue) {
@@ -842,6 +858,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (!pressed) {
             return;
         }
+        if (dismissGlobalSettingsOverlayForModeButton(Mode.DRUM)) {
+            return;
+        }
         if (isGlobalAltHeld()) {
             return;
         }
@@ -863,6 +882,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void handleNotePressed(final boolean pressed) {
         if (!pressed) {
+            return;
+        }
+        if (dismissGlobalSettingsOverlayForModeButton(Mode.NOTE_PLAY)) {
             return;
         }
         if (isGlobalShiftHeld()) {
@@ -920,6 +942,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private void handleStepPressed(final boolean pressed) {
+        if (pressed && dismissGlobalSettingsOverlayForStepButton()) {
+            return;
+        }
         if (modeState.activeMode() == Mode.MELODIC_STEP) {
             if (!pressed && suppressNextMelodicStepRelease) {
                 suppressNextMelodicStepRelease = false;
@@ -971,6 +996,9 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void handlePerformPressed(final boolean pressed) {
         if (!pressed) {
+            return;
+        }
+        if (dismissGlobalSettingsOverlayForModeButton(Mode.PERFORM)) {
             return;
         }
         final boolean enteringPerform = modeState.activeMode() != Mode.PERFORM;
@@ -1138,11 +1166,19 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         return sharedPitchContext.context();
     }
 
+    public VelocitySettings getSharedVelocitySettings() {
+        return sharedVelocitySettings;
+    }
+
     private void initializeSharedPitchContext() {
         sharedPitchContext.initializeFromPreferences(
                 getDefaultScalePreference(),
                 getDefaultRootKeyPreference(),
                 getDefaultNoteInputOctavePreference());
+    }
+
+    private void initializeSharedVelocitySettings() {
+        sharedVelocitySettings.setSensitivity(getDefaultVelocitySensitivityPreference());
     }
 
     private void onMidi0(final ShortMidiMessage msg) {
@@ -1809,13 +1845,43 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         refreshSurfaceLights();
     }
 
+    private boolean dismissGlobalSettingsOverlayForModeButton(final Mode targetMode) {
+        if (!shouldDismissGlobalSettingsOverlayForPlainModeButton()) {
+            return false;
+        }
+        globalSettingsOverlayLatch.close();
+        final boolean alreadyInTargetMode = modeState.activeMode() == targetMode;
+        deactivateGlobalSettingsOverlay();
+        return alreadyInTargetMode;
+    }
+
+    private boolean dismissGlobalSettingsOverlayForStepButton() {
+        if (!shouldDismissGlobalSettingsOverlayForPlainModeButton()) {
+            return false;
+        }
+        globalSettingsOverlayLatch.close();
+        final boolean alreadyInStepFamily = switch (modeState.activeMode()) {
+            case CHORD_STEP, MELODIC_STEP, FUGUE_STEP, NESTED_RHYTHM -> true;
+            default -> false;
+        };
+        deactivateGlobalSettingsOverlay();
+        return alreadyInStepFamily;
+    }
+
+    private boolean shouldDismissGlobalSettingsOverlayForPlainModeButton() {
+        return globalSettingsOverlayActive && !isGlobalShiftHeld() && !isGlobalAltHeld();
+    }
+
     private void updateGlobalSettingsOverlayState() {
         final BiColorButton browserButton = getButton(NoteAssign.BROWSER);
-        final boolean shouldShow = browserButton != null
+        final boolean momentaryComboHeld = browserButton != null
                 && browserButton.isPressed()
                 && isGlobalShiftHeld()
                 && !isGlobalAltHeld()
                 && !isPopupBrowserActive();
+        final boolean shouldShow = globalSettingsOverlayLatch.shouldBeActive(
+                momentaryComboHeld,
+                isPopupBrowserActive());
         if (shouldShow) {
             activateGlobalSettingsOverlay();
         } else {
@@ -1824,8 +1890,19 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     private void showGlobalSettingsOverview() {
+        if (globalSettingsEncoderMode == EncoderMode.MIXER) {
+            oled.detailInfo("Global Settings",
+                    "Page: %s\n1: Vel Sens %d%%\n2: Vel Ctr %d\n3: Pad Bright %s\n4: Pad Sat %s".formatted(
+                            globalSettingsPageLabel(),
+                            sharedVelocitySettings.sensitivity(),
+                            sharedVelocitySettings.centerVelocity(),
+                            padBrightnessLabel(),
+                            padSaturationLabel()));
+            return;
+        }
         oled.detailInfo("Global Settings",
-                "1: Root %s\n2: Scale %s\n3: Oct %d\n4: ClipRecLen %s\nTracks: %s".formatted(
+                "Page: %s\n1: Root %s\n2: Scale %s\n3: Oct %d\n4: ClipLen %s\nTracks: %s".formatted(
+                        globalSettingsPageLabel(),
                         com.oikoaudio.fire.note.NoteGridLayout.noteName(sharedPitchContext.getRootNote()),
                         sharedPitchContext.getScaleDisplayName(),
                         sharedPitchContext.getOctave(),
@@ -1835,6 +1912,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
 
     private void adjustGlobalSettings(final int encoderIndex, final int inc) {
         if (inc == 0) {
+            return;
+        }
+        if (globalSettingsEncoderMode == EncoderMode.MIXER) {
+            adjustGlobalInputSettings(encoderIndex, inc);
             return;
         }
         if (encoderIndex == 0) {
@@ -1866,6 +1947,10 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             showGlobalSettingsOverview();
             return;
         }
+        if (globalSettingsEncoderMode == EncoderMode.MIXER) {
+            showGlobalInputSetting(encoderIndex);
+            return;
+        }
         if (encoderIndex == 0) {
             oled.valueInfo("Root", com.oikoaudio.fire.note.NoteGridLayout.noteName(sharedPitchContext.getRootNote()));
             return;
@@ -1879,19 +1964,114 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
             return;
         }
         if (encoderIndex == 3) {
-            oled.valueInfo("ClipRecLen", defaultClipLengthLabel());
+            oled.valueInfo("ClipLen", defaultClipLengthLabel());
             return;
         }
         showGlobalSettingsOverview();
     }
 
     private void handleGlobalSettingsPad(final int padIndex, final boolean pressed) {
-        if (!pressed || padIndex != SETTINGS_SHOW_DEACTIVATED_TRACKS_PAD || showDeactivatedTracksPref == null) {
+        if (!pressed) {
+            return;
+        }
+        if (padIndex != SETTINGS_SHOW_DEACTIVATED_TRACKS_PAD || showDeactivatedTracksPref == null) {
             return;
         }
         showDeactivatedTracksPref.set(!showDeactivatedTracks());
         oled.valueInfo("Tracks", showDeactivatedTracks() ? "All" : "Active");
         refreshSurfaceLights();
+    }
+
+    private void handleGlobalSettingsModeAdvance(final boolean pressed) {
+        if (!pressed) {
+            oled.clearScreenDelayed();
+            return;
+        }
+        globalSettingsEncoderMode = globalSettingsEncoderMode == EncoderMode.CHANNEL
+                ? EncoderMode.MIXER
+                : EncoderMode.CHANNEL;
+        for (final EncoderStepAccumulator accumulator : globalSettingsAccumulators) {
+            accumulator.reset();
+        }
+        showGlobalSettingsOverview();
+        refreshSurfaceLights();
+    }
+
+    private BiColorLightState globalSettingsModeLightState() {
+        return globalSettingsEncoderMode.getState();
+    }
+
+    private String globalSettingsPageLabel() {
+        return globalSettingsEncoderMode == EncoderMode.MIXER ? "Input" : "Pitch";
+    }
+
+    private void adjustGlobalInputSettings(final int encoderIndex, final int inc) {
+        if (encoderIndex == 0) {
+            if (sharedVelocitySettings.adjustSensitivity(inc)) {
+                oled.paramInfo("Velocity Sens", sharedVelocitySettings.sensitivity(), "Global Input", 0, 100);
+            }
+            return;
+        }
+        if (encoderIndex == 1) {
+            if (sharedVelocitySettings.adjustCenterVelocity(inc)) {
+                oled.paramInfo("Velocity Center", sharedVelocitySettings.centerVelocity(), "Global Input",
+                        sharedVelocitySettings.minCenterVelocity(), sharedVelocitySettings.maxCenterVelocity());
+            }
+            return;
+        }
+        if (encoderIndex == 2) {
+            adjustPadBrightness(inc);
+            return;
+        }
+        if (encoderIndex == 3) {
+            adjustPadSaturation(inc);
+            return;
+        }
+        showGlobalSettingsOverview();
+    }
+
+    private void showGlobalInputSetting(final int encoderIndex) {
+        if (encoderIndex == 0) {
+            oled.valueInfo("Velocity Sens", sharedVelocitySettings.sensitivity() + "%");
+            return;
+        }
+        if (encoderIndex == 1) {
+            oled.valueInfo("Velocity Center", Integer.toString(sharedVelocitySettings.centerVelocity()));
+            return;
+        }
+        if (encoderIndex == 2) {
+            oled.valueInfo("Pad Bright", padBrightnessLabel());
+            return;
+        }
+        if (encoderIndex == 3) {
+            oled.valueInfo("Pad Sat", padSaturationLabel());
+            return;
+        }
+        showGlobalSettingsOverview();
+    }
+
+    private void adjustPadBrightness(final int inc) {
+        final double next = FireControlPreferences.normalizePadBrightness(
+                (padBrightnessPref == null ? padBrightness : padBrightnessPref.getRaw())
+                        + inc * FireControlPreferences.PAD_BRIGHTNESS_STEP);
+        if (padBrightnessPref != null) {
+            padBrightnessPref.setRaw(next);
+        } else {
+            padBrightness = next;
+        }
+        oled.valueInfo("Pad Bright", padBrightnessLabel(next));
+    }
+
+    private void adjustPadSaturation(final int inc) {
+        final double next = FireControlPreferences.normalizePadSaturation(
+                (padSaturationPref == null ? padSaturation : padSaturationPref.getRaw())
+                        + inc * FireControlPreferences.PAD_SATURATION_STEP);
+        if (padSaturationPref != null) {
+            padSaturationPref.setRaw(next);
+        } else {
+            padSaturation = next;
+        }
+        oled.valueInfo("Pad Sat", padSaturationLabel(next));
     }
 
     private void adjustDefaultClipLength(final int inc) {
@@ -1909,13 +2089,29 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         final int nextIndex = Math.max(0,
                 Math.min(FireControlPreferences.DEFAULT_CLIP_LENGTHS.length - 1, currentIndex + inc));
         defaultClipLengthPref.set(FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
-        oled.valueInfo("ClipRecLen", FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
+        oled.valueInfo("ClipLen", FireControlPreferences.DEFAULT_CLIP_LENGTHS[nextIndex]);
     }
 
     private String defaultClipLengthLabel() {
         return FireControlPreferences.normalizeDefaultClipLength(defaultClipLengthPref == null
                 ? FireControlPreferences.CLIP_LENGTH_2_BARS
                 : defaultClipLengthPref.get());
+    }
+
+    private String padBrightnessLabel() {
+        return padBrightnessLabel(padBrightnessPref == null ? padBrightness : padBrightnessPref.getRaw());
+    }
+
+    private String padBrightnessLabel(final double value) {
+        return "%.0f%%".formatted(FireControlPreferences.normalizePadBrightness(value));
+    }
+
+    private String padSaturationLabel() {
+        return padSaturationLabel(padSaturationPref == null ? padSaturation : padSaturationPref.getRaw());
+    }
+
+    private String padSaturationLabel(final double value) {
+        return "%.0f%%".formatted(FireControlPreferences.normalizePadSaturation(value));
     }
 
     private RgbLigthState globalSettingsPadState(final int padIndex) {
@@ -2142,20 +2338,35 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
         if (!pressed) {
             browserPressToken++;
             updateGlobalSettingsOverlayState();
-            oled.clearScreenDelayed();
+            if (!globalSettingsOverlayActive) {
+                oled.clearScreenDelayed();
+            }
             return;
         }
-        updateGlobalSettingsOverlayState();
+        if (globalSettingsOverlayActive && !isGlobalShiftHeld()) {
+            globalSettingsOverlayLatch.close();
+            updateGlobalSettingsOverlayState();
+            notifyAction("Settings", "Closed");
+            return;
+        }
         if (isPopupBrowserActive()) {
             popupBrowser.cancel();
             notifyAction("Browser", "Closed");
             return;
         }
         if (isGlobalShiftHeld() && !isGlobalAltHeld()) {
-            activateGlobalSettingsOverlay();
-            notifyAction("Settings", "Global");
+            final boolean wasLatched = globalSettingsOverlayLatch.isLatched();
+            globalSettingsOverlayLatch.toggleLatch(true);
+            if (wasLatched) {
+                deactivateGlobalSettingsOverlay();
+                notifyAction("Settings", "Closed");
+                return;
+            }
+            updateGlobalSettingsOverlayState();
+            notifyAction("Settings", "Latched");
             return;
         }
+        updateGlobalSettingsOverlayState();
         final int pressToken = ++browserPressToken;
         host.scheduleTask(() -> maybeOpenPopupBrowser(pressToken), BROWSER_OPEN_DEFER_MS);
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/AkaiFireOikontrolExtension.java
@@ -2294,21 +2294,38 @@ public class AkaiFireOikontrolExtension extends ControllerExtension {
     }
 
     public boolean handleMainEncoderGlobalChord(final int inc) {
-        if (inc == 0 || isPopupBrowserActive()) {
-            return false;
-        }
-        if (patternPressed) {
-            patternGestureConsumed = true;
-            adjustTransportPositionByGrid(inc, isGlobalShiftHeld());
-            return true;
-        }
-        if (isGlobalAltHeld()) {
-            if (isGlobalShiftHeld()) {
-                zoomTimelineVertically(inc);
-            } else {
-                zoomTimelineHorizontally(inc);
+        final MainEncoderGlobalChord.Action action = MainEncoderGlobalChord.resolve(
+                inc,
+                isPopupBrowserActive(),
+                patternPressed,
+                isGlobalShiftHeld(),
+                isGlobalAltHeld());
+        switch (action) {
+            case PLAYBACK_START_GRID -> {
+                adjustPlaybackStartPositionByGrid(inc);
+                return true;
             }
-            return true;
+            case PLAY_POSITION_GRID -> {
+                patternGestureConsumed = true;
+                adjustTransportPositionByGrid(inc, false);
+                return true;
+            }
+            case PLAY_POSITION_FINE -> {
+                patternGestureConsumed = true;
+                adjustTransportPositionByGrid(inc, true);
+                return true;
+            }
+            case TIMELINE_ZOOM_HORIZONTAL -> {
+                zoomTimelineHorizontally(inc);
+                return true;
+            }
+            case TIMELINE_ZOOM_VERTICAL -> {
+                zoomTimelineVertically(inc);
+                return true;
+            }
+            case NONE -> {
+                return false;
+            }
         }
         return false;
     }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/ArrangerGridStep.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/ArrangerGridStep.java
@@ -1,0 +1,54 @@
+package com.oikoaudio.fire;
+
+final class ArrangerGridStep {
+    private static final double[] ZOOM_LIMITS = {
+            8.8, 27.94, 279.11, 661.61, 1176.20, 2091.03, 4956.52, 8811.59,
+            20886.75, 37132.00, 66012.45, 156473.96, 278175.93, 600000.0, 800000.0
+    };
+    private static final double[] STEPS = {
+            Double.NaN, Double.NaN, 1.0, 1.0 / 4.0, 1.0 / 16.0, 1.0 / 32.0,
+            1.0 / 64.0, 1.0 / 128.0, 1.0 / 256.0, 1.0 / 512.0,
+            1.0 / 1024.0, 1.0 / 2048.0, 1.0 / 4096.0, 1.0 / 8192.0,
+            1.0 / 16384.0
+    };
+    private static final double FOUR_BAR_ZOOM_LIMIT = 14.0;
+
+    private ArrangerGridStep() {
+    }
+
+    static double fallbackBeatStep(final int denominator) {
+        return Math.max(0.125, 4.0 / Math.max(1, denominator));
+    }
+
+    static double barStep(final int numerator, final int denominator) {
+        return Math.max(fallbackBeatStep(denominator),
+                Math.max(1, numerator) * 4.0 / Math.max(1, denominator));
+    }
+
+    static double phraseStep(final int numerator, final int denominator, final int bars) {
+        return barStep(numerator, denominator) * Math.max(1, bars);
+    }
+
+    static double fromContentPerPixel(final double contentPerPixel,
+                                      final int numerator,
+                                      final int denominator) {
+        if (contentPerPixel <= 0.0) {
+            return fallbackBeatStep(denominator);
+        }
+        final double inverseContentPerPixel = 1.0 / contentPerPixel;
+        for (int i = 0; i < ZOOM_LIMITS.length; i++) {
+            if (inverseContentPerPixel < ZOOM_LIMITS[i]) {
+                if (i == 0) {
+                    return phraseStep(numerator, denominator, 8);
+                }
+                if (i == 1) {
+                    return inverseContentPerPixel < FOUR_BAR_ZOOM_LIMIT
+                            ? phraseStep(numerator, denominator, 4)
+                            : barStep(numerator, denominator);
+                }
+                return STEPS[i];
+            }
+        }
+        return STEPS[STEPS.length - 1];
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/FireControlPreferences.java
@@ -96,7 +96,6 @@ public final class FireControlPreferences {
             MAIN_ENCODER_TEMPO,
             MAIN_ENCODER_NOTE_REPEAT,
             MAIN_ENCODER_TRACK_SELECT,
-            MAIN_ENCODER_PLAYBACK_START,
             MAIN_ENCODER_DRUM_GRID
     };
     public static final String MAIN_ENCODER_STARTUP_LAST_TOUCHED = "Last Touched";
@@ -246,9 +245,9 @@ public final class FireControlPreferences {
             return MAIN_ENCODER_TRACK_SELECT;
         }
         if (MAIN_ENCODER_TRACK_SELECT.equals(normalizedRole)) {
-            return MAIN_ENCODER_PLAYBACK_START;
+            return includeDrumGrid ? MAIN_ENCODER_DRUM_GRID : MAIN_ENCODER_SHUFFLE;
         }
-        if (MAIN_ENCODER_PLAYBACK_START.equals(normalizedRole)) {
+        if (MAIN_ENCODER_PLAYBACK_START.equals(currentRole)) {
             return includeDrumGrid ? MAIN_ENCODER_DRUM_GRID : MAIN_ENCODER_SHUFFLE;
         }
         return MAIN_ENCODER_SHUFFLE;

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/GlobalSettingsOverlayLatch.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/GlobalSettingsOverlayLatch.java
@@ -1,0 +1,25 @@
+package com.oikoaudio.fire;
+
+final class GlobalSettingsOverlayLatch {
+    private boolean latched;
+
+    boolean toggleLatch(final boolean available) {
+        if (!available) {
+            return false;
+        }
+        latched = !latched;
+        return true;
+    }
+
+    void close() {
+        latched = false;
+    }
+
+    boolean shouldBeActive(final boolean momentaryComboHeld, final boolean popupBrowserActive) {
+        return !popupBrowserActive && (latched || momentaryComboHeld);
+    }
+
+    boolean isLatched() {
+        return latched;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/MainEncoderGlobalChord.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/MainEncoderGlobalChord.java
@@ -1,0 +1,35 @@
+package com.oikoaudio.fire;
+
+final class MainEncoderGlobalChord {
+    enum Action {
+        NONE,
+        PLAYBACK_START_GRID,
+        PLAY_POSITION_GRID,
+        PLAY_POSITION_FINE,
+        TIMELINE_ZOOM_HORIZONTAL,
+        TIMELINE_ZOOM_VERTICAL
+    }
+
+    private MainEncoderGlobalChord() {
+    }
+
+    static Action resolve(final int increment,
+                          final boolean popupBrowserActive,
+                          final boolean patternHeld,
+                          final boolean shiftHeld,
+                          final boolean altHeld) {
+        if (increment == 0 || popupBrowserActive) {
+            return Action.NONE;
+        }
+        if (patternHeld) {
+            return shiftHeld ? Action.PLAY_POSITION_FINE : Action.PLAY_POSITION_GRID;
+        }
+        if (altHeld) {
+            return shiftHeld ? Action.TIMELINE_ZOOM_VERTICAL : Action.TIMELINE_ZOOM_HORIZONTAL;
+        }
+        if (shiftHeld) {
+            return Action.PLAYBACK_START_GRID;
+        }
+        return Action.NONE;
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/ViewCursorControl.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/ViewCursorControl.java
@@ -6,6 +6,7 @@ import com.bitwig.extension.controller.api.CursorTrack;
 import com.bitwig.extension.controller.api.DeviceBank;
 import com.bitwig.extension.controller.api.DeviceMatcher;
 import com.bitwig.extension.controller.api.DrumPadBank;
+import com.bitwig.extension.controller.api.PinnableCursorClip;
 import com.bitwig.extension.controller.api.PinnableCursorDevice;
 import com.bitwig.extension.controller.api.TrackBank;
 import com.oikoaudio.fire.values.SpecialDevices;
@@ -16,6 +17,7 @@ public class ViewCursorControl {
 	private final DeviceBank deviceBank;
 	private final PinnableCursorDevice primaryDevice;
 	private final PinnableCursorDevice selectedDevice;
+	private final PinnableCursorClip selectedClip;
 	private final DeviceBank drumBank;
 	private final DrumPadBank drumPadBank;
 	private final TrackBank trackBank;
@@ -68,7 +70,11 @@ public class ViewCursorControl {
 		selectedDevice = cursorTrack.createCursorDevice("selecteddevice", "Selected Device", 8,
 				CursorDeviceFollowMode.FOLLOW_SELECTION);
 		selectedDevice.exists().markInterested();
+		selectedDevice.isPinned().markInterested();
 		selectedDevice.isWindowOpen().markInterested();
+		selectedClip = cursorTrack.createLauncherCursorClip("VIEW_SELECTED_CLIP", "Selected Clip", 64, 128);
+		selectedClip.exists().markInterested();
+		selectedClip.isPinned().markInterested();
 		final DeviceMatcher drumMatcher = host.createBitwigDeviceMatcher(SpecialDevices.DRUM.getUuid());
 		drumBank = cursorTrack.createDeviceBank(1);
 		drumBank.setDeviceMatcher(drumMatcher);
@@ -109,6 +115,10 @@ public class ViewCursorControl {
 
 	public PinnableCursorDevice getSelectedDevice() {
 		return selectedDevice;
+	}
+
+	public PinnableCursorClip getSelectedClip() {
+		return selectedClip;
 	}
 
 	public DeviceBank getDrumBank() {

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/chordstep/ChordStepMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/chordstep/ChordStepMode.java
@@ -58,8 +58,6 @@ public final class ChordStepMode extends Layer implements StepSequencerHost, Seq
     private static final int AUDITION_VELOCITY = 96;
     private static final int MIN_MIDI_VALUE = 0;
     private static final int MAX_MIDI_VALUE = 127;
-    private static final int MIN_VELOCITY = 1;
-    private static final int STANDARD_CHORD_VELOCITY = ChordStepAccentEditor.STANDARD_VELOCITY;
     private static final int ACCENTED_CHORD_VELOCITY = ChordStepAccentEditor.ACCENTED_VELOCITY;
     private static final RgbLigthState ROOT_COLOR = new RgbLigthState(120, 64, 0, true);
     private static final RgbLigthState IN_SCALE_COLOR = new RgbLigthState(0, 72, 110, true);
@@ -85,8 +83,7 @@ public final class ChordStepMode extends Layer implements StepSequencerHost, Seq
     private final ChordStepChordSelection chordSelection = new ChordStepChordSelection();
     private final ChordStepBuilderController chordBuilder;
     private final ChordStepAuditionController chordStepAudition;
-    private final VelocitySettings chordStepVelocity = new VelocitySettings(STANDARD_CHORD_VELOCITY, MIN_VELOCITY,
-            ACCENTED_CHORD_VELOCITY - 1, 100);
+    private final VelocitySettings chordStepVelocity;
     private final ChordStepVisibleClipCache visibleClipCache = new ChordStepVisibleClipCache(STEP_COUNT);
     private final ChordStepFineNudgeState<ChordStepEventIndex.Event> fineNudgeState = new ChordStepFineNudgeState<>();
     private final ChordStepFineNudgeController<ChordStepEventIndex.Event> fineNudgeController;
@@ -116,6 +113,7 @@ public final class ChordStepMode extends Layer implements StepSequencerHost, Seq
         this.driver = driver;
         this.pitchContext = driver.getSharedPitchContextController();
         this.oled = driver.getOled();
+        this.chordStepVelocity = driver.getSharedVelocitySettings();
         this.chordStepAccentControls = new ChordStepAccentControls(oled);
         final ChordStepStepButtonControls chordStepStepButtonControls = new ChordStepStepButtonControls(
                 chordStepAccentControls, chordStepStepButtonHost());

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/UndoRedoBankButtonHandler.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/control/UndoRedoBankButtonHandler.java
@@ -1,0 +1,22 @@
+package com.oikoaudio.fire.control;
+
+/**
+ * Resolves the project history gesture on physical BANK left/right buttons.
+ */
+public final class UndoRedoBankButtonHandler {
+    private UndoRedoBankButtonHandler() {
+    }
+
+    public static Action actionFor(final boolean pressed, final int amount, final boolean altHeld) {
+        if (!pressed || !altHeld || amount == 0) {
+            return Action.NONE;
+        }
+        return amount < 0 ? Action.UNDO : Action.REDO;
+    }
+
+    public enum Action {
+        NONE,
+        UNDO,
+        REDO
+    }
+}

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LivePadSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LivePadSurfaceLayer.java
@@ -57,7 +57,6 @@ public abstract class LivePadSurfaceLayer extends Layer {
     private static final int MIN_MIDI_VALUE = 0;
     private static final int MAX_MIDI_VALUE = 127;
     private static final int MIN_VELOCITY = 1;
-    private static final int DEFAULT_LIVE_VELOCITY = 100;
     private static final int DEFAULT_DRUM_MACHINE_LOW_NOTE = 36;
     private static final int MAX_DRUM_MACHINE_SCROLL_POSITION = MAX_MIDI_VALUE - DrumMachinePadLayout.PAD_WINDOW_SIZE + 1;
     private static final long TOUCH_RESET_HOLD_MS = 750L;
@@ -147,8 +146,7 @@ public abstract class LivePadSurfaceLayer extends Layer {
     private boolean mainEncoderPressConsumed = false;
     private final boolean drumPadsOnly;
     private LiveNoteSubMode liveNoteSubMode = LiveNoteSubMode.MELODIC;
-    private final VelocitySettings liveVelocity = new VelocitySettings(DEFAULT_LIVE_VELOCITY, MIN_VELOCITY,
-            MAX_MIDI_VALUE, 100);
+    private final VelocitySettings liveVelocity;
     private int livePitchOffsetIndex = DEFAULT_LIVE_PITCH_OFFSET_INDEX;
     private int liveScaleDegreeGlissOffset = 0;
     private LivePitchGlissMode livePitchGlissMode = LivePitchGlissMode.FIFTH_OCTAVE;
@@ -192,6 +190,7 @@ public abstract class LivePadSurfaceLayer extends Layer {
         super(driver.getLayers(), layerName);
         this.driver = driver;
         this.pitchContext = driver.getSharedPitchContextController();
+        this.liveVelocity = driver.getSharedVelocitySettings();
         this.drumPadsOnly = drumPadsOnly;
         this.liveNoteSubMode = drumPadsOnly ? LiveNoteSubMode.DRUM_PADS : LiveNoteSubMode.MELODIC;
         this.oled = driver.getOled();

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LivePadSurfaceLayer.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/note/LivePadSurfaceLayer.java
@@ -1125,6 +1125,9 @@ public abstract class LivePadSurfaceLayer extends Layer {
     }
 
     private void handleBankButton(final boolean pressed, final int amount) {
+        if (driver.handleGlobalUndoRedoBankButton(pressed, amount)) {
+            return;
+        }
         if (!pressed) {
             return;
         }

--- a/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
+++ b/modules/akai-fire/src/main/java/com/oikoaudio/fire/perform/PerformClipLauncherMode.java
@@ -1027,6 +1027,9 @@ public class PerformClipLauncherMode extends Layer {
     }
 
     private void handleTrackScroll(final boolean pressed, final int direction) {
+        if (driver.handleGlobalUndoRedoBankButton(pressed, direction)) {
+            return;
+        }
         if (pressed) {
             suppressMixMeterDisplay();
         }

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -275,24 +275,22 @@
           <tr><td><code>SHIFT + DRUM</code></td><td>Tap tempo</td></tr>
           <tr><td><code>SHIFT + NOTE</code></td><td>Toggle record quantization, restoring the previous grid or <code>1/16</code></td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Latch or close global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Global settings overlay</h3>
-      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <p>Press <code>SHIFT + BROWSER</code> to latch the global settings overlay. Press <code>SHIFT + BROWSER</code> again, press <code>BROWSER</code>, or press a plain mode button from the latched overlay to close it. Press <code>KNOB MODE</code> to switch between settings pages.</p>
       <table>
-        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <thead><tr><th>Page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
-          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
-          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
       </tbody>
       </table>
-      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -433,7 +431,7 @@
         <tbody>
           <tr class="encoder-primary"><td><code>Channel</code></td><td>Mod</td><td>Pitch bend</td><td>Pitch Gliss / <code>ALT</code>: gliss mode</td><td>Shared scale / <code>ALT</code>: shared root key / <code>SHIFT</code>: local layout</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
-          <tr class="encoder-expression"><td><code>User 1</code></td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
+          <tr class="encoder-expression"><td><code>User 1</code></td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
           <tr class="encoder-shared"><td><code>User 2</code></td><td>Selected device remote 1</td><td>Remote 2</td><td>Remote 3</td><td>Remote 4</td></tr>
       </tbody>
       </table>
@@ -539,7 +537,7 @@
       <table class="encoder-map">
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
+          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
           <tr class="encoder-expression"><td><code>User 1</code></td><td>Note velocity</td><td>Pressure</td><td>Timbre</td><td>Pitch</td></tr>
           <tr class="encoder-expression"><td><code>User 2</code></td><td>Note length</td><td>Chance</td><td>Velocity spread</td><td>Repeats</td></tr>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -359,7 +359,7 @@
       </table>
       <p>Hold one or more step pads, then use the timing gestures to move those held notes directly. Fine-nudged notes stay attached to the held target during the gesture.</p>
       <p>Hold <code>MUTE_3</code> and press a clip slot, drum pad, or step to paste from the selected item of the same type. Clip-row paste falls back to the playing clip on that track if no clip was explicitly selected.</p>
-      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
+      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this, while <code>ALT + BANK LEFT/RIGHT</code> still undo/redo Bitwig project history. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
       <h3>Nested Rhythm mode</h3>
       <p><code>Nested Rhythm</code> is the second <code>DRUM</code> surface. It generates rhythm from nested segment divisions, writes exact timing to a hidden fine clip grid, and projects the generated hits back to the Fire. It is suited to tuplets, ratchets, asymmetric subdivisions, and layered rhythmic structures that are awkward on a coarse step grid.</p>
       <p>Entering the mode never overwrites an existing clip. If there is no selected clip, the OLED prompts you to select or create one. Creating a clip from the Nested Rhythm clip row generates a starter pattern. Existing clips are protected from encoder-driven generator changes until you explicitly press <code>PATTERN DOWN</code> to overwrite and claim the clip for Nested Rhythm editing.</p>
@@ -421,6 +421,7 @@
           <tr><td><code>ALT + NOTE</code></td><td>Toggle the current layout variant: chromatic / in-key in melodic input, bass columns / full field in harmonic input</td></tr>
           <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step</code>; press again for <code>Chord Step</code></td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Shared octave down / up</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>MUTE_1</code></td><td>Sustain</td></tr>
           <tr><td><code>MUTE_2</code></td><td>Sostenuto</td></tr>
           <tr><td><code>MUTE_3</code></td><td>Note Repeat toggle</td></tr>
@@ -586,6 +587,7 @@
           <tr><td><code>MUTE_4</code> + pad</td><td>Delete</td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Scroll tracks by visible page</td></tr>
           <tr><td><code>SHIFT + BANK LEFT/RIGHT</code></td><td>Scroll tracks by one</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>PATTERN UP/DOWN</code></td><td>Scroll scenes by visible page</td></tr>
           <tr><td><code>SHIFT + PATTERN UP/DOWN</code></td><td>Scroll scenes by one</td></tr>
           <tr><td><code>KNOB MODE</code></td><td>Cycle Launcher encoder pages</td></tr>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -298,6 +298,7 @@
       <table class="control-map">
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
+          <tr><td>Hold <code>SHIFT</code> + turn <code>SELECT</code></td><td>Move the playback start by the current arranger grid resolution</td></tr>
           <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
           <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
           <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
@@ -312,7 +313,6 @@
           <tr><td><code>Tempo</code></td><td>Adjust project tempo</td><td>None</td></tr>
           <tr><td><code>Note Repeat</code></td><td>Select repeat division; <code>Off</code> disables repeat</td><td>Active repeat control</td></tr>
           <tr><td><code>Track Select</code></td><td>Previous / next track</td><td>Hold while turning to jump by visible pages</td></tr>
-          <tr><td><code>Playback Start</code></td><td>Move the playback start by the current arranger grid resolution</td><td>None</td></tr>
           <tr><td><code>Drum Grid</code></td><td>Drum-step grid resolution</td><td><code>DRUM</code> mode only</td></tr>
       </tbody>
       </table>
@@ -678,7 +678,6 @@
         <li><code>Pad Brightness</code></li>
         <li><code>Pad Saturation</code></li>
         <li><code>Encoder touch reset</code></li>
-        <li><code>SELECT Encoder</code></li>
         <li><code>Euclid Scope</code></li>
         <li><code>Drum Mode Pinning</code></li>
         <li><code>Step Seq Pad Audition</code></li>

--- a/modules/akai-fire/src/main/resources/Documentation/index.html
+++ b/modules/akai-fire/src/main/resources/Documentation/index.html
@@ -288,9 +288,10 @@
         <tbody>
           <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
           <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
+          <tr><td><code>Pins</code></td><td>Pin track</td><td>Pin device</td><td>Pin clip</td><td>--</td></tr>
       </tbody>
       </table>
-      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>On the <code>Pins</code> page, turn an encoder right for <code>On</code> and left for <code>Off</code>; the pin controls stop at those two states and do not wrap. The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/ArrangerGridStepTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/ArrangerGridStepTest.java
@@ -1,0 +1,37 @@
+package com.oikoaudio.fire;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArrangerGridStepTest {
+    @Test
+    void usesPhraseStepsForWideArrangerZoomLevels() {
+        assertEquals(32.0, ArrangerGridStep.fromContentPerPixel(1.0 / 8.0, 4, 4));
+        assertEquals(16.0, ArrangerGridStep.fromContentPerPixel(1.0 / 12.0, 4, 4));
+    }
+
+    @Test
+    void usesBarStepsBeforeBeatStepsWhenEditingAtMediumWideZoomLevels() {
+        assertEquals(4.0, ArrangerGridStep.fromContentPerPixel(1.0 / 20.0, 4, 4));
+    }
+
+    @Test
+    void phraseStepsFollowCurrentTimeSignature() {
+        assertEquals(24.0, ArrangerGridStep.fromContentPerPixel(1.0 / 8.0, 3, 4));
+        assertEquals(12.0, ArrangerGridStep.fromContentPerPixel(1.0 / 8.0, 6, 16));
+        assertEquals(1.5, ArrangerGridStep.fromContentPerPixel(1.0 / 20.0, 6, 16));
+    }
+
+    @Test
+    void keepsBeatAndFineStepsForCloserZoomLevels() {
+        assertEquals(1.0, ArrangerGridStep.fromContentPerPixel(1.0 / 100.0, 4, 4));
+        assertEquals(0.25, ArrangerGridStep.fromContentPerPixel(1.0 / 400.0, 4, 4));
+    }
+
+    @Test
+    void fallsBackToMeterBeatUnitWhenZoomIsUnavailable() {
+        assertEquals(1.0, ArrangerGridStep.fromContentPerPixel(0.0, 4, 4));
+        assertEquals(0.5, ArrangerGridStep.fromContentPerPixel(-1.0, 4, 8));
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/FireControlPreferencesTest.java
@@ -34,12 +34,12 @@ class FireControlPreferencesTest {
                 FireControlPreferences.normalizeMainEncoderRole(FireControlPreferences.MAIN_ENCODER_TEMPO));
         assertEquals(FireControlPreferences.MAIN_ENCODER_TRACK_SELECT,
                 FireControlPreferences.normalizeMainEncoderRole(FireControlPreferences.MAIN_ENCODER_TRACK_SELECT));
-        assertEquals(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START,
-                FireControlPreferences.normalizeMainEncoderRole(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START));
         assertEquals(FireControlPreferences.MAIN_ENCODER_DRUM_GRID,
                 FireControlPreferences.normalizeMainEncoderRole(FireControlPreferences.MAIN_ENCODER_DRUM_GRID));
         assertEquals(FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED,
                 FireControlPreferences.normalizeMainEncoderRole("unexpected"));
+        assertEquals(FireControlPreferences.MAIN_ENCODER_LAST_TOUCHED,
+                FireControlPreferences.normalizeMainEncoderRole(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START));
     }
 
     @Test
@@ -66,7 +66,7 @@ class FireControlPreferencesTest {
                 FireControlPreferences.nextAlternateMainEncoderRole(FireControlPreferences.MAIN_ENCODER_TEMPO));
         assertEquals(FireControlPreferences.MAIN_ENCODER_TRACK_SELECT,
                 FireControlPreferences.nextAlternateMainEncoderRole(FireControlPreferences.MAIN_ENCODER_NOTE_REPEAT));
-        assertEquals(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START,
+        assertEquals(FireControlPreferences.MAIN_ENCODER_DRUM_GRID,
                 FireControlPreferences.nextAlternateMainEncoderRole(FireControlPreferences.MAIN_ENCODER_TRACK_SELECT));
         assertEquals(FireControlPreferences.MAIN_ENCODER_DRUM_GRID,
                 FireControlPreferences.nextAlternateMainEncoderRole(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START));
@@ -80,7 +80,7 @@ class FireControlPreferencesTest {
 
     @Test
     void skipsDrumGridWhenCyclingAlternateMainEncoderRolesOutsideDrumMode() {
-        assertEquals(FireControlPreferences.MAIN_ENCODER_PLAYBACK_START,
+        assertEquals(FireControlPreferences.MAIN_ENCODER_SHUFFLE,
                 FireControlPreferences.nextAlternateMainEncoderRole(
                         FireControlPreferences.MAIN_ENCODER_TRACK_SELECT, false));
         assertEquals(FireControlPreferences.MAIN_ENCODER_SHUFFLE,

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/GlobalSettingsOverlayLatchTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/GlobalSettingsOverlayLatchTest.java
@@ -1,0 +1,46 @@
+package com.oikoaudio.fire;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GlobalSettingsOverlayLatchTest {
+
+    @Test
+    void latchKeepsOverlayActiveAfterMomentaryComboIsReleased() {
+        final GlobalSettingsOverlayLatch latch = new GlobalSettingsOverlayLatch();
+
+        assertTrue(latch.toggleLatch(true));
+
+        assertTrue(latch.shouldBeActive(false, false));
+    }
+
+    @Test
+    void secondAvailableToggleClosesLatchedOverlay() {
+        final GlobalSettingsOverlayLatch latch = new GlobalSettingsOverlayLatch();
+        latch.toggleLatch(true);
+
+        assertTrue(latch.toggleLatch(true));
+
+        assertFalse(latch.shouldBeActive(false, false));
+        assertFalse(latch.isLatched());
+    }
+
+    @Test
+    void popupBrowserSuppressesOverlayEvenWhenLatched() {
+        final GlobalSettingsOverlayLatch latch = new GlobalSettingsOverlayLatch();
+        latch.toggleLatch(true);
+
+        assertFalse(latch.shouldBeActive(true, true));
+    }
+
+    @Test
+    void unavailableToggleDoesNotChangeLatch() {
+        final GlobalSettingsOverlayLatch latch = new GlobalSettingsOverlayLatch();
+
+        assertFalse(latch.toggleLatch(false));
+
+        assertFalse(latch.shouldBeActive(false, false));
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/MainEncoderGlobalChordTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/MainEncoderGlobalChordTest.java
@@ -1,0 +1,37 @@
+package com.oikoaudio.fire;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MainEncoderGlobalChordTest {
+    @Test
+    void shiftTurnMovesPlaybackStartByGrid() {
+        assertEquals(MainEncoderGlobalChord.Action.PLAYBACK_START_GRID,
+                MainEncoderGlobalChord.resolve(1, false, false, true, false));
+    }
+
+    @Test
+    void patternChordKeepsExistingPlayPositionBehavior() {
+        assertEquals(MainEncoderGlobalChord.Action.PLAY_POSITION_GRID,
+                MainEncoderGlobalChord.resolve(1, false, true, false, false));
+        assertEquals(MainEncoderGlobalChord.Action.PLAY_POSITION_FINE,
+                MainEncoderGlobalChord.resolve(1, false, true, true, false));
+    }
+
+    @Test
+    void altChordKeepsExistingTimelineZoomBehavior() {
+        assertEquals(MainEncoderGlobalChord.Action.TIMELINE_ZOOM_HORIZONTAL,
+                MainEncoderGlobalChord.resolve(1, false, false, false, true));
+        assertEquals(MainEncoderGlobalChord.Action.TIMELINE_ZOOM_VERTICAL,
+                MainEncoderGlobalChord.resolve(1, false, false, true, true));
+    }
+
+    @Test
+    void ignoresZeroIncrementsAndPopupBrowserTurns() {
+        assertEquals(MainEncoderGlobalChord.Action.NONE,
+                MainEncoderGlobalChord.resolve(0, false, false, true, false));
+        assertEquals(MainEncoderGlobalChord.Action.NONE,
+                MainEncoderGlobalChord.resolve(1, true, false, true, false));
+    }
+}

--- a/modules/akai-fire/src/test/java/com/oikoaudio/fire/control/UndoRedoBankButtonHandlerTest.java
+++ b/modules/akai-fire/src/test/java/com/oikoaudio/fire/control/UndoRedoBankButtonHandlerTest.java
@@ -1,0 +1,27 @@
+package com.oikoaudio.fire.control;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UndoRedoBankButtonHandlerTest {
+    @Test
+    void altPressOnLeftBankRequestsUndo() {
+        assertEquals(UndoRedoBankButtonHandler.Action.UNDO,
+                UndoRedoBankButtonHandler.actionFor(true, -1, true));
+    }
+
+    @Test
+    void altPressOnRightBankRequestsRedo() {
+        assertEquals(UndoRedoBankButtonHandler.Action.REDO,
+                UndoRedoBankButtonHandler.actionFor(true, 1, true));
+    }
+
+    @Test
+    void releaseOrUnmodifiedPressDoesNotConsumeBankButton() {
+        assertEquals(UndoRedoBankButtonHandler.Action.NONE,
+                UndoRedoBankButtonHandler.actionFor(false, -1, true));
+        assertEquals(UndoRedoBankButtonHandler.Action.NONE,
+                UndoRedoBankButtonHandler.actionFor(true, -1, false));
+    }
+}

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -275,24 +275,22 @@
           <tr><td><code>SHIFT + DRUM</code></td><td>Tap tempo</td></tr>
           <tr><td><code>SHIFT + NOTE</code></td><td>Toggle record quantization, restoring the previous grid or <code>1/16</code></td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Latch or close global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Global settings overlay</h3>
-      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <p>Press <code>SHIFT + BROWSER</code> to latch the global settings overlay. Press <code>SHIFT + BROWSER</code> again, press <code>BROWSER</code>, or press a plain mode button from the latched overlay to close it. Press <code>KNOB MODE</code> to switch between settings pages.</p>
       <table>
-        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <thead><tr><th>Page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
-          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
-          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
       </tbody>
       </table>
-      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -433,7 +431,7 @@
         <tbody>
           <tr class="encoder-primary"><td><code>Channel</code></td><td>Mod</td><td>Pitch bend</td><td>Pitch Gliss / <code>ALT</code>: gliss mode</td><td>Shared scale / <code>ALT</code>: shared root key / <code>SHIFT</code>: local layout</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
-          <tr class="encoder-expression"><td><code>User 1</code></td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
+          <tr class="encoder-expression"><td><code>User 1</code></td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
           <tr class="encoder-shared"><td><code>User 2</code></td><td>Selected device remote 1</td><td>Remote 2</td><td>Remote 3</td><td>Remote 4</td></tr>
       </tbody>
       </table>
@@ -539,7 +537,7 @@
       <table class="encoder-map">
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
+          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
           <tr class="encoder-expression"><td><code>User 1</code></td><td>Note velocity</td><td>Pressure</td><td>Timbre</td><td>Pitch</td></tr>
           <tr class="encoder-expression"><td><code>User 2</code></td><td>Note length</td><td>Chance</td><td>Velocity spread</td><td>Repeats</td></tr>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -359,7 +359,7 @@
       </table>
       <p>Hold one or more step pads, then use the timing gestures to move those held notes directly. Fine-nudged notes stay attached to the held target during the gesture.</p>
       <p>Hold <code>MUTE_3</code> and press a clip slot, drum pad, or step to paste from the selected item of the same type. Clip-row paste falls back to the playing clip on that track if no clip was explicitly selected.</p>
-      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
+      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this, while <code>ALT + BANK LEFT/RIGHT</code> still undo/redo Bitwig project history. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
       <h3>Nested Rhythm mode</h3>
       <p><code>Nested Rhythm</code> is the second <code>DRUM</code> surface. It generates rhythm from nested segment divisions, writes exact timing to a hidden fine clip grid, and projects the generated hits back to the Fire. It is suited to tuplets, ratchets, asymmetric subdivisions, and layered rhythmic structures that are awkward on a coarse step grid.</p>
       <p>Entering the mode never overwrites an existing clip. If there is no selected clip, the OLED prompts you to select or create one. Creating a clip from the Nested Rhythm clip row generates a starter pattern. Existing clips are protected from encoder-driven generator changes until you explicitly press <code>PATTERN DOWN</code> to overwrite and claim the clip for Nested Rhythm editing.</p>
@@ -421,6 +421,7 @@
           <tr><td><code>ALT + NOTE</code></td><td>Toggle the current layout variant: chromatic / in-key in melodic input, bass columns / full field in harmonic input</td></tr>
           <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step</code>; press again for <code>Chord Step</code></td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Shared octave down / up</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>MUTE_1</code></td><td>Sustain</td></tr>
           <tr><td><code>MUTE_2</code></td><td>Sostenuto</td></tr>
           <tr><td><code>MUTE_3</code></td><td>Note Repeat toggle</td></tr>
@@ -586,6 +587,7 @@
           <tr><td><code>MUTE_4</code> + pad</td><td>Delete</td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Scroll tracks by visible page</td></tr>
           <tr><td><code>SHIFT + BANK LEFT/RIGHT</code></td><td>Scroll tracks by one</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>PATTERN UP/DOWN</code></td><td>Scroll scenes by visible page</td></tr>
           <tr><td><code>SHIFT + PATTERN UP/DOWN</code></td><td>Scroll scenes by one</td></tr>
           <tr><td><code>KNOB MODE</code></td><td>Cycle Launcher encoder pages</td></tr>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -298,6 +298,7 @@
       <table class="control-map">
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
+          <tr><td>Hold <code>SHIFT</code> + turn <code>SELECT</code></td><td>Move the playback start by the current arranger grid resolution</td></tr>
           <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
           <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
           <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
@@ -312,7 +313,6 @@
           <tr><td><code>Tempo</code></td><td>Adjust project tempo</td><td>None</td></tr>
           <tr><td><code>Note Repeat</code></td><td>Select repeat division; <code>Off</code> disables repeat</td><td>Active repeat control</td></tr>
           <tr><td><code>Track Select</code></td><td>Previous / next track</td><td>Hold while turning to jump by visible pages</td></tr>
-          <tr><td><code>Playback Start</code></td><td>Move the playback start by the current arranger grid resolution</td><td>None</td></tr>
           <tr><td><code>Drum Grid</code></td><td>Drum-step grid resolution</td><td><code>DRUM</code> mode only</td></tr>
       </tbody>
       </table>
@@ -678,7 +678,6 @@
         <li><code>Pad Brightness</code></li>
         <li><code>Pad Saturation</code></li>
         <li><code>Encoder touch reset</code></li>
-        <li><code>SELECT Encoder</code></li>
         <li><code>Euclid Scope</code></li>
         <li><code>Drum Mode Pinning</code></li>
         <li><code>Step Seq Pad Audition</code></li>

--- a/modules/launchcontrol/src/main/resources/Documentation/index.html
+++ b/modules/launchcontrol/src/main/resources/Documentation/index.html
@@ -288,9 +288,10 @@
         <tbody>
           <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
           <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
+          <tr><td><code>Pins</code></td><td>Pin track</td><td>Pin device</td><td>Pin clip</td><td>--</td></tr>
       </tbody>
       </table>
-      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>On the <code>Pins</code> page, turn an encoder right for <code>On</code> and left for <code>Off</code>; the pin controls stop at those two states and do not wrap. The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -275,24 +275,22 @@
           <tr><td><code>SHIFT + DRUM</code></td><td>Tap tempo</td></tr>
           <tr><td><code>SHIFT + NOTE</code></td><td>Toggle record quantization, restoring the previous grid or <code>1/16</code></td></tr>
           <tr><td><code>BROWSER</code></td><td>Open or close Bitwig popup browser</td></tr>
-          <tr><td><code>SHIFT + BROWSER</code></td><td>Hold global settings overlay</td></tr>
+          <tr><td><code>SHIFT + BROWSER</code></td><td>Latch or close global settings overlay</td></tr>
           <tr><td><code>ALT + BROWSER</code></td><td>Open browser after the current device / insertion context</td></tr>
           <tr><td><code>SHIFT + ALT + BROWSER</code></td><td>Open browser before the current device / insertion context</td></tr>
       </tbody>
       </table>
       <p>When the popup browser is open, <code>SELECT</code> turn moves through results, <code>SELECT</code> press commits the selected result, and <code>BROWSER</code> closes the browser.</p>
       <h3>Global settings overlay</h3>
-      <p>Hold <code>SHIFT + BROWSER</code> to edit shared settings from the four encoders.</p>
+      <p>Press <code>SHIFT + BROWSER</code> to latch the global settings overlay. Press <code>SHIFT + BROWSER</code> again, press <code>BROWSER</code>, or press a plain mode button from the latched overlay to close it. Press <code>KNOB MODE</code> to switch between settings pages.</p>
       <table>
-        <thead><tr><th>Encoder</th><th>Setting</th></tr></thead>
+        <thead><tr><th>Page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr><td><code>Channel</code></td><td>Shared root key</td></tr>
-          <tr><td><code>Mixer</code></td><td>Shared scale</td></tr>
-          <tr><td><code>User 1</code></td><td>Shared octave</td></tr>
-          <tr><td><code>User 2</code></td><td><code>ClipRecLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
+          <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
       </tbody>
       </table>
-      <p>The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad while holding <code>SHIFT + BROWSER</code> to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>
@@ -433,7 +431,7 @@
         <tbody>
           <tr class="encoder-primary"><td><code>Channel</code></td><td>Mod</td><td>Pitch bend</td><td>Pitch Gliss / <code>ALT</code>: gliss mode</td><td>Shared scale / <code>ALT</code>: shared root key / <code>SHIFT</code>: local layout</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
-          <tr class="encoder-expression"><td><code>User 1</code></td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
+          <tr class="encoder-expression"><td><code>User 1</code></td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Aftertouch</td><td>Timbre</td><td>Pitch expression</td></tr>
           <tr class="encoder-shared"><td><code>User 2</code></td><td>Selected device remote 1</td><td>Remote 2</td><td>Remote 3</td><td>Remote 4</td></tr>
       </tbody>
       </table>
@@ -539,7 +537,7 @@
       <table class="encoder-map">
         <thead><tr><th>Encoder page</th><th>Encoder 1</th><th>Encoder 2</th><th>Encoder 3</th><th>Encoder 4</th></tr></thead>
         <tbody>
-          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
+          <tr class="encoder-primary"><td><code>Channel</code></td><td>Chord octave / <code>ALT</code>: shared root</td><td>Global velocity sensitivity / <code>SHIFT</code>: velocity center</td><td>Chord family / <code>ALT</code>: family page</td><td>Interpretation / <code>SHIFT</code>: shared scale / <code>ALT</code>: invert chord</td></tr>
           <tr class="encoder-shared"><td><code>Mixer</code></td><td>Track volume</td><td>Track pan</td><td>Send 1</td><td>Send 2</td></tr>
           <tr class="encoder-expression"><td><code>User 1</code></td><td>Note velocity</td><td>Pressure</td><td>Timbre</td><td>Pitch</td></tr>
           <tr class="encoder-expression"><td><code>User 2</code></td><td>Note length</td><td>Chance</td><td>Velocity spread</td><td>Repeats</td></tr>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -359,7 +359,7 @@
       </table>
       <p>Hold one or more step pads, then use the timing gestures to move those held notes directly. Fine-nudged notes stay attached to the held target during the gesture.</p>
       <p>Hold <code>MUTE_3</code> and press a clip slot, drum pad, or step to paste from the selected item of the same type. Clip-row paste falls back to the playing clip on that track if no clip was explicitly selected.</p>
-      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
+      <p>In <code>Drum Pads</code>, <code>Grid64</code> plays a 64-pad Bitwig Drum Machine window. The starting page puts C1 on the lower-left pad, then pads run left-to-right from the bottom row. LEDs use explicit Drum Machine pad colors when set; pads with a sound but no explicit color use the track color, and empty pads stay dark. Pressing a pad shows the Bitwig pad name. <code>PATTERN UP/DOWN</code> scrolls the pad window by 16 pads; <code>BANK LEFT/RIGHT</code> reminds you to use Pattern for this, while <code>ALT + BANK LEFT/RIGHT</code> still undo/redo Bitwig project history. On the <code>Channel</code> page, encoder 1 selects layouts (<code>Grid64</code>, <code>Velocity</code>, and <code>Bongos</code>) and encoder 2 controls velocity sensitivity / <code>SHIFT</code>: velocity center. In <code>Velocity</code> and <code>Bongos</code>, the left 4x4 block selects the sound. <code>Velocity</code> uses the remaining 12x4 pads as fixed velocity zones; <code>Bongos</code> leaves separator columns between the selector and two 5x4 bongo surfaces, uses hit velocity for note velocity, and maps surface position to per-note pressure.</p>
       <h3>Nested Rhythm mode</h3>
       <p><code>Nested Rhythm</code> is the second <code>DRUM</code> surface. It generates rhythm from nested segment divisions, writes exact timing to a hidden fine clip grid, and projects the generated hits back to the Fire. It is suited to tuplets, ratchets, asymmetric subdivisions, and layered rhythmic structures that are awkward on a coarse step grid.</p>
       <p>Entering the mode never overwrites an existing clip. If there is no selected clip, the OLED prompts you to select or create one. Creating a clip from the Nested Rhythm clip row generates a starter pattern. Existing clips are protected from encoder-driven generator changes until you explicitly press <code>PATTERN DOWN</code> to overwrite and claim the clip for Nested Rhythm editing.</p>
@@ -421,6 +421,7 @@
           <tr><td><code>ALT + NOTE</code></td><td>Toggle the current layout variant: chromatic / in-key in melodic input, bass columns / full field in harmonic input</td></tr>
           <tr><td><code>STEP</code></td><td>Enter <code>Melodic Step</code>; press again for <code>Chord Step</code></td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Shared octave down / up</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>MUTE_1</code></td><td>Sustain</td></tr>
           <tr><td><code>MUTE_2</code></td><td>Sostenuto</td></tr>
           <tr><td><code>MUTE_3</code></td><td>Note Repeat toggle</td></tr>
@@ -586,6 +587,7 @@
           <tr><td><code>MUTE_4</code> + pad</td><td>Delete</td></tr>
           <tr><td><code>BANK LEFT/RIGHT</code></td><td>Scroll tracks by visible page</td></tr>
           <tr><td><code>SHIFT + BANK LEFT/RIGHT</code></td><td>Scroll tracks by one</td></tr>
+          <tr><td><code>ALT + BANK LEFT/RIGHT</code></td><td>Undo / redo Bitwig project history</td></tr>
           <tr><td><code>PATTERN UP/DOWN</code></td><td>Scroll scenes by visible page</td></tr>
           <tr><td><code>SHIFT + PATTERN UP/DOWN</code></td><td>Scroll scenes by one</td></tr>
           <tr><td><code>KNOB MODE</code></td><td>Cycle Launcher encoder pages</td></tr>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -298,6 +298,7 @@
       <table class="control-map">
         <thead><tr><th>Control</th><th>Action</th></tr></thead>
         <tbody>
+          <tr><td>Hold <code>SHIFT</code> + turn <code>SELECT</code></td><td>Move the playback start by the current arranger grid resolution</td></tr>
           <tr><td>Hold <code>PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by the current meter's beat unit</td></tr>
           <tr><td>Hold <code>SHIFT + PATTERN</code> + turn <code>SELECT</code></td><td>Move the play position by fine 1/16-beat steps</td></tr>
           <tr><td>Hold <code>ALT</code> + turn <code>SELECT</code></td><td>Zoom the arranger/detail timeline horizontally</td></tr>
@@ -312,7 +313,6 @@
           <tr><td><code>Tempo</code></td><td>Adjust project tempo</td><td>None</td></tr>
           <tr><td><code>Note Repeat</code></td><td>Select repeat division; <code>Off</code> disables repeat</td><td>Active repeat control</td></tr>
           <tr><td><code>Track Select</code></td><td>Previous / next track</td><td>Hold while turning to jump by visible pages</td></tr>
-          <tr><td><code>Playback Start</code></td><td>Move the playback start by the current arranger grid resolution</td><td>None</td></tr>
           <tr><td><code>Drum Grid</code></td><td>Drum-step grid resolution</td><td><code>DRUM</code> mode only</td></tr>
       </tbody>
       </table>
@@ -678,7 +678,6 @@
         <li><code>Pad Brightness</code></li>
         <li><code>Pad Saturation</code></li>
         <li><code>Encoder touch reset</code></li>
-        <li><code>SELECT Encoder</code></li>
         <li><code>Euclid Scope</code></li>
         <li><code>Drum Mode Pinning</code></li>
         <li><code>Step Seq Pad Audition</code></li>

--- a/modules/oikontrol/src/main/resources/Documentation/index.html
+++ b/modules/oikontrol/src/main/resources/Documentation/index.html
@@ -288,9 +288,10 @@
         <tbody>
           <tr><td><code>Pitch</code></td><td>Shared root key</td><td>Shared scale</td><td>Shared octave</td><td><code>ClipLen</code>: launcher recording length</td></tr>
           <tr><td><code>Input</code></td><td>Global velocity sensitivity</td><td>Global velocity center</td><td>Pad brightness</td><td>Pad saturation</td></tr>
+          <tr><td><code>Pins</code></td><td>Pin track</td><td>Pin device</td><td>Pin clip</td><td>--</td></tr>
       </tbody>
       </table>
-      <p>The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
+      <p>On the <code>Pins</code> page, turn an encoder right for <code>On</code> and left for <code>Off</code>; the pin controls stop at those two states and do not wrap. The <code>Input</code> velocity settings are shared by live <code>NOTE</code>, <code>Drum Pads</code>, and <code>Chord Step</code> input. The global settings screen also shows whether launcher and mixer track views are using all tracks or only active tracks. Press the bottom-right pad from the overlay to toggle <code>Show deactivated tracks</code>; the same persistent option is available in the controller preferences and defaults to off.</p>
       <h3>Main SELECT encoder</h3>
       <p>Tap <code>SELECT</code> to swap between <code>Last Touched Parameter</code> and the current alternate role. Press <code>SHIFT + SELECT</code> to cycle the alternate role. Press <code>ALT + SELECT</code> to open or close the selected device window.</p>
       <p>Global <code>SELECT</code> turn chords:</p>


### PR DESCRIPTION
Completes the remaining Akai Fire global-control release batch after the Mix Devices PR.\n\nIncluded changes:\n- Add ALT + BANK LEFT/RIGHT undo/redo handling across launcher, Mix, Note, Harmonic, and Drum Pads contexts.\n- Add the latched SHIFT + BROWSER global settings overlay.\n- Add global pin controls for track, device, and clip from the Fire settings overlay.\n- Add SHIFT + SELECT playback-start movement using the arranger grid, plus grid-jump tuning.\n- Refresh user-facing docs and bundled generated documentation for these controls.\n\nThis PR is intentionally grouped for the same release as the Akai Fire Mix device view work already merged in #55. Release-please should treat the merge as a feature release entry.